### PR TITLE
fix(ui): Fixed mobile menu not displaying properly on iOS.

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "@types/react-google-recaptcha": "2.1.5",
     "@typescript-eslint/eslint-plugin": "5.42.0",
     "@typescript-eslint/parser": "5.42.0",
+    "autoprefixer": "10.4.16",
     "css-loader": "6.7.3",
     "dotenv": "16.0.3",
     "dotenv-expand": "8.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,9 @@ devDependencies:
   '@typescript-eslint/parser':
     specifier: 5.42.0
     version: 5.42.0(eslint@8.34.0)(typescript@5.1.3)
+  autoprefixer:
+    specifier: 10.4.16
+    version: 10.4.16(postcss@8.4.24)
   css-loader:
     specifier: 6.7.3
     version: 6.7.3(webpack@5.76.0)
@@ -8849,16 +8852,16 @@ packages:
     dev: false
     optional: true
 
-  /autoprefixer@10.4.14(postcss@8.4.24):
-    resolution: {integrity: sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==}
+  /autoprefixer@10.4.16(postcss@8.4.24):
+    resolution: {integrity: sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
       browserslist: 4.21.10
-      caniuse-lite: 1.0.30001519
-      fraction.js: 4.2.0
+      caniuse-lite: 1.0.30001541
+      fraction.js: 4.3.6
       normalize-range: 0.1.2
       picocolors: 1.0.0
       postcss: 8.4.24
@@ -9390,7 +9393,7 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001519
+      caniuse-lite: 1.0.30001541
       electron-to-chromium: 1.4.483
       node-releases: 2.0.13
       update-browserslist-db: 1.0.11(browserslist@4.21.10)
@@ -9513,8 +9516,8 @@ packages:
     dev: false
     optional: true
 
-  /caniuse-lite@1.0.30001519:
-    resolution: {integrity: sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==}
+  /caniuse-lite@1.0.30001541:
+    resolution: {integrity: sha512-bLOsqxDgTqUBkzxbNlSBt8annkDpQB9NdzdTbO2ooJ+eC/IQcvDspDc058g84ejCelF7vHUx57KIOjEecOHXaw==}
 
   /ccount@1.1.0:
     resolution: {integrity: sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==}
@@ -12312,8 +12315,8 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
-  /fraction.js@4.2.0:
-    resolution: {integrity: sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==}
+  /fraction.js@4.3.6:
+    resolution: {integrity: sha512-n2aZ9tNfYDwaHhvFTkhFErqOMIb8uyzSQ+vGJBjZyanAKZVbGUQ1sngfk9FdkBw7G26O7AgNjLcecLffD1c7eg==}
     dev: true
 
   /fragment-cache@0.2.1:
@@ -17529,7 +17532,7 @@ packages:
       '@csstools/postcss-text-decoration-shorthand': 1.0.0(postcss@8.4.24)
       '@csstools/postcss-trigonometric-functions': 1.0.2(postcss@8.4.24)
       '@csstools/postcss-unset-value': 1.0.2(postcss@8.4.24)
-      autoprefixer: 10.4.14(postcss@8.4.24)
+      autoprefixer: 10.4.16(postcss@8.4.24)
       browserslist: 4.21.10
       css-blank-pseudo: 3.0.3(postcss@8.4.24)
       css-has-pseudo: 3.0.4(postcss@8.4.24)

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -2,5 +2,6 @@ module.exports = {
   plugins: [
     require('tailwindcss/nesting'),
     require('tailwindcss'),
+    require('autoprefixer'),
   ],
 };


### PR DESCRIPTION
I had at some point removed autoprefixer apparently, which auto fills a
ton of CSS stuff for various browsers. This caused the compiled CSS file
to not have anything for webkit, including blur stuff. So the browser on
mobile was just showing the menu without any of the fancier styling.

Resolves #1513
