### PR TITLE
fix(ui): Don't show spending selection on deposits.

### DIFF
--- a/ui/pages/transaction/details.tsx
+++ b/ui/pages/transaction/details.tsx
@@ -136,10 +136,12 @@ export default function TransactionDetails(): JSX.Element {
               className='w-full'
               disabled
             />
-            <MSelectSpending
-              className='w-full'
-              name='spendingId'
-            />
+            { !transaction.getIsAddition() && (
+              <MSelectSpending
+                className='w-full'
+                name='spendingId'
+              />
+            ) }
           </div>
         </div>
       </div>


### PR DESCRIPTION
The spent from dropdown should not show on the details screen for
deposit transactions.

Resolves #1512
