### PR TITLE
fix(ui): Fix transactions page crash.

### DIFF
--- a/ui/hooks/transactions.ts
+++ b/ui/hooks/transactions.ts
@@ -22,8 +22,8 @@ export function useTransactionsSink(): TransactionsResult {
   );
   return {
     ...result,
-    // Take all the pages and build an array.
-    result: result?.data?.pages.flatMap(x => x).map(item => new Transaction(item)),
+    // Take all the pages and build an array. Make sure we actually return an array here even if it's empty.
+    result: result?.data?.pages.flatMap(x => x).map(item => new Transaction(item)) || [],
   };
 }
 


### PR DESCRIPTION
Make sure the array of transactions returned by the hook is never
undefined. It should at least be an empty array in any code path.

Resolves #1032
