### PR TITLE
feat(api): Add DTSTART equivalent support to spending/funding.

### DIFF
--- a/pkg/migrations/schema/2023022000_DateStarted.tx.up.sql
+++ b/pkg/migrations/schema/2023022000_DateStarted.tx.up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "spending" ADD COLUMN "date_started" TIMESTAMPTZ NULL;
+UPDATE "spending" SET "date_started" = "next_recurrence" WHERE "date_started" IS NULL;
+ALTER TABLE "spending" ALTER COLUMN "date_started" SET NOT NULL;
+
+ALTER TABLE "funding_schedules" ADD COLUMN "date_started" TIMESTAMPTZ NULL;
+UPDATE "funding_schedules" SET "date_started" = "next_occurrence" WHERE "date_started" IS NULL;
+ALTER TABLE "funding_schedules" ALTER COLUMN "date_started" SET NOT NULL;

--- a/pkg/repository/expenses.go
+++ b/pkg/repository/expenses.go
@@ -96,6 +96,7 @@ func (r *repositoryBase) CreateSpending(ctx context.Context, spending *models.Sp
 
 	spending.AccountId = r.AccountId()
 	spending.DateCreated = time.Now().UTC()
+	spending.DateStarted = spending.NextRecurrence
 
 	if _, err := r.txn.ModelContext(span.Context(), spending).Insert(spending); err != nil {
 		span.Status = sentry.SpanStatusInternalError

--- a/pkg/repository/funding_schedules.go
+++ b/pkg/repository/funding_schedules.go
@@ -74,6 +74,8 @@ func (r *repositoryBase) CreateFundingSchedule(ctx context.Context, fundingSched
 	}
 
 	fundingSchedule.AccountId = r.AccountId()
+	fundingSchedule.DateStarted = fundingSchedule.NextOccurrence
+
 	if _, err := r.txn.ModelContext(span.Context(), fundingSchedule).Insert(fundingSchedule); err != nil {
 		span.Status = sentry.SpanStatusInternalError
 		return errors.Wrap(err, "failed to create funding schedule")


### PR DESCRIPTION
Right now we do not store the DTSTART component of the RRule, this has
led to some bugs already where we have to assume the DTSTART based on
some educated guess data. This can lead to wrong calculations in the
future. So going forward I want to support this parameter. This is the
start of the work on that.
