### PR TITLE
fix(ui): Fixed crash on the funding schedule page.

### DIFF
--- a/ui/components/FundingSchedules/FundingScheduleListItem.tsx
+++ b/ui/components/FundingSchedules/FundingScheduleListItem.tsx
@@ -85,13 +85,8 @@ export default function FundingScheduleListItem(props: Props): JSX.Element {
     let textColor = 'text-gray-500'
 
     let amount: string | null;
-    if (!contributionForecast.isLoading) {
+    if (!contributionForecast.isLoading && balance !== null) {
       const est = (balance.safe + schedule.estimatedDeposit) - contributionForecast.result
-      console.log({
-        safe: balance.safe,
-        deposit: schedule.estimatedDeposit,
-        contribution: contributionForecast.result,
-      });
       amount = formatAmount(est);
       textColor = est > 0 ? 'text-green-500' : 'text-red-500';
     }


### PR DESCRIPTION
The funding schedule page would crash if it was the first page loaded,
this was because the page did not properly wait for balances to load
before trying to access the balance data.

Resolves #1244
