### PR TITLE
fix(api): Don't return internal errors to the client.

### DIFF
--- a/docs/developing/api/resources/authentication.md
+++ b/docs/developing/api/resources/authentication.md
@@ -63,7 +63,7 @@ POST /api/authentication/login
 
 ??? note
 
-    When the request is successful the response body is pretty minimal. User details should be retrieved using a follow 
+    When the request is successful the response body is pretty minimal. User details should be retrieved using a follow
     up request to [Get Me](user.md#get-me-current-user)
 
 ### Login Examples
@@ -244,6 +244,17 @@ If the registration succeeds, but we need to verify the login's email address.
 {
   "message": "A verification email has been sent to your email address, please verify your email.",
   "requireVerification": true
+}
+```
+
+#### Email already exists
+
+If the provided email is already in use by someone else for monetr then you will receive a bad request response.
+
+```json title="400 Bad Request"
+{
+  "error": "email already in use",
+	"code": "EMAIL_IN_USE"
 }
 ```
 

--- a/pkg/controller/authentication_test.go
+++ b/pkg/controller/authentication_test.go
@@ -696,8 +696,9 @@ func TestRegister(t *testing.T) {
 				WithJSON(registerRequest).
 				Expect()
 
-			response.Status(http.StatusInternalServerError)
-			response.JSON().Path("$.error").Equal("failed to create login: a login with the same email already exists")
+			response.Status(http.StatusBadRequest)
+			response.JSON().Path("$.code").Equal("EMAIL_IN_USE")
+			response.JSON().Path("$.error").Equal("email already in use")
 		}
 	})
 
@@ -807,7 +808,7 @@ func TestRegister(t *testing.T) {
 		response.JSON().
 			Path("$.error").
 			String().
-			Equal("could not generate email verification token: lifetime must be greater than 1 second")
+			Equal("could not generate email verification token")
 		response.JSON().Object().NotContainsKey("token")
 	})
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -440,4 +440,5 @@ func (c *Controller) reportError(ctx iris.Context, err error) {
 			sentry.CaptureException(err)
 		}
 	}
+	c.getLog(ctx).WithError(err).Errorf("error in request: %s", err)
 }

--- a/pkg/controller/error.go
+++ b/pkg/controller/error.go
@@ -56,6 +56,7 @@ func (c *Controller) onAnyErrorCode(ctx iris.Context) {
 var (
 	ErrMFARequired            = errors.New("login requires MFA")
 	ErrEmailNotVerified       = errors.New("email address is not verified")
+	ErrEmailAlreadyExists     = errors.New("email already in use")
 	ErrPasswordChangeRequired = errors.New("password must be changed")
 )
 
@@ -109,6 +110,29 @@ func (e EmailNotVerifiedError) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"error": e.FriendlyMessage(),
 		"code":  "EMAIL_NOT_VERIFIED",
+	})
+}
+
+// EmailNotVerifiedError is returned to the client when they attempt to authenticate using a login with an email that
+// has not yet been verified.
+type EmailAlreadyExists struct{}
+
+func (e EmailAlreadyExists) Cause() error {
+	return ErrEmailAlreadyExists
+}
+
+func (e EmailAlreadyExists) Error() string {
+	return e.FriendlyMessage()
+}
+
+func (e EmailAlreadyExists) FriendlyMessage() string {
+	return e.Cause().Error()
+}
+
+func (e EmailAlreadyExists) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]interface{}{
+		"error": e.FriendlyMessage(),
+		"code":  "EMAIL_IN_USE",
 	})
 }
 

--- a/pkg/controller/plaid_test.go
+++ b/pkg/controller/plaid_test.go
@@ -148,7 +148,7 @@ func TestPutUpdatePlaidLink(t *testing.T) {
 			Expect()
 
 		response.Status(http.StatusInternalServerError)
-		response.JSON().Path("$.error").String().Equal("failed to create Plaid client for link: failed to retrieve access token for plaid link: pg: no rows in result set")
+		response.JSON().Path("$.error").String().Equal("failed to create Plaid client for link")
 	})
 
 	t.Run("missing link ID", func(t *testing.T) {

--- a/pkg/controller/user_test.go
+++ b/pkg/controller/user_test.go
@@ -302,7 +302,7 @@ func TestChangePassword(t *testing.T) {
 				Expect()
 
 			response.Status(http.StatusInternalServerError)
-			response.JSON().Path("$.error").String().Equal("failed to retrieve current user details: user does not exist")
+			response.JSON().Path("$.error").String().Equal("failed to retrieve current user details")
 		}
 	})
 

--- a/pkg/repository/unauthenticated.go
+++ b/pkg/repository/unauthenticated.go
@@ -17,6 +17,10 @@ import (
 )
 
 var (
+	ErrEmailAlreadyExists = errors.New("a login with the same email already exists")
+)
+
+var (
 	_ UnauthenticatedRepository = &unauthenticatedRepo{}
 )
 
@@ -56,7 +60,7 @@ func (u *unauthenticatedRepo) CreateLogin(
 
 	if count != 0 {
 		span.Status = sentry.SpanStatusInvalidArgument
-		return nil, errors.Errorf("a login with the same email already exists")
+		return nil, errors.WithStack(ErrEmailAlreadyExists)
 	}
 
 	_, err = u.txn.ModelContext(span.Context(), login).Insert(login)


### PR DESCRIPTION
Resolves #95
