### PR TITLE
fix: Prevent multiple subscriptions from being made.

### DIFF
--- a/pkg/billing/paywall.go
+++ b/pkg/billing/paywall.go
@@ -1,0 +1,108 @@
+package billing
+
+import (
+	"context"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// BasicPayWall is used by the API middleware and other operations to restrict access to some features or functionality
+// that requires an active subscription.
+type BasicPayWall interface {
+	// GetHasSubscription should return whether or not there is a non-canceled subscription object associated with an
+	// account. It does not indicate whether or not this subscription object is in a state that the customer should be
+	// allowed to use their account, only whether or not the subscription object already exists in such a state that a
+	// new subscription should not be created.
+	GetHasSubscription(ctx context.Context, accountId uint64) (bool, error)
+	// GetSubscriptionIsActive should return whether or not the customer's subscription (or lack thereof) is in a state
+	// where the customer should have access to their account and data. If they lack a subscription entirely, or the
+	// subscription has been canceled or past due; then the customer should not be permitted to access their
+	// application.
+	GetSubscriptionIsActive(ctx context.Context, accountId uint64) (bool, error)
+}
+
+var (
+	_ BasicPayWall = &baseBasicPaywall{}
+)
+
+type baseBasicPaywall struct {
+	log      *logrus.Entry
+	accounts AccountRepository
+}
+
+func NewBasicPaywall(log *logrus.Entry, repo AccountRepository) BasicPayWall {
+	return &baseBasicPaywall{
+		log:      log,
+		accounts: repo,
+	}
+}
+
+func (b *baseBasicPaywall) GetHasSubscription(ctx context.Context, accountId uint64) (bool, error) {
+	span := sentry.StartSpan(ctx, "Billing - GetHasSubscription")
+	defer span.Finish()
+
+	log := b.log.WithContext(span.Context()).WithField("accountId", accountId)
+	log.Trace("checking whether or not subscription is present")
+
+	account, err := b.accounts.GetAccount(span.Context(), accountId)
+	if err != nil {
+		span.Status = sentry.SpanStatusInternalError
+		return false, errors.Wrap(err, "could not determine whether subscription was present")
+	}
+
+	return account.HasSubscription(), nil
+}
+
+// GetSubscriptionIsActive will retrieve the account data from the AccountRepository interface. This means it is
+// possible for it to return a stale response within a few seconds. But in general it should be acceptable. When an
+// account is updated -> its cache is invalidated. There is likely a very small window where an invalid state could be
+// evaluated, but it should be fine.
+func (b *baseBasicPaywall) GetSubscriptionIsActive(ctx context.Context, accountId uint64) (active bool, err error) {
+	span := sentry.StartSpan(ctx, "Billing - GetSubscriptionIsActive")
+	defer span.Finish()
+
+	defer func() {
+		if hub := sentry.GetHubFromContext(ctx); hub != nil {
+			level := sentry.LevelDebug
+			crumbType := "debug"
+			if err != nil {
+				crumbType = "error"
+				level = sentry.LevelError
+			}
+
+			var message string
+			if active {
+				message = "Subscription is active."
+			} else if err == nil {
+				message = "Subscription is not active, the current endpoint may require an active subscription."
+			} else {
+				message = "There was a problem verifying whether or not the subscription was active"
+			}
+
+			hub.AddBreadcrumb(&sentry.Breadcrumb{
+				Type:      crumbType,
+				Category:  "subscription",
+				Message:   message,
+				Level:     level,
+				Timestamp: time.Now(),
+			}, nil)
+		}
+	}()
+
+	log := b.log.WithContext(span.Context()).WithField("accountId", accountId)
+
+	log.Trace("checking if account subscription is active")
+
+	account, err := b.accounts.GetAccount(span.Context(), accountId)
+	if err != nil {
+		span.Status = sentry.SpanStatusInternalError
+		return false, errors.Wrap(err, "cannot determine if account subscription is active")
+	}
+
+	span.Status = sentry.SpanStatusOK
+
+	return account.IsSubscriptionActive(), nil
+}

--- a/pkg/billing/paywall_test.go
+++ b/pkg/billing/paywall_test.go
@@ -1,0 +1,130 @@
+package billing
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/monetr/monetr/pkg/internal/fixtures"
+	"github.com/monetr/monetr/pkg/internal/myownsanity"
+	"github.com/monetr/monetr/pkg/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stripe/stripe-go/v72"
+)
+
+func TestBaseBasicPaywall_GetHasSubscription(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		db := testutils.GetPgDatabase(t)
+		memoryCache := testutils.GetCache(t)
+		log := testutils.GetLog(t)
+
+		accountRepo := NewAccountRepository(log, memoryCache, db)
+
+		paywall := NewBasicPaywall(log, accountRepo)
+
+		user, _ := fixtures.GivenIHaveABasicAccount(t)
+
+		hasSubscription, err := paywall.GetHasSubscription(context.Background(), user.AccountId)
+		assert.NoError(t, err, "must not return an error checking for subscription")
+		assert.True(t, hasSubscription, "fixture account should have a subscription by default")
+
+		account := user.Account
+		canceledStatus := stripe.SubscriptionStatusCanceled
+		account.SubscriptionActiveUntil = myownsanity.TimeP(time.Now().Add(-1 * time.Hour))
+		account.SubscriptionStatus = &canceledStatus
+
+		err = accountRepo.UpdateAccount(context.Background(), account)
+		assert.NoError(t, err, "failed to update account with new status")
+
+		hasSubscription, err = paywall.GetHasSubscription(context.Background(), user.AccountId)
+		assert.NoError(t, err, "must not return an error checking for subscription")
+		assert.False(t, hasSubscription, "account should no longer have a subscription")
+	})
+
+	t.Run("payment past due", func(t *testing.T) {
+		db := testutils.GetPgDatabase(t)
+		memoryCache := testutils.GetCache(t)
+		log := testutils.GetLog(t)
+
+		accountRepo := NewAccountRepository(log, memoryCache, db)
+
+		paywall := NewBasicPaywall(log, accountRepo)
+
+		user, _ := fixtures.GivenIHaveABasicAccount(t)
+		account := user.Account
+		subscriptionStatus := stripe.SubscriptionStatusPastDue
+		account.SubscriptionActiveUntil = myownsanity.TimeP(time.Now().Add(7 * 24 * time.Hour))
+		account.SubscriptionStatus = &subscriptionStatus
+
+		err := accountRepo.UpdateAccount(context.Background(), account)
+		assert.NoError(t, err, "failed to update account with new status")
+
+		hasSubscription, err := paywall.GetHasSubscription(context.Background(), user.AccountId)
+		assert.NoError(t, err, "must not return an error checking for subscription")
+		assert.True(t, hasSubscription, "the subscription should be present for past due")
+	})
+
+	t.Run("subscription is canceled", func(t *testing.T) {
+		db := testutils.GetPgDatabase(t)
+		memoryCache := testutils.GetCache(t)
+		log := testutils.GetLog(t)
+
+		accountRepo := NewAccountRepository(log, memoryCache, db)
+
+		paywall := NewBasicPaywall(log, accountRepo)
+
+		user, _ := fixtures.GivenIHaveABasicAccount(t)
+		account := user.Account
+		subscriptionStatus := stripe.SubscriptionStatusCanceled
+		account.SubscriptionActiveUntil = myownsanity.TimeP(time.Now().Add(-7 * 24 * time.Hour))
+		account.SubscriptionStatus = &subscriptionStatus
+
+		err := accountRepo.UpdateAccount(context.Background(), account)
+		assert.NoError(t, err, "failed to update account with new status")
+
+		hasSubscription, err := paywall.GetHasSubscription(context.Background(), user.AccountId)
+		assert.NoError(t, err, "must not return an error checking for subscription")
+		assert.False(t, hasSubscription, "the subscription is not present when canceled")
+	})
+
+	t.Run("status is nil", func(t *testing.T) {
+		db := testutils.GetPgDatabase(t)
+		memoryCache := testutils.GetCache(t)
+		log := testutils.GetLog(t)
+
+		accountRepo := NewAccountRepository(log, memoryCache, db)
+
+		paywall := NewBasicPaywall(log, accountRepo)
+
+		user, _ := fixtures.GivenIHaveABasicAccount(t)
+
+		hasSubscription, err := paywall.GetHasSubscription(context.Background(), user.AccountId)
+		assert.NoError(t, err, "must not return an error checking for subscription")
+		assert.True(t, hasSubscription, "fixture account should have a subscription by default")
+
+		account := user.Account
+		account.SubscriptionStatus = nil
+
+		err = accountRepo.UpdateAccount(context.Background(), account)
+		assert.NoError(t, err, "failed to update account with new status")
+
+		hasSubscription, err = paywall.GetHasSubscription(context.Background(), user.AccountId)
+		assert.NoError(t, err, "must not return an error checking for subscription")
+		assert.True(t, hasSubscription, "the subscription should be present for past due")
+	})
+
+	t.Run("account not found", func(t *testing.T) {
+		db := testutils.GetPgDatabase(t)
+		memoryCache := testutils.GetCache(t)
+		log := testutils.GetLog(t)
+
+		accountRepo := NewAccountRepository(log, memoryCache, db)
+
+		paywall := NewBasicPaywall(log, accountRepo)
+
+		hasSubscription, err := paywall.GetHasSubscription(context.Background(), math.MaxUint64)
+		assert.EqualError(t, err, "could not determine whether subscription was present: failed to retrieve account by Id: pg: no rows in result set")
+		assert.False(t, hasSubscription, "account that does not exist should return false")
+	})
+}

--- a/pkg/cache/wrapper_test.go
+++ b/pkg/cache/wrapper_test.go
@@ -1,14 +1,16 @@
-package cache
+package cache_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/alicebob/miniredis/v2"
 	"github.com/gomodule/redigo/redis"
+	"github.com/monetr/monetr/pkg/cache"
 	"github.com/monetr/monetr/pkg/internal/testutils"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 var (
@@ -32,29 +34,29 @@ func NewTestRedisPool(t *testing.T) *redis.Pool {
 	return redisPool
 }
 
-func NewTestCache(t *testing.T) Cache {
-	return NewCache(testutils.GetLog(t), NewTestRedisPool(t))
+func NewTestCache(t *testing.T) cache.Cache {
+	return cache.NewCache(testutils.GetLog(t), NewTestRedisPool(t))
 }
 
 func TestRedisCache_Set(t *testing.T) {
 	t.Run("simple", func(t *testing.T) {
-		cache := NewTestCache(t)
+		memoryCache := NewTestCache(t)
 
-		err := cache.Set(context.Background(), "test:data", TestValue)
+		err := memoryCache.Set(context.Background(), "test:data", TestValue)
 		assert.NoError(t, err, "should successfully set value")
 	})
 
 	t.Run("nil value", func(t *testing.T) {
-		cache := NewTestCache(t)
+		memoryCache := NewTestCache(t)
 
-		err := cache.Set(context.Background(), "test:data", nil)
+		err := memoryCache.Set(context.Background(), "test:data", nil)
 		assert.NoError(t, err, "should successfully set value")
 	})
 
 	t.Run("no key", func(t *testing.T) {
-		cache := NewTestCache(t)
+		memoryCache := NewTestCache(t)
 
-		err := cache.Set(context.Background(), "", TestValue)
-		assert.Equal(t, ErrBlankKey, errors.Cause(err), "should be blank key error")
+		err := memoryCache.Set(context.Background(), "", TestValue)
+		assert.Equal(t, cache.ErrBlankKey, errors.Cause(err), "should be blank key error")
 	})
 }

--- a/pkg/controller/billing_test.go
+++ b/pkg/controller/billing_test.go
@@ -70,4 +70,98 @@ func TestGetAfterCheckout(t *testing.T) {
 			result.JSON().Path("$.nextUrl").String().Equal("/")
 		}
 	})
+
+	t.Run("will show active", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		stripeMock := mock_stripe.NewMockStripeHelper(t)
+
+		stripeMock.MockStripeCreateCustomerSuccess(t)
+		stripeMock.MockNewCheckoutSession(t)
+		stripeMock.MockGetCheckoutSession(t)
+		stripeMock.MockGetSubscription(t)
+
+		conf := NewTestApplicationConfig(t)
+		conf.Stripe.Enabled = true
+		conf.Stripe.BillingEnabled = true
+		conf.Stripe.APIKey = gofakeit.UUID()
+		conf.Stripe.InitialPlan = &config.Plan{
+			FreeTrialDays: 0,
+			Visible:       true,
+			StripePriceId: mock_stripe.FakeStripePriceId(t),
+			Default:       true,
+		}
+
+		e := NewTestApplicationWithConfig(t, conf)
+
+		token := GivenIHaveToken(t, e)
+
+		// Make sure that our customer has been created.
+		stripeMock.AssertNCustomersCreated(t, 1)
+
+		{ // Make sure that initially the customer's subscription is not present or active.
+			result := e.GET("/api/users/me").
+				WithCookie(TestCookieName, token).
+				Expect()
+
+			result.Status(http.StatusOK)
+			result.JSON().Path("$.isActive").Boolean().False()
+			result.JSON().Path("$.hasSubscription").Boolean().False()
+		}
+
+		var checkoutSessionId string
+		{ // Create a checkout session
+			result := e.POST("/api/billing/create_checkout").
+				WithCookie(TestCookieName, token).
+				WithJSON(swag.CreateCheckoutSessionRequest{
+					PriceId:    nil,
+					CancelPath: nil,
+				}).
+				Expect()
+
+			result.Status(http.StatusOK)
+			result.JSON().Path("$.sessionId").String().NotEmpty()
+			checkoutSessionId = result.JSON().Path("$.sessionId").String().Raw()
+		}
+
+		// Mark the checkout session as complete.
+		stripeMock.CompleteCheckoutSession(t, checkoutSessionId)
+
+		{ // Then do the callback from the frontend to complete the checkout session for our application.
+			result := e.GET("/api/billing/checkout/{checkoutSessionId}").
+				WithPath("checkoutSessionId", checkoutSessionId).
+				WithCookie(TestCookieName, token).
+				Expect()
+
+			result.Status(http.StatusOK)
+			result.JSON().Path("$.isActive").Boolean().True()
+			result.JSON().Path("$.nextUrl").String().Equal("/")
+		}
+
+		{ // Then once it's all said and done, make sure the customer's subscription shows as present and active.
+			result := e.GET("/api/users/me").
+				WithCookie(TestCookieName, token).
+				Expect()
+
+			result.Status(http.StatusOK)
+			result.JSON().Path("$.isActive").Boolean().True()
+			result.JSON().Path("$.hasSubscription").Boolean().True()
+		}
+
+		// Make sure that if the customer attempts to create a checkout session when they already have a subscription
+		// that it will fail.
+		{
+			result := e.POST("/api/billing/create_checkout").
+				WithCookie(TestCookieName, token).
+				WithJSON(swag.CreateCheckoutSessionRequest{
+					PriceId:    nil,
+					CancelPath: nil,
+				}).
+				Expect()
+
+			result.Status(http.StatusBadRequest)
+			result.JSON().Path("$.error").String().Equal("there is already an active subscription for your account")
+		}
+	})
 }

--- a/pkg/controller/user.go
+++ b/pkg/controller/user.go
@@ -32,32 +32,31 @@ func (c *Controller) getMe(ctx *context.Context) {
 
 	if !c.configuration.Stripe.IsBillingEnabled() {
 		ctx.JSON(map[string]interface{}{
-			"user":     user,
-			"isSetup":  isSetup,
-			"isActive": true,
+			"user":            user,
+			"isSetup":         isSetup,
+			"isActive":        true,
+			"hasSubscription": true,
 		})
 		return
 	}
 
-	subscriptionIsActive, err := c.paywall.GetSubscriptionIsActive(c.getContext(ctx), user.AccountId)
-	if err != nil {
-		c.wrapAndReturnError(ctx, err, http.StatusInternalServerError, "could not verify subscription is active")
-		return
-	}
+	subscriptionIsActive := user.Account.IsSubscriptionActive()
 
 	if !subscriptionIsActive {
 		ctx.JSON(map[string]interface{}{
-			"user":     user,
-			"isSetup":  isSetup,
-			"isActive": subscriptionIsActive,
-			"nextUrl":  "/account/subscribe",
+			"user":            user,
+			"isSetup":         isSetup,
+			"isActive":        subscriptionIsActive,
+			"hasSubscription": user.Account.HasSubscription(),
+			"nextUrl":         "/account/subscribe",
 		})
 		return
 	}
 
 	ctx.JSON(map[string]interface{}{
-		"user":     user,
-		"isSetup":  isSetup,
-		"isActive": subscriptionIsActive,
+		"user":            user,
+		"isSetup":         isSetup,
+		"isActive":        subscriptionIsActive,
+		"hasSubscription": user.Account.HasSubscription(),
 	})
 }

--- a/pkg/internal/fixtures/login.go
+++ b/pkg/internal/fixtures/login.go
@@ -13,6 +13,7 @@ import (
 	"github.com/monetr/monetr/pkg/models"
 	"github.com/monetr/monetr/pkg/repository"
 	"github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-go/v72"
 )
 
 func GivenIHaveLogin(t *testing.T) (_ models.Login, password string) {
@@ -40,12 +41,14 @@ func GivenIHaveABasicAccount(t *testing.T) (_ models.User, password string) {
 func GivenIHaveAnAccount(t *testing.T, login models.Login) models.User {
 	db := testutils.GetPgDatabase(t)
 	repo := repository.NewUnauthenticatedRepository(db)
+	subStatus := stripe.SubscriptionStatusActive
 	account := models.Account{
 		Timezone:                     gofakeit.TimeZoneRegion(),
 		StripeCustomerId:             myownsanity.StringP(mock_stripe.FakeStripeCustomerId(t)),
 		StripeSubscriptionId:         myownsanity.StringP(mock_stripe.FakeStripeSubscriptionId(t)),
 		StripeWebhookLatestTimestamp: myownsanity.TimeP(time.Now().Add(-4 * time.Minute)),
 		SubscriptionActiveUntil:      myownsanity.TimeP(time.Now().Add(10 * time.Minute)),
+		SubscriptionStatus:           &subStatus,
 	}
 	err := repo.CreateAccountV2(context.Background(), &account)
 	require.NoError(t, err, "must be able to seed basic account")

--- a/pkg/internal/testutils/redis.go
+++ b/pkg/internal/testutils/redis.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/gomodule/redigo/redis"
+	"github.com/monetr/monetr/pkg/cache"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,4 +28,10 @@ func GetRedisPool(t *testing.T) *redis.Pool {
 	})
 
 	return pool
+}
+
+func GetCache(t *testing.T) cache.Cache {
+	log := GetLog(t)
+	redisPool := GetRedisPool(t)
+	return cache.NewCache(log, redisPool)
 }

--- a/pkg/migrations/schema/2022022500_SubscriptionStatus.tx.down.sql
+++ b/pkg/migrations/schema/2022022500_SubscriptionStatus.tx.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "accounts" DROP COLUMN "subscription_status";

--- a/pkg/migrations/schema/2022022500_SubscriptionStatus.tx.up.sql
+++ b/pkg/migrations/schema/2022022500_SubscriptionStatus.tx.up.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "accounts"
+    ADD COLUMN "subscription_status" TEXT;
+
+-- For accounts that do have an active subscription, make sure the status is "active".
+UPDATE "accounts"
+SET "subscription_status" = 'active'
+WHERE "subscription_active_until" > CURRENT_TIMESTAMP;
+-- For accounts that do not currently have an active subscription, just update the status to be "canceled".
+UPDATE "accounts"
+SET "subscription_status" = 'canceled'
+WHERE "subscription_active_until" <= CURRENT_TIMESTAMP;
+

--- a/pkg/models/account.go
+++ b/pkg/models/account.go
@@ -5,17 +5,19 @@ import (
 
 	"github.com/monetr/monetr/pkg/feature"
 	"github.com/pkg/errors"
+	"github.com/stripe/stripe-go/v72"
 )
 
 type Account struct {
 	tableName string `pg:"accounts"`
 
-	AccountId                    uint64     `json:"accountId" pg:"account_id,notnull,pk,type:'bigserial'"`
-	Timezone                     string     `json:"timezone" pg:"timezone,notnull,default:'UTC'"`
-	StripeCustomerId             *string    `json:"-" pg:"stripe_customer_id"`
-	StripeSubscriptionId         *string    `json:"-" pg:"stripe_subscription_id"`
-	StripeWebhookLatestTimestamp *time.Time `json:"-" pg:"stripe_webhook_latest_timestamp"`
-	SubscriptionActiveUntil      *time.Time `json:"subscriptionActiveUntil" pg:"subscription_active_until"`
+	AccountId                    uint64                     `json:"accountId" pg:"account_id,notnull,pk,type:'bigserial'"`
+	Timezone                     string                     `json:"timezone" pg:"timezone,notnull,default:'UTC'"`
+	StripeCustomerId             *string                    `json:"-" pg:"stripe_customer_id"`
+	StripeSubscriptionId         *string                    `json:"-" pg:"stripe_subscription_id"`
+	StripeWebhookLatestTimestamp *time.Time                 `json:"-" pg:"stripe_webhook_latest_timestamp"`
+	SubscriptionActiveUntil      *time.Time                 `json:"subscriptionActiveUntil" pg:"subscription_active_until"`
+	SubscriptionStatus           *stripe.SubscriptionStatus `json:"subscriptionStatus" pg:"subscription_status"`
 }
 
 func (a *Account) GetTimezone() (*time.Location, error) {
@@ -35,5 +37,43 @@ func (a *Account) HasFeature(feature feature.Feature) bool {
 // IsSubscriptionActive will return true if the SubscriptionActiveUntil date is not nill and is in the future. Even if
 // the StripeSubscriptionId or StripeCustomerId is nil.
 func (a *Account) IsSubscriptionActive() bool {
-	return a.SubscriptionActiveUntil != nil && a.SubscriptionActiveUntil.After(time.Now())
+	endsInTheFuture := a.SubscriptionActiveUntil != nil && a.SubscriptionActiveUntil.After(time.Now())
+	if a.SubscriptionStatus == nil {
+		return endsInTheFuture
+	}
+
+	switch *a.SubscriptionStatus {
+	case stripe.SubscriptionStatusActive, stripe.SubscriptionStatusTrialing:
+		return endsInTheFuture
+	default:
+		return false
+	}
+}
+
+// HasSubscription is used to determine if a "active" subscription has already been established for the account. This is
+// active in the sense that the subscription is an accurate representation of their payment status for the application.
+// The subscription could be past due, which would put the application in a "not usable" state; but the subscription
+// would still be "active" because we would not want to create a new subscription.
+func (a *Account) HasSubscription() bool {
+	if a.SubscriptionStatus == nil {
+		return a.SubscriptionActiveUntil != nil &&
+			a.SubscriptionActiveUntil.After(time.Now()) &&
+			a.StripeSubscriptionId != nil
+	}
+
+	switch *a.SubscriptionStatus {
+	case stripe.SubscriptionStatusActive,
+		stripe.SubscriptionStatusTrialing,
+		stripe.SubscriptionStatusPastDue,
+		stripe.SubscriptionStatusIncomplete,
+		stripe.SubscriptionStatusUnpaid:
+		// When the subscription is one of these statuses, then the current subscription object should be used in stripe
+		// and a new object should not be created.
+		return a.StripeSubscriptionId != nil
+	case stripe.SubscriptionStatusCanceled:
+		// When the customer's subscription is canceled, it will not be re-used. A new subscription should be created.
+		return false
+	default:
+		return false
+	}
 }

--- a/ui/shared/authentication/actions.ts
+++ b/ui/shared/authentication/actions.ts
@@ -20,6 +20,7 @@ export interface LoginSuccess extends Action<typeof Login.Success> {
   payload: {
     user: User;
     isActive: boolean;
+    hasSubscription: boolean;
   };
 }
 

--- a/ui/shared/authentication/actions/bootstrapLogin.ts
+++ b/ui/shared/authentication/actions/bootstrapLogin.ts
@@ -30,6 +30,7 @@ export default function useBootstrapLogin(): (user?: User | null, subscriptionIs
         payload: {
           user: new User(result.data.user),
           isActive: result.data.isActive,
+          hasSubscription: result.data.hasSubscription,
         },
       }))
       .catch((error: AxiosError) => {

--- a/ui/shared/authentication/selectors.ts
+++ b/ui/shared/authentication/selectors.ts
@@ -3,3 +3,7 @@ import { AppState } from 'store';
 export const getIsAuthenticated = (state: AppState): boolean => state.authentication.isAuthenticated || false;
 
 export const getSubscriptionIsActive = (state: AppState): boolean => state.authentication.isActive || false;
+
+// getHasSubscription should not be used to determine whether or not the user's subscription is _active_. It is intended
+// to be used to determine whether or not a subscription already exists for the user.
+export const getHasSubscription = (state: AppState): boolean => state.authentication.hasSubscription || false;

--- a/ui/shared/authentication/state.ts
+++ b/ui/shared/authentication/state.ts
@@ -5,5 +5,6 @@ export default class AuthenticationState {
   // isActive indicates whether or not the user's subscription is activated. This is determined by the authentication
   // API call, or by the /users/me request.
   isActive: boolean;
+  hasSubscription: boolean;
   user: User | null;
 }

--- a/ui/views/Subscriptions/Subscribe.tsx
+++ b/ui/views/Subscriptions/Subscribe.tsx
@@ -1,18 +1,25 @@
+import { getHasSubscription } from 'shared/authentication/selectors';
 import request from 'shared/util/request';
-import React from 'react';
 import { useSelector } from 'react-redux';
 import { getInitialPlan } from 'shared/bootstrap/selectors';
 import useMountEffect from 'shared/util/useMountEffect';
 
 export default function Subscribe(): JSX.Element {
   const initialPlan = useSelector(getInitialPlan);
+  const hasSubscription = useSelector(getHasSubscription);
 
   useMountEffect(() => {
-    if (initialPlan) {
+    if (initialPlan && !hasSubscription) {
       request().post(`/billing/create_checkout`, {
         priceId: '',
         cancelPath: '/logout',
       })
+        .then(result => window.location.assign(result.data.url))
+        .catch(error => alert(error));
+    } else if (hasSubscription) {
+      // If the customer has a subscription then we want to just manage it. This will allow a customer to fix a
+      // subscription for a card that has failed payment or something similar.
+      request().get('/billing/portal')
         .then(result => window.location.assign(result.data.url))
         .catch(error => alert(error));
     }


### PR DESCRIPTION
When a subscription is "past_due", right now it is possible for another
subscription to be made. With the updated payment method; both
subscriptions can then charge the customer. This is an attempt to
resolve that by preventing a new subscription from being made unless the
original subscription is truely canceled or expired.

Resolves #717