### PR TITLE
fix(api): Fix plain text secret encoding.

### DIFF
--- a/server/cmd/admin.go
+++ b/server/cmd/admin.go
@@ -83,12 +83,7 @@ func newViewSecretCommand(parent *cobra.Command) {
 				return errors.Wrap(err, "failed to retrieve secret")
 			}
 
-			decoded, err := hex.DecodeString(token.AccessToken)
-			if err != nil {
-				log.WithError(err).Fatal("failed to decode secret")
-				return err
-			}
-			decrypted, err := kms.Decrypt(cmd.Context(), token.KeyID, token.Version, decoded)
+			decrypted, err := kms.Decrypt(cmd.Context(), token.KeyID, token.Version, token.AccessToken)
 			if err != nil {
 				log.WithError(err).Fatal("failed to decrypt secret")
 				return err
@@ -132,7 +127,7 @@ func newTestKMSCommand(parent *cobra.Command) {
 			testString := "Lorem ipsum dolor sit amet"
 			fmt.Printf("Testing KMS with test string: %s\n", testString)
 
-			keyId, version, result, err := kms.Encrypt(context.Background(), []byte(testString))
+			keyId, version, result, err := kms.Encrypt(context.Background(), testString)
 			if err != nil {
 				log.WithError(err).Error("failed to encrypt test string")
 				return err
@@ -143,9 +138,9 @@ func newTestKMSCommand(parent *cobra.Command) {
 			fmt.Printf("Version: %s\n", version)
 			fmt.Printf("Result Binary -----------\n")
 			fmt.Println()
-			fmt.Println(hex.Dump(result))
+			fmt.Println(hex.Dump([]byte(result)))
 			fmt.Println()
-			fmt.Printf("Result Formatted: %s\n", hex.EncodeToString(result))
+			fmt.Printf("Result Formatted: %s\n", result)
 			fmt.Println()
 			fmt.Println("Testing decryption with test string...")
 
@@ -157,7 +152,7 @@ func newTestKMSCommand(parent *cobra.Command) {
 
 			fmt.Printf("Successfully dencrypted test string!\n")
 
-			if !bytes.Equal([]byte(testString), decrypted) {
+			if !bytes.Equal([]byte(testString), []byte(decrypted)) {
 				log.Error("Input string and result do not match!")
 				fmt.Println("Input:", testString)
 				fmt.Println("Output:", string(decrypted))

--- a/server/internal/mockgen/key_management.go
+++ b/server/internal/mockgen/key_management.go
@@ -35,10 +35,10 @@ func (m *MockKeyManagement) EXPECT() *MockKeyManagementMockRecorder {
 }
 
 // Decrypt mocks base method.
-func (m *MockKeyManagement) Decrypt(ctx context.Context, keyID, version *string, input []byte) ([]byte, error) {
+func (m *MockKeyManagement) Decrypt(ctx context.Context, keyID, version *string, input string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Decrypt", ctx, keyID, version, input)
-	ret0, _ := ret[0].([]byte)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -50,12 +50,12 @@ func (mr *MockKeyManagementMockRecorder) Decrypt(ctx, keyID, version, input inte
 }
 
 // Encrypt mocks base method.
-func (m *MockKeyManagement) Encrypt(ctx context.Context, input []byte) (*string, *string, []byte, error) {
+func (m *MockKeyManagement) Encrypt(ctx context.Context, input string) (*string, *string, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Encrypt", ctx, input)
 	ret0, _ := ret[0].(*string)
 	ret1, _ := ret[1].(*string)
-	ret2, _ := ret[2].([]byte)
+	ret2, _ := ret[2].(string)
 	ret3, _ := ret[3].(error)
 	return ret0, ret1, ret2, ret3
 }

--- a/server/repository/secrets_test.go
+++ b/server/repository/secrets_test.go
@@ -71,13 +71,13 @@ func TestSecretsRepository_Store(t *testing.T) {
 
 		kms := mockgen.NewMockKeyManagement(ctrl)
 
-		encrypted := []byte(base64.StdEncoding.EncodeToString([]byte(accessToken)))
+		encrypted := base64.StdEncoding.EncodeToString([]byte(accessToken))
 		version := "1"
 		keyName := "project/us-east1/key"
 		kms.EXPECT().
 			Encrypt(
 				gomock.Any(),
-				gomock.Eq([]byte(accessToken)),
+				gomock.Eq(accessToken),
 			).
 			Return(
 				&keyName,  // Key name
@@ -105,8 +105,8 @@ func TestSecretsRepository_Store(t *testing.T) {
 				gomock.Eq(encrypted),
 			).
 			Return(
-				[]byte(accessToken), // Decrypted access token
-				nil,                 // Error
+				accessToken, // Decrypted access token
+				nil,         // Error
 			).
 			MaxTimes(1)
 

--- a/server/secrets/google_kms_test.go
+++ b/server/secrets/google_kms_test.go
@@ -63,7 +63,7 @@ func TestGoogleKMS_Encrypt(t *testing.T) {
 		require.NoError(t, err, "must not return an error when creating the KMS interface")
 		require.NotNil(t, kms, "the KMS interface returned must be valid")
 
-		input := []byte("i am a little teapot")
+		input := "i am a little teapot"
 		keyId, version, data, err := kms.Encrypt(context.Background(), input)
 		assert.NoError(t, err, "should not return an error when encrypting")
 		assert.Equal(t, keyName, *keyId, "should have the same key Id as the configuration specified")
@@ -86,7 +86,7 @@ func TestGoogleKMS_Dencrypt(t *testing.T) {
 		require.NoError(t, err, "must not return an error when creating the KMS interface")
 		require.NotNil(t, kms, "the KMS interface returned must be valid")
 
-		input := []byte("i am a little teapot")
+		input := "i am a little teapot"
 		keyId, version, data, err := kms.Encrypt(context.Background(), input)
 		require.NoError(t, err, "should not return an error when encrypting")
 		require.Equal(t, keyName, *keyId, "should have the same key Id as the configuration specified")

--- a/server/secrets/key_management.go
+++ b/server/secrets/key_management.go
@@ -6,6 +6,6 @@ import (
 
 //go:generate mockgen -source=key_management.go -package=mockgen -destination=../internal/mockgen/key_management.go KeyManagement
 type KeyManagement interface {
-	Encrypt(ctx context.Context, input []byte) (keyID, version *string, result []byte, _ error)
-	Decrypt(ctx context.Context, keyID, version *string, input []byte) (result []byte, _ error)
+	Encrypt(ctx context.Context, input string) (keyID, version *string, result string, _ error)
+	Decrypt(ctx context.Context, keyID, version *string, input string) (result string, _ error)
 }

--- a/server/secrets/plaintext.go
+++ b/server/secrets/plaintext.go
@@ -8,10 +8,10 @@ func NewPlaintextKMS() KeyManagement {
 	return plaintextKms{}
 }
 
-func (plaintextKms) Encrypt(ctx context.Context, input []byte) (keyId, version *string, result []byte, _ error) {
+func (plaintextKms) Encrypt(ctx context.Context, input string) (keyId, version *string, result string, _ error) {
 	return nil, nil, input, nil
 }
 
-func (plaintextKms) Decrypt(ctx context.Context, keyId, version *string, input []byte) (result []byte, _ error) {
+func (plaintextKms) Decrypt(ctx context.Context, keyId, version *string, input string) (result string, _ error) {
 	return input, nil
 }


### PR DESCRIPTION
Plaintext secrets were meant to be stored as exclusively plain text. But
the changes to how secrets were stored is causing them to be
read/written as hexadecimal which is incorrect. This lives the
hexadecimal encoding out of the secrets repository and instead into the
key management implementation itself. If the implementation is actually
encrypting the secrets then they will be returned in a hexadecimal
format. Plaintext secrets will be stored unaltered.

Resolves #1673
