### PR TITLE
feat(ui): Allow icons to be searched via POST request.

### DIFF
--- a/pkg/controller/icons.go
+++ b/pkg/controller/icons.go
@@ -9,12 +9,28 @@ import (
 
 func (c *Controller) iconsController(p iris.Party) {
 	if icons.GetIconsEnabled() {
+		// DEPRECATED Use the POST method.
 		p.Get("/search", c.searchIcon)
+		p.Post("/search", c.searchIcon)
 	}
 }
 
 func (c *Controller) searchIcon(ctx iris.Context) {
-	name := ctx.URLParam("name")
+	var name string
+	switch ctx.Method() {
+	case "GET":
+		name = ctx.URLParam("name")
+	case "POST":
+		var body struct {
+			Name string `json:"name"`
+		}
+		if err := ctx.ReadJSON(&body); err != nil {
+			c.invalidJson(ctx)
+			return
+		}
+		name = body.Name
+	}
+
 	if name == "" {
 		c.badRequest(ctx, "must provide a name to search icons for")
 		return

--- a/ui/Root.tsx
+++ b/ui/Root.tsx
@@ -32,14 +32,14 @@ export default function Root(): JSX.Element {
   async function queryFn<T = unknown, TQueryKey extends QueryKey = QueryKey>(
     context: QueryFunctionContext<TQueryKey>,
   ): Promise<T> {
-    const { data } = await axios.get<T>(
-      `/api${ context.queryKey[0] }`,
-      {
-        params: context.pageParam && {
-          offset: context.pageParam,
-        },
+    const { data } = await axios.request<T>({
+      url: `/api${ context.queryKey[0] }`,
+      method: context.queryKey.length === 1 ? 'GET' : 'POST',
+      params: context.pageParam && {
+        offset: context.pageParam,
       },
-    )
+      data: context.queryKey.length === 2 && context.queryKey[1],
+    })
       .catch(result => {
         switch (result.response.status) {
           case 500:

--- a/ui/hooks/useIconSearch.ts
+++ b/ui/hooks/useIconSearch.ts
@@ -9,7 +9,7 @@ export interface Icon {
 
 export function useIconSearch(name: string): Icon | null {
   const configuration = useAppConfiguration();
-  const { data } = useQuery<Icon>(`/icons/search?name=${ encodeURIComponent(name) }`, {
+  const { data } = useQuery<Icon>(['/icons/search', { name }], {
     // Need to !! this otherwise it doesnt work right and evaluates to true when app config is loading.
     enabled: !!configuration.iconsEnabled && !!name && name?.length > 0,
     staleTime: 60 * 60 * 1000, // 60 minutes in milliseconds


### PR DESCRIPTION
This will make it so that the transaction names no longer show up in the
request URL in load balancer logs.

Resolves #1175
