### PR TITLE
fix(plaid): Fixed an issue with Plaid update callback syncing.

### DIFF
--- a/pkg/controller/plaid.go
+++ b/pkg/controller/plaid.go
@@ -363,12 +363,19 @@ func (c *Controller) updatePlaidTokenCallback(ctx echo.Context) error {
 		}
 	}
 
-	err = background.TriggerPullTransactions(c.getContext(ctx), c.jobRunner, background.PullTransactionsArguments{
-		AccountId: link.AccountId,
-		LinkId:    link.LinkId,
-		Start:     time.Now().Add(-7 * 24 * time.Hour), // Last 7 days.
-		End:       time.Now(),
-	})
+	if link.PlaidLink.UsePlaidSync {
+		err = background.TriggerSyncPlaid(c.getContext(ctx), c.jobRunner, background.SyncPlaidArguments{
+			AccountId: link.AccountId,
+			LinkId:    link.LinkId,
+		})
+	} else {
+		err = background.TriggerPullTransactions(c.getContext(ctx), c.jobRunner, background.PullTransactionsArguments{
+			AccountId: link.AccountId,
+			LinkId:    link.LinkId,
+			Start:     time.Now().Add(-7 * 24 * time.Hour), // Last 7 days.
+			End:       time.Now(),
+		})
+	}
 	if err != nil {
 		log.WithError(err).Warn("failed to trigger pulling latest transactions after updating plaid link")
 	}


### PR DESCRIPTION
When we would initiate a sync after a Plaid update callback had been
completed, we were always triggering a pull transactions sync. This is
the legacy method for syncing data, and the preferred method is the
regular plaid sync.

This resolve the issue by looking at the setting on the plaid link
itself to determine which type of sync to initiate.

Resolves #1445
