### PR TITLE
fix(docs): Fixed sign in URL on the documentation site.

### DIFF
--- a/docs/custom/overrides/partials/tabs.html
+++ b/docs/custom/overrides/partials/tabs.html
@@ -9,7 +9,7 @@ This file was automatically generated - do not edit
       {% include "partials/tabs-item.html" %}
       {% endfor %}
       <li style="margin-left: auto; margin-right: 0; position: relative; right: 0; float: right" class="md-tabs__item">
-        <a href="https://my.monetr.dog/login" class="md-tabs__link">
+        <a href="https://my.monetr.app/login" class="md-tabs__link">
           Sign In
         </a>
       </li>


### PR DESCRIPTION
Resolves #1070
