### PR TITLE
fix(api): Deprecate old icon search endpoint.

### DIFF
--- a/pkg/controller/icons.go
+++ b/pkg/controller/icons.go
@@ -9,34 +9,25 @@ import (
 
 func (c *Controller) iconsController(p iris.Party) {
 	if icons.GetIconsEnabled() {
-		// DEPRECATED Use the POST method.
-		p.Get("/search", c.searchIcon)
 		p.Post("/search", c.searchIcon)
 	}
 }
 
 func (c *Controller) searchIcon(ctx iris.Context) {
-	var name string
-	switch ctx.Method() {
-	case "GET":
-		name = ctx.URLParam("name")
-	case "POST":
-		var body struct {
-			Name string `json:"name"`
-		}
-		if err := ctx.ReadJSON(&body); err != nil {
-			c.invalidJson(ctx)
-			return
-		}
-		name = body.Name
+	var body struct {
+		Name string `json:"name"`
+	}
+	if err := ctx.ReadJSON(&body); err != nil {
+		c.invalidJson(ctx)
+		return
 	}
 
-	if name == "" {
+	if body.Name == "" {
 		c.badRequest(ctx, "must provide a name to search icons for")
 		return
 	}
 
-	icon, err := icons.SearchIcon(name)
+	icon, err := icons.SearchIcon(body.Name)
 	if err != nil || icon == nil {
 		ctx.StatusCode(http.StatusNoContent)
 		return


### PR DESCRIPTION
This removes support for `GET` requests against the icon search
endpoint. Going forward, requests must be made via a `POST` request in
order to keep transaction data out of query parameters.

Resolves #1217
