### PR TITLE
fix(teller): Fix teller transaction amounts on credit accounts.

### DIFF
--- a/server/background/sync_teller.go
+++ b/server/background/sync_teller.go
@@ -700,6 +700,11 @@ func (s *SyncTellerJob) syncTransactions(ctx context.Context) error {
 				return err
 			}
 
+			// If the account is a credit account, invert the transaction amount
+			if bankAccount.TellerBankAccount.GetIsCredit() {
+				amount *= -1
+			}
+
 			runningBalance, err := tellerTxnRaw.GetRunningBalance()
 			if err != nil {
 				return err

--- a/server/migrations/schema/2024022100_FixCreditTransactions.tx.up.sql
+++ b/server/migrations/schema/2024022100_FixCreditTransactions.tx.up.sql
@@ -1,0 +1,13 @@
+UPDATE "transactions" AS "transactions"
+SET "amount" = "transactions"."amount" * -1
+FROM "teller_transactions" 
+INNER JOIN "teller_bank_accounts" ON "teller_transactions"."teller_bank_account_id" = "teller_bank_accounts"."teller_bank_account_id" AND "teller_transactions"."account_id" = "teller_bank_accounts"."account_id"
+WHERE "transactions"."teller_transaction_id" = "teller_transactions"."teller_transaction_id" AND 
+      "transactions"."account_id" = "teller_transactions"."account_id" AND
+      "teller_bank_accounts"."type" = 'credit' AND "teller_bank_accounts"."sub_type" = 'credit_card';
+
+UPDATE "teller_transactions" AS "teller_transactions"
+SET "amount" = "teller_transactions"."amount" * -1
+FROM "teller_bank_accounts" 
+WHERE "teller_transactions"."teller_bank_account_id" = "teller_bank_accounts"."teller_bank_account_id" AND "teller_transactions"."account_id" = "teller_bank_accounts"."account_id" AND
+      "teller_bank_accounts"."type" = 'credit' AND "teller_bank_accounts"."sub_type" = 'credit_card';

--- a/server/models/teller_bank_account.go
+++ b/server/models/teller_bank_account.go
@@ -32,3 +32,7 @@ type TellerBankAccount struct {
 	CreatedAt           time.Time               `json:"createdAt" pg:"created_at,notnull"`
 	BalancedAt          *time.Time              `json:"balancedAt" pg:"balanced_at"`
 }
+
+func (t TellerBankAccount) GetIsCredit() bool {
+	return t.Type == "credit" && t.SubType == "credit_card"
+}


### PR DESCRIPTION
Transaction amounts were inverted for transactions on credit accounts.
This corrects the transactions but does not correct the balance of those
accounts.

Resolves #1677
