### PR TITLE
feat(api): Moving contribution calculation out of models

### DIFF
--- a/server/forecast/contribution.go
+++ b/server/forecast/contribution.go
@@ -1,0 +1,108 @@
+package forecast
+
+import (
+	"context"
+	"time"
+
+	"github.com/monetr/monetr/server/crumbs"
+	"github.com/monetr/monetr/server/models"
+	"github.com/sirupsen/logrus"
+)
+
+type Contribution struct {
+	IsBehind           bool
+	ContributionAmount int64
+	NextRecurrence     time.Time
+}
+
+// Do not use this yet!
+func CalculateNextContribution(
+	ctx context.Context,
+	spending models.Spending,
+	fundingSchedule models.FundingSchedule,
+	timezone *time.Location,
+	now time.Time,
+	log *logrus.Entry,
+) (Contribution, error) {
+	span := crumbs.StartFnTrace(ctx)
+	defer span.Finish()
+
+	crumbs.Debug(span.Context(), "Calculating next contribution for spending", map[string]interface{}{
+		"spending": map[string]interface{}{
+			"spendingId":    spending.SpendingId,
+			"spendingType":  spending.SpendingType,
+			"ruleset":       spending.RuleSet,
+			"targetAmount":  spending.TargetAmount,
+			"usedAmount":    spending.UsedAmount,
+			"currentAmount": spending.CurrentAmount,
+			"isPaused":      spending.IsPaused,
+		},
+		"funding": map[string]interface{}{
+			"fundingScheduleId": fundingSchedule.FundingScheduleId,
+			"ruleset":           fundingSchedule.RuleSet,
+			"excludeWeekends":   fundingSchedule.ExcludeWeekends,
+		},
+	})
+
+	// At the time of writing this overflow spending isn't implemented really
+	// anywhere. But its pretty simple. We don't make pre-calculated contributions
+	// to them. They are meant to be used as a way to just be an earmark outside
+	// of the forecast.
+	if spending.SpendingType == models.SpendingTypeOverflow || spending.GetIsPaused() {
+		return Contribution{
+			IsBehind:           false,
+			ContributionAmount: 0,
+			NextRecurrence:     spending.NextRecurrence,
+		}, nil
+	}
+
+	// Don't change the time by converting it to the account timezone. This will
+	// make debugging easier if there is a problem. It's possible that the time
+	// was already in the account's timezone, but this still is good to have
+	// because it makes this function consistent. If the time was already in the
+	// account's timezone then this won't do anything.
+	now = now.In(timezone)
+
+	fundingInstructions := NewFundingScheduleFundingInstructions(
+		log,
+		fundingSchedule,
+	)
+
+	spendingInstructions := NewSpendingInstructions(
+		log,
+		spending,
+		fundingInstructions,
+	)
+
+	spendingEvent, err := spendingInstructions.GetNextNSpendingEventsAfter(
+		span.Context(),
+		1,
+		now,
+		timezone,
+	)
+	if err != nil {
+		return Contribution{}, nil
+	}
+
+	nextRecurrence := spending.NextRecurrence
+	isBehind := false
+	if len(spendingEvent) == 1 {
+		isBehind = spendingEvent[0].IsBehind
+		nextRecurrence = spendingEvent[0].Date
+	}
+
+	contributionEvent, err := spendingInstructions.GetNextContributionEvent(
+		span.Context(),
+		now,
+		timezone,
+	)
+	if err != nil {
+		return Contribution{}, nil
+	}
+
+	return Contribution{
+		IsBehind:           isBehind,
+		ContributionAmount: contributionEvent.ContributionAmount,
+		NextRecurrence:     nextRecurrence,
+	}, nil
+}

--- a/server/forecast/contribution_test.go
+++ b/server/forecast/contribution_test.go
@@ -1,0 +1,50 @@
+package forecast
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/monetr/monetr/server/internal/testutils"
+	"github.com/monetr/monetr/server/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCalculateNextContribution(t *testing.T) {
+	t.Run("simple monthly expense", func(t *testing.T) {
+		t.Skip("not relevant yet")
+		timezone := testutils.Must(t, time.LoadLocation, "America/Chicago")
+		fundingRule := testutils.NewRuleSet(t, 2022, 1, 15, timezone, "FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15,-1")
+		spendingRule := testutils.NewRuleSet(t, 2022, 10, 8, timezone, "FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=8")
+		now := time.Date(2024, 4, 9, 0, 0, 1, 0, timezone).UTC()
+		log := testutils.GetLog(t)
+
+		funding := models.FundingSchedule{
+			RuleSet:         fundingRule,
+			ExcludeWeekends: false,
+			NextOccurrence:  time.Date(2024, 4, 15, 0, 0, 0, 0, timezone),
+		}
+		spending := models.Spending{
+			SpendingType:   models.SpendingTypeExpense,
+			TargetAmount:   5000,
+			CurrentAmount:  0,
+			NextRecurrence: time.Date(2024, 5, 8, 0, 0, 0, 0, timezone),
+			RuleSet:        spendingRule,
+		}
+
+		contribution, err := CalculateNextContribution(
+			context.Background(),
+			spending,
+			funding,
+			timezone,
+			now,
+			log,
+		)
+		assert.NoError(t, err, "should be able to calculate next contribution")
+		assert.Equal(t, Contribution{
+			IsBehind:           false,
+			ContributionAmount: 2500,
+			NextRecurrence:     time.Date(2024, 5, 8, 0, 0, 0, 0, timezone),
+		}, contribution)
+	})
+}

--- a/server/forecast/forecast_test.go
+++ b/server/forecast/forecast_test.go
@@ -67,9 +67,11 @@ func TestForecasterBase_GetForecast(t *testing.T) {
 		var firstAverage, secondAverage int64
 		{ // Initial
 			forecaster := NewForecaster(log, spending, fundingSchedules)
-			forecast := forecaster.GetForecast(context.Background(), now, now.AddDate(0, 1, 4), timezone)
+			forecast, err := forecaster.GetForecast(context.Background(), now, now.AddDate(0, 1, 4), timezone)
+			assert.NoError(t, err, "should not have an errors forecasting")
 			assert.Greater(t, forecast.StartingBalance, int64(0))
-			firstAverage = forecaster.GetAverageContribution(context.Background(), now, now.AddDate(0, 1, 4), timezone)
+			firstAverage, err = forecaster.GetAverageContribution(context.Background(), now, now.AddDate(0, 1, 4), timezone)
+			assert.NoError(t, err, "should not have an errors forecasting")
 		}
 
 		{ // With added expense
@@ -79,9 +81,11 @@ func TestForecasterBase_GetForecast(t *testing.T) {
 				CurrentAmount:  0,
 				NextRecurrence: util.Midnight(now.AddDate(1, 0, 0), timezone),
 			}), fundingSchedules)
-			forecast := forecaster.GetForecast(context.Background(), now, now.AddDate(0, 1, 4), timezone)
+			forecast, err := forecaster.GetForecast(context.Background(), now, now.AddDate(0, 1, 4), timezone)
+			assert.NoError(t, err, "should not have an errors forecasting")
 			assert.Greater(t, forecast.StartingBalance, int64(0))
-			secondAverage = forecaster.GetAverageContribution(context.Background(), now, now.AddDate(0, 1, 4), timezone)
+			secondAverage, err = forecaster.GetAverageContribution(context.Background(), now, now.AddDate(0, 1, 4), timezone)
+			assert.NoError(t, err, "should not have an errors forecasting")
 		}
 		assert.Greater(t, secondAverage, firstAverage, "should need to contribute more per funding")
 	})
@@ -119,10 +123,9 @@ func TestForecasterBase_GetForecast(t *testing.T) {
 		forecaster := NewForecaster(log, spending, fundingSchedules)
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		assert.NotPanics(t, func() {
-			result := forecaster.GetForecast(ctx, now, end, timezone)
-			assert.NotNil(t, result, "just make sure something is returned, this is to make sure we dont timeout")
-		})
+		result, err := forecaster.GetForecast(ctx, now, end, timezone)
+		assert.NoError(t, err, "should not have an errors forecasting")
+		assert.NotNil(t, result, "just make sure something is returned, this is to make sure we dont timeout")
 	})
 
 	t.Run("midnight goofiness", func(t *testing.T) {
@@ -165,7 +168,8 @@ func TestForecasterBase_GetForecast(t *testing.T) {
 		//ctx := context.Background()
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		result := forecaster.GetForecast(ctx, now, end, timezone)
+		result, err := forecaster.GetForecast(ctx, now, end, timezone)
+		assert.NoError(t, err, "should not have an errors forecasting")
 		expected := Forecast{
 			StartingTime:    now,
 			EndingTime:      end,
@@ -287,7 +291,8 @@ func TestForecasterBase_GetForecast(t *testing.T) {
 		forecaster := NewForecaster(log, spending, funding)
 		ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Second)
 		defer cancel()
-		result := forecaster.GetForecast(ctx, now, end, timezone)
+		result, err := forecaster.GetForecast(ctx, now, end, timezone)
+		assert.NoError(t, err, "should not have an errors forecasting")
 		assert.NotNil(t, result, "just make sure something is returned, this is to make sure we dont timeout")
 		pretty, err := json.MarshalIndent(result, "", "  ")
 		assert.NoError(t, err, "must be able to convert the forecast into a pretty json")
@@ -331,7 +336,8 @@ func TestForecasterBase_GetForecast(t *testing.T) {
 		forecaster := NewForecaster(log, spending, fundingSchedules)
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		result := forecaster.GetForecast(ctx, now, end, timezone)
+		result, err := forecaster.GetForecast(ctx, now, end, timezone)
+		assert.NoError(t, err, "should not have an errors forecasting")
 		expected := Forecast{
 			StartingTime:    now,
 			EndingTime:      end,

--- a/server/models/spending.go
+++ b/server/models/spending.go
@@ -81,6 +81,7 @@ func (e *Spending) GetRecurrencesBefore(now, before time.Time, timezone *time.Lo
 	}
 }
 
+// Deprecated: Please use the forcasting library.
 func (e *Spending) CalculateNextContribution(
 	ctx context.Context,
 	accountTimezone string,
@@ -113,6 +114,7 @@ func (e *Spending) CalculateNextContribution(
 //   - NextRecurrence
 //
 // The provided objects are unmodified.
+// Deprecaetd: Please use the forecasting package.
 func CalculateNextContribution(
 	ctx context.Context,
 	spending Spending,


### PR DESCRIPTION
Right now monetr calculates contributions to expenses and goals using
some specific code co-located in the models package. This isn't great as
that package should not contain business logic as much as possible. This
is the groundwork of moving that logic out of that package and to make
use of the existing forecasting code to facilitate the same
calculations. This should also make things more consistent as both the
contribution and spending calculations will be the same code.
