### PR TITLE
feat(jobs): Adding basic support for job retries

### DIFF
--- a/server/migrations/schema/2024021901_JobRetries.tx.up.sql
+++ b/server/migrations/schema/2024021901_JobRetries.tx.up.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "jobs" 
+ADD COLUMN "attempt" INT,
+ADD COLUMN "timestamp" TIMESTAMP WITH TIME ZONE,
+ADD COLUMN "previous_job_id" BIGINT;
+
+UPDATE "jobs" SET
+  "attempt" = 1,
+  "timestamp" = "created_at";
+
+ALTER TABLE "jobs"
+ALTER COLUMN "attempt" SET NOT NULL,
+ALTER COLUMN "timestamp" SET NOT NULL;

--- a/server/migrations/schema/2024021901_JobRetries.tx.up.sql
+++ b/server/migrations/schema/2024021901_JobRetries.tx.up.sql
@@ -10,3 +10,7 @@ UPDATE "jobs" SET
 ALTER TABLE "jobs"
 ALTER COLUMN "attempt" SET NOT NULL,
 ALTER COLUMN "timestamp" SET NOT NULL;
+
+CREATE INDEX "ix_jobs_timestamped" 
+ON "jobs" ("timestamp", "status", "queue") 
+WHERE "status" = 'pending';

--- a/server/models/job.go
+++ b/server/models/job.go
@@ -16,14 +16,18 @@ const (
 type Job struct {
 	tableName string `pg:"jobs"`
 
-	JobId       uint64     `json:"-" pg:"job_id,notnull,pk,type:'bigserial'"`
-	Queue       string     `json:"-" pg:"queue,notnull"`
-	Signature   string     `json:"-" pg:"signature,notnull"`
-	Input       string     `json:"-" pg:"input"`
-	Output      string     `json:"-" pg:"output"`
-	Status      JobStatus  `json:"-" pg:"status,notnull"`
-	CreatedAt   time.Time  `json:"-" pg:"created_at,notnull"`
-	UpdatedAt   time.Time  `json:"-" pg:"updated_at,notnull"`
-	StartedAt   *time.Time `json:"-" pg:"started_at"`
-	CompletedAt *time.Time `json:"-" pg:"completed_at"`
+	JobId         uint64     `json:"-" pg:"job_id,notnull,pk,type:'bigserial'"`
+	Queue         string     `json:"-" pg:"queue,notnull"`
+	Signature     string     `json:"-" pg:"signature,notnull"`
+	Input         string     `json:"-" pg:"input"`
+	Output        string     `json:"-" pg:"output"`
+	Status        JobStatus  `json:"-" pg:"status,notnull"`
+	Attempt       int        `json:"-" pg:"attempt,notnull"`
+	Timestamp     time.Time  `json:"-" pg:"timestamp,notnull"`
+	PreviousJobId *uint64    `json:"-" pg:"previous_job_id"`
+	PreviousJob   *Job       `json:"-" pg:"rel:has-one"`
+	CreatedAt     time.Time  `json:"-" pg:"created_at,notnull"`
+	UpdatedAt     time.Time  `json:"-" pg:"updated_at,notnull"`
+	StartedAt     *time.Time `json:"-" pg:"started_at"`
+	CompletedAt   *time.Time `json:"-" pg:"completed_at"`
 }


### PR DESCRIPTION
This is laying the ground work for allowing the PostgreSQL job processor
to handle retrying a job. This will be done by marking the initial job
as failed and creating a new job row with a new signature and
incrementing the attempt counter.