### PR TITLE
fix(docs): Fixed table rendering in documentation.

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -11,3 +11,7 @@
 .home-container {
     padding: 5em;
 }
+
+tr td:first-child code {
+    white-space: nowrap;
+}


### PR DESCRIPTION
Made tables describing objects and fields easier to read by making sure
the field name does not wrap.

Resolves #974
