### PR TITLE
fix(ui): Fixed requesting more transactions.

### DIFF
--- a/ui/components/Transactions/TransactionsView/TransactionsView.tsx
+++ b/ui/components/Transactions/TransactionsView/TransactionsView.tsx
@@ -9,12 +9,7 @@ import { useTransactionsSink } from 'hooks/transactions';
 import Transaction from 'models/Transaction';
 
 function TransactionsView(): JSX.Element {
-  const { isLoading, isFetching, fetchNextPage, error, result: transactions } = useTransactionsSink();
-
-  // TODO This is a temp approach, since we don't know how many transactions we have for a given bank account, we can
-  //  just request transactions until we get a page that is not full. But this is not a good way to do it. If they have
-  //  a total number of transactions divisible by 25 then we could continue to try to request more.
-  const hasNextPage = transactions.length % 25 === 0 && transactions.length !== 0;
+  const { isLoading, isFetching, fetchNextPage, error, result: transactions, hasNextPage } = useTransactionsSink();
   const loading = isLoading || isFetching;
 
   const [sentryRef] = useInfiniteScroll({

--- a/ui/hooks/transactions.ts
+++ b/ui/hooks/transactions.ts
@@ -7,7 +7,10 @@ import Transaction from 'models/Transaction';
 import request from 'util/request';
 
 export type TransactionsResult =
-  { result: Array<Transaction> }
+  {
+    result: Array<Transaction>;
+    hasNextPage: boolean;
+  }
   & UseInfiniteQueryResult<Array<Partial<Transaction>>>;
 
 export function useTransactionsSink(): TransactionsResult {
@@ -22,6 +25,7 @@ export function useTransactionsSink(): TransactionsResult {
   );
   return {
     ...result,
+    hasNextPage: !result?.data?.pages.some(page => page.length < 25),
     // Take all the pages and build an array. Make sure we actually return an array here even if it's empty.
     result: result?.data?.pages.flatMap(x => x).map(item => new Transaction(item)) || [],
   };


### PR DESCRIPTION
Previously if you had a number of transactions exactly divisible by 25
we would continue to request more and more transactions unnecessarily.

This makes it so that we properly handle this by looking to see if we
have any pages with less than 25, which would include a page that is
empty.

Resolves #1331
