### PR TITLE
fix(spending): Fix spending contribution calculation.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.4.2
 	github.com/golang/mock v1.6.0
 	github.com/gomodule/redigo v1.8.9
+	github.com/google/uuid v1.3.0
 	github.com/hashicorp/vault/api v1.3.1
 	github.com/iris-contrib/middleware/cors v0.0.0-20220815101939-754509eb4d57
 	github.com/jarcoal/httpmock v1.2.0
@@ -73,7 +74,6 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect

--- a/pkg/models/funding_schedule.go
+++ b/pkg/models/funding_schedule.go
@@ -29,8 +29,12 @@ type FundingSchedule struct {
 func (f *FundingSchedule) GetNumberOfContributionsBetween(start, end time.Time) int64 {
 	rule := f.Rule.RRule
 	// Make sure that the rule is using the timezone of the dates provided. This is an easy way to force that.
-	rule.DTStart(start.Add(-365 * 24 * time.Hour))
-	return int64(len(rule.Between(start, end, false)))
+	// We also need to truncate the hours on the start time. To make sure that we are operating relative to
+	// midnight.
+	dtStart := start.Add(-365 * 24 * time.Hour).Truncate(time.Hour)
+	rule.DTStart(dtStart)
+	items := rule.Between(start, end, true)
+	return int64(len(items))
 }
 
 // GetNextTwoContributionDatesAfter returns the next two contribution dates relative to the timestamp provided. This is


### PR DESCRIPTION
Fixed issue where when the next recurrence or the due date of a spending
object matched the funding date, it would omit that funding event from
its calculations.

Resolves #1077
