### PR TITLE
fix(ui): Fixed Sentry crash dialog during registration.

### DIFF
--- a/ui/components/Authentication/Registration/RegisterView.tsx
+++ b/ui/components/Authentication/Registration/RegisterView.tsx
@@ -107,7 +107,7 @@ export default function RegisterView(): JSX.Element {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  function submit(values: SignUpValues, { setSubmitting }: FormikHelpers<SignUpValues>): Promise<void> {
+  async function submit(values: SignUpValues, { setSubmitting }: FormikHelpers<SignUpValues>): Promise<void> {
     setSubmitting(true);
     return signUp({
       agree: values.agree,
@@ -142,7 +142,6 @@ export default function RegisterView(): JSX.Element {
           variant: 'error',
           disableWindowBlurListener: true,
         });
-        throw error;
       })
       .finally(() => {
         setVerification(null);

--- a/ui/hooks/useSignUp.ts
+++ b/ui/hooks/useSignUp.ts
@@ -25,7 +25,7 @@ export interface SignUpError {
 }
 
 export default function useSignUp(): (args: SignUpArguments) => Promise<SignUpResponse | SignUpError> {
-  return (args: SignUpArguments) => {
+  return async (args: SignUpArguments) => {
     return request().post('/authentication/register', args)
       .then(result => result.data as SignUpResponse);
   };


### PR DESCRIPTION
If you attempt to sign up using an invalid beta code you will be
presented with a Sentry dialog. This is not correct and is removed in
this commit. This is not a page crash and should not behave like that.
