### PR TITLE
fix(makefile): Add check for pnpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,9 +144,14 @@ $(SOURCE_MAP_DIR):
 	mkdir -p $(SOURCE_MAP_DIR)
 
 PNPM=$(shell which pnpm)
+check-pnpm:
+	@if [ -z "$(PNPM)" ]; then \
+		echo "Error: pnpm not found."; \
+		exit 1; \
+	fi
 
 NODE_MODULES=$(PWD)/node_modules
-$(NODE_MODULES): $(UI_DEPS)
+$(NODE_MODULES): $(UI_DEPS) check-pnpm
 	$(PNPM) install
 	touch -a -m $(NODE_MODULES) # Dumb hack to make sure the node modules directory timestamp gets bumpbed for make.
 


### PR DESCRIPTION
When running `make develop` for the first time, I ran into an error where a `install` binary was being called.

This happens because I didn't have `pnpm` installed, resulting in `$(PNPM) install` resolving to ` install` 

```
$ make develop
install
usage: install [-bCcpSsv] [-B suffix] [-f flags] [-g group] [-m mode]
               [-o owner] file1 file2
       install [-bCcpSsv] [-B suffix] [-f flags] [-g group] [-m mode]
               [-o owner] file1 ... fileN directory
       install -d [-v] [-g group] [-m mode] [-o owner] directory ...
make: *** [/Users/fbittenc/go/src/github.com/monetr/monetr/node_modules] Error 64
```

I've added a check for `pnpm` in Makefile to show a proper error message when running `make develop` without `pnpm`, resulting in the following message:

```
$ make develop
Error: pnpm not found.
make: *** [check-pnpm] Error 1
```

I placed `check-pnpm` as a dependency of `$(NODE_MODULES)`, which itself is a dependency of other steps. Let me know if you think there is a better step to add this in. 