### PR TITLE
feat(api): Migrate object IDs to use ulid instead.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16 // indirect

--- a/go.sum
+++ b/go.sum
@@ -364,6 +364,8 @@ github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/nyaruka/phonenumbers v1.1.8 h1:mjFu85FeoH2Wy18aOMUvxqi1GgAqiQSJsa/cCC5yu2s=
 github.com/nyaruka/phonenumbers v1.1.8/go.mod h1:DC7jZd321FqUe+qWSNcHi10tyIyGNXGcNbfkPvdp1Vs=
+github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
+github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.2 h1:8mVmC9kjFFmA8H4pKMUhcblgifdkOIXPvbhN1T36q1M=
@@ -372,6 +374,7 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3 h1:gph6h/qe9GSUw1NhH1gp+qb+h8rXD8Cy60Z32Qw3ELA=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=

--- a/server/internal/identification/id.go
+++ b/server/internal/identification/id.go
@@ -1,0 +1,47 @@
+package identification
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/oklog/ulid/v2"
+)
+
+type Kind string
+
+const (
+	LoginKind              Kind = "login"
+	UserKind               Kind = "user"
+	AccountKind            Kind = "account"
+	LinkKind               Kind = "link"
+	PlaidLinkKind          Kind = "plaid_link"
+	TellerLinkKind         Kind = "teller_link"
+	BankAccountKind        Kind = "bank_account"
+	PlaidBankAccountKind   Kind = "plaid_bank_account"
+	TellerBankAccountKind  Kind = "teller_bank_account"
+	PlaidSyncKind          Kind = "plaid_sync"
+	TellerSyncKind         Kind = "teller_sync"
+	TransactionKind        Kind = "transaction"
+	PlaidTransactionKind   Kind = "plaid_transaction"
+	TellerTransactionKind  Kind = "teller_transaction"
+	TransactionClusterKind Kind = "transaction_cluster"
+	SecretKind             Kind = "secret"
+	SpendingKind           Kind = "spending"
+	FundingScheduleKind    Kind = "funding_schedule"
+	FileKind               Kind = "file"
+	CronJobKind            Kind = "cron"
+	JobKind                Kind = "job"
+	BetaKind               Kind = "beta"
+)
+
+type ID string
+
+func (i ID) Kind() Kind {
+	str := string(i)
+	index := strings.LastIndex(str, "_")
+	return Kind(str[:index])
+}
+
+func New(kind Kind) ID {
+	return ID(strings.ToLower(fmt.Sprintf("%s_%s", kind, ulid.Make())))
+}

--- a/server/internal/identification/id_test.go
+++ b/server/internal/identification/id_test.go
@@ -1,0 +1,45 @@
+package identification_test
+
+import (
+	"testing"
+
+	"github.com/monetr/monetr/server/internal/identification"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("test a few", func(t *testing.T) {
+		kinds := []identification.Kind{
+			identification.LoginKind,
+			identification.UserKind,
+			identification.AccountKind,
+			identification.LinkKind,
+			identification.PlaidLinkKind,
+			identification.TellerLinkKind,
+			identification.BankAccountKind,
+			identification.PlaidBankAccountKind,
+			identification.TellerBankAccountKind,
+			identification.PlaidSyncKind,
+			identification.TellerSyncKind,
+			identification.TransactionKind,
+			identification.PlaidTransactionKind,
+			identification.TellerTransactionKind,
+			identification.TransactionClusterKind,
+			identification.SecretKind,
+			identification.SpendingKind,
+			identification.FundingScheduleKind,
+			identification.FileKind,
+			identification.CronJobKind,
+			identification.JobKind,
+			identification.BetaKind,
+		}
+
+		for i := range kinds {
+			kind := kinds[i]
+
+			id := identification.New(kind)
+			outKind := id.Kind()
+			assert.Equal(t, kind, outKind, "kinds should match!")
+		}
+	})
+}

--- a/server/migrations/functional/2024021000_UlidConvertion.go
+++ b/server/migrations/functional/2024021000_UlidConvertion.go
@@ -1,0 +1,18 @@
+package functional
+
+import "github.com/go-pg/migrations/v8"
+
+func init() {
+	FunctionalMigrations = append(FunctionalMigrations, &migrations.Migration{
+		Version: 2024011000,
+		UpTx:    true,
+		Up: func(db migrations.DB) error {
+
+			return nil
+		},
+		DownTx: true,
+		Down: func(db migrations.DB) error {
+			return nil
+		},
+	})
+}

--- a/server/models/account.go
+++ b/server/models/account.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/monetr/monetr/server/feature"
+	"github.com/monetr/monetr/server/internal/identification"
 	"github.com/monetr/monetr/server/internal/myownsanity"
 	"github.com/pkg/errors"
 	"github.com/stripe/stripe-go/v72"
@@ -12,7 +13,7 @@ import (
 type Account struct {
 	tableName string `pg:"accounts"`
 
-	AccountId                    uint64                     `json:"accountId" pg:"account_id,notnull,pk,type:'bigserial'"`
+	AccountId                    identification.ID          `json:"accountId" pg:"account_id,notnull,pk,type:'bigserial'"`
 	Timezone                     string                     `json:"timezone" pg:"timezone,notnull,default:'UTC'"`
 	StripeCustomerId             *string                    `json:"-" pg:"stripe_customer_id"`
 	StripeSubscriptionId         *string                    `json:"-" pg:"stripe_subscription_id"`

--- a/server/models/bank_account.go
+++ b/server/models/bank_account.go
@@ -1,6 +1,10 @@
 package models
 
-import "time"
+import (
+	"time"
+
+	"github.com/monetr/monetr/server/internal/identification"
+)
 
 type BankAccountType string
 
@@ -44,14 +48,14 @@ const (
 type BankAccount struct {
 	tableName string `pg:"bank_accounts"`
 
-	BankAccountId       uint64             `json:"bankAccountId" pg:"bank_account_id,notnull,pk,type:'bigserial'"`
-	AccountId           uint64             `json:"-" pg:"account_id,notnull,pk,on_delete:CASCADE"`
+	BankAccountId       identification.ID  `json:"bankAccountId" pg:"bank_account_id,notnull,pk,type:'bigserial'"`
+	AccountId           identification.ID  `json:"-" pg:"account_id,notnull,pk,on_delete:CASCADE"`
 	Account             *Account           `json:"-" pg:"rel:has-one"`
-	LinkId              uint64             `json:"linkId" pg:"link_id,notnull,on_delete:CASCADE"`
+	LinkId              identification.ID  `json:"linkId" pg:"link_id,notnull,on_delete:CASCADE"`
 	Link                *Link              `json:"-,omitempty" pg:"rel:has-one"`
-	PlaidBankAccountId  *uint64            `json:"-" pg:"plaid_bank_account_id"`
+	PlaidBankAccountId  *identification.ID `json:"-" pg:"plaid_bank_account_id"`
 	PlaidBankAccount    *PlaidBankAccount  `json:"plaidBankAccount,omitempty" pg:"rel:has-one"`
-	TellerBankAccountId *uint64            `json:"-" pg:"teller_bank_account_id"`
+	TellerBankAccountId *identification.ID `json:"-" pg:"teller_bank_account_id"`
 	TellerBankAccount   *TellerBankAccount `json:"tellerBankAccount,omitempty" pg:"rel:has-one"`
 	AvailableBalance    int64              `json:"availableBalance" pg:"available_balance,notnull,use_zero"`
 	CurrentBalance      int64              `json:"currentBalance" pg:"current_balance,notnull,use_zero"`

--- a/server/models/transaction.go
+++ b/server/models/transaction.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/monetr/monetr/server/crumbs"
+	"github.com/monetr/monetr/server/internal/identification"
 	"github.com/monetr/monetr/server/internal/myownsanity"
 	"github.com/pkg/errors"
 )
@@ -13,23 +14,20 @@ import (
 type Transaction struct {
 	tableName string `pg:"transactions"`
 
-	TransactionId uint64       `json:"transactionId" pg:"transaction_id,notnull,pk,type:'bigserial'"`
-	AccountId     uint64       `json:"-" pg:"account_id,notnull,pk,on_delete:CASCADE,type:'bigint'"`
-	Account       *Account     `json:"-" pg:"rel:has-one"`
-	BankAccountId uint64       `json:"bankAccountId" pg:"bank_account_id,notnull,pk,on_delete:CASCADE,type:'bigint',unique:per_bank_account"`
-	BankAccount   *BankAccount `json:"-" pg:"rel:has-one"`
-
-	PlaidTransactionId        *uint64           `json:"-" pg:"plaid_transaction_id"`
-	PlaidTransaction          *PlaidTransaction `json:"plaidTransaction" pg:"rel:has-one"`
-	PendingPlaidTransactionId *uint64           `json:"-" pg:"pending_plaid_transaction_id"`
-	PendingPlaidTransaction   *PlaidTransaction `json:"pendingPlaidTransaction" pg:"rel:has-one,fk:pending_"` // fk: is the prefix of the column we want to use to join on in a multikey join.
-
-	TellerTransactionId *uint64            `json:"-" pg:"teller_transaction_id"`
-	TellerTransaction   *TellerTransaction `json:"tellerTransaction" pg:"rel:has-one"`
-
-	Amount     int64     `json:"amount" pg:"amount,notnull,use_zero"`
-	SpendingId *uint64   `json:"spendingId" pg:"spending_id,on_delete:SET NULL"`
-	Spending   *Spending `json:"spending,omitempty" pg:"rel:has-one"`
+	TransactionId             identification.ID  `json:"transactionId" pg:"transaction_id,notnull,pk,type:'bigserial'"`
+	AccountId                 identification.ID  `json:"-" pg:"account_id,notnull,pk,on_delete:CASCADE,type:'bigint'"`
+	Account                   *Account           `json:"-" pg:"rel:has-one"`
+	BankAccountId             identification.ID  `json:"bankAccountId" pg:"bank_account_id,notnull,pk,on_delete:CASCADE,type:'bigint',unique:per_bank_account"`
+	BankAccount               *BankAccount       `json:"-" pg:"rel:has-one"`
+	PlaidTransactionId        *identification.ID `json:"-" pg:"plaid_transaction_id"`
+	PlaidTransaction          *PlaidTransaction  `json:"plaidTransaction" pg:"rel:has-one"`
+	PendingPlaidTransactionId *identification.ID `json:"-" pg:"pending_plaid_transaction_id"`
+	PendingPlaidTransaction   *PlaidTransaction  `json:"pendingPlaidTransaction" pg:"rel:has-one,fk:pending_"` // fk: is the prefix of the column we want to use to join on in a multikey join.
+	TellerTransactionId       *identification.ID `json:"-" pg:"teller_transaction_id"`
+	TellerTransaction         *TellerTransaction `json:"tellerTransaction" pg:"rel:has-one"`
+	Amount                    int64              `json:"amount" pg:"amount,notnull,use_zero"`
+	SpendingId                *identification.ID `json:"spendingId" pg:"spending_id,on_delete:SET NULL"`
+	Spending                  *Spending          `json:"spending,omitempty" pg:"rel:has-one"`
 	// SpendingAmount is the amount deducted from the expense this transaction was
 	// spent from. This is used when a transaction is more than the expense
 	// currently has allocated. If the transaction were to be deleted or changed


### PR DESCRIPTION
This is a start of a project to migrate all of monetr's object IDs to
use ulid instead of an unsigned 64 bit integer. This migration would
benefit monetr in a lot of ways, but the biggest ones are:

- Better support for a SQLite datastore in the future.
- More efficient bulk insert of data, IDs for everything can be
  generated ahead of the insert. Including foreign key data. Allowing
  large sync jobs to be far more efficient in their operations.
- More URL friendly.
