### PR TITLE
fix(config): Fixed how the external URL and protocol was determined

### DIFF
--- a/compose/docker-compose.monetr.yaml.in
+++ b/compose/docker-compose.monetr.yaml.in
@@ -89,7 +89,7 @@ services:
       retries: 12
       start_period: 60s
     environment:
-      WS_PROTO: 'wss'
+      WS_PROTO: 'wss' # TODO Make this based on the local protocol
       INSECURE_WS: "false" # Makes it so that we are not trying to use TLS for the hot-reload websocket.
       NODE_OPTIONS: --openssl-legacy-provider # Fixes a weird issue when trying to include SVGs.
       IS_COMPOSE: "true" # Makes it so that the WebPack progress bar is disabled.
@@ -117,9 +117,7 @@ services:
       air_wd: /build
       DISABLE_GO_RELOAD: "@DISABLE_GO_RELOAD@"
       CLOUD_MAGIC: "@CLOUD_MAGIC@"
-      MONETR_EXTERNAL_PROTOCOL: "@LOCAL_PROTOCOL@"
-      MONETR_UI_DOMAIN_NAME: "@MONETR_LOCAL_DOMAIN@"
-      MONETR_API_DOMAIN_NAME: "@MONETR_LOCAL_DOMAIN@"
+      MONETR_SERVER_EXTERNAL_URL: "@LOCAL_PROTOCOL@://@MONETR_LOCAL_DOMAIN@"
       # By default we want to use the AWS KMS provider as that is what we have built into the local env. But iuf the
       # developer specifies a different KMS provider we want to use that instead.
       MONETR_KMS_PROVIDER: "aws"

--- a/compose/docker-compose.monetr.yaml.in
+++ b/compose/docker-compose.monetr.yaml.in
@@ -154,7 +154,6 @@ services:
     volumes:
       - goData:/go/pkg/mod
       - "@CMAKE_SOURCE_DIR@:/build"
-      # - ./compose/monetr.yaml:/etc/monetr/config.yaml
     depends_on:
       mail:
         condition: service_started

--- a/compose/monetr.yaml
+++ b/compose/monetr.yaml
@@ -1,5 +1,5 @@
 allowsignup: true
-externalUrlProtocol: https
+environment: development
 plaid:
   environment: https://sandbox.plaid.com
 backgroundjobs:
@@ -22,7 +22,6 @@ email:
   verification:
     enabled: true
     tokenLifetime: 10m0s
-environment: development
 logging:
   format: text
   level: trace

--- a/server/application/app_test.go
+++ b/server/application/app_test.go
@@ -18,7 +18,7 @@ func TestNewApp(t *testing.T) {
 	conf := config.Configuration{
 		AllowSignUp: true,
 		Server: config.Server{
-			ExternalURL: "http://monetr.local",
+			ExternalURL: "https://monetr.local",
 			Cookies: config.Cookies{
 				SameSiteStrict: true,
 				Secure:         true,

--- a/server/application/app_test.go
+++ b/server/application/app_test.go
@@ -16,10 +16,9 @@ import (
 func TestNewApp(t *testing.T) {
 	log := testutils.GetLog(t)
 	conf := config.Configuration{
-		UIDomainName:  "monetr.local",
-		APIDomainName: "monetr.local",
-		AllowSignUp:   true,
+		AllowSignUp: true,
 		Server: config.Server{
+			ExternalURL: "http://monetr.local",
 			Cookies: config.Cookies{
 				SameSiteStrict: true,
 				Secure:         true,

--- a/server/cmd/serve.go
+++ b/server/cmd/serve.go
@@ -73,7 +73,13 @@ func RunServer() error {
 		return err
 	}
 
-	clientTokens, err := security.NewPasetoClientTokens(log, clock, configuration.APIDomainName, publicKey, privateKey)
+	clientTokens, err := security.NewPasetoClientTokens(
+		log,
+		clock,
+		configuration.Server.GetBaseURL().String(),
+		publicKey,
+		privateKey,
+	)
 	if err != nil {
 		log.WithError(err).Fatal("failed to init paseto client tokens interface")
 		return err
@@ -273,8 +279,10 @@ func RunServer() error {
 
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
-	log.WithField("address", fmt.Sprintf("http://%s", listenAddress)).
-		Info("monetr is running")
+	log.WithFields(logrus.Fields{
+		"listenAddress":   fmt.Sprintf("http://%s", listenAddress),
+		"externalAddress": configuration.Server.GetBaseURL().String(),
+	}).Info("monetr is running")
 
 	<-quit
 	log.Info("shutting down")

--- a/server/config/configuration.go
+++ b/server/config/configuration.go
@@ -31,44 +31,27 @@ type Configuration struct {
 	// configuration.
 	configFile string `yaml:"-"`
 
-	Environment string `yaml:"environment"`
-	// ExternalURLProtocol is used to determine what protocol should be used in things like email templates. It defaults
-	// to https.
-	ExternalURLProtocol string        `yaml:"externalUrlProtocol"`
-	UIDomainName        string        `yaml:"uiDomainName"`
-	APIDomainName       string        `yaml:"apiDomainName"`
-	AllowSignUp         bool          `yaml:"allowSignUp"`
-	Beta                Beta          `yaml:"beta"`
-	CORS                CORS          `yaml:"cors"`
-	Email               Email         `yaml:"email"`
-	KeyManagement       KeyManagement `yaml:"keyManagement"`
-	Links               Links         `yaml:"links"`
-	Logging             Logging       `yaml:"logging"`
-	Plaid               Plaid         `yaml:"plaid"`
-	PostgreSQL          PostgreSQL    `yaml:"postgreSql"`
-	ReCAPTCHA           ReCAPTCHA     `yaml:"reCAPTCHA"`
-	Redis               Redis         `yaml:"redis"`
-	Security            Security      `yaml:"security"`
-	Sentry              Sentry        `yaml:"sentry"`
-	Server              Server        `yaml:"server"`
-	Storage             Storage       `yaml:"storage"`
-	Stripe              Stripe        `yaml:"stripe"`
+	Environment   string        `yaml:"environment"`
+	AllowSignUp   bool          `yaml:"allowSignUp"`
+	Beta          Beta          `yaml:"beta"`
+	CORS          CORS          `yaml:"cors"`
+	Email         Email         `yaml:"email"`
+	KeyManagement KeyManagement `yaml:"keyManagement"`
+	Links         Links         `yaml:"links"`
+	Logging       Logging       `yaml:"logging"`
+	Plaid         Plaid         `yaml:"plaid"`
+	PostgreSQL    PostgreSQL    `yaml:"postgreSql"`
+	ReCAPTCHA     ReCAPTCHA     `yaml:"reCAPTCHA"`
+	Redis         Redis         `yaml:"redis"`
+	Security      Security      `yaml:"security"`
+	Sentry        Sentry        `yaml:"sentry"`
+	Server        Server        `yaml:"server"`
+	Storage       Storage       `yaml:"storage"`
+	Stripe        Stripe        `yaml:"stripe"`
 }
 
 func (c Configuration) GetConfigFileName() string {
 	return c.configFile
-}
-
-func (c Configuration) GetUIDomainName() string {
-	return c.UIDomainName
-}
-
-func (c Configuration) GetHTTPSecureCookie() bool {
-	return c.ExternalURLProtocol == "https" && c.Server.Cookies.Secure
-}
-
-func (c Configuration) GetUIURL() string {
-	return fmt.Sprintf("%s://%s", c.ExternalURLProtocol, c.UIDomainName)
 }
 
 type Storage struct {
@@ -147,39 +130,6 @@ type VaultTransit struct {
 	AuthMethod string `yaml:"authMethod"`
 	// If the AuthMethod is `token` then this value must be specified.
 	Token *string `yaml:"token"`
-}
-
-type Server struct {
-	// ListenPort defines the port that monetr will listen for HTTP requests on. This port should be forwarded such that
-	// it is accessible to the desired clients. Be that on a local network, or forwarded to the public internet.
-	ListenPort int `yaml:"listenPort"`
-	// ListenAddress defines the IP address that monetr should listen on for HTTP requests.
-	ListenAddress string `yaml:"listenAddress"`
-	// StatsPort is the port that our prometheus metrics are served on. This port should not be publicly accessible and
-	// should only be accessible by the prometheus server scraping for metrics. It is not an endpoint that needs to be
-	// secured as no sensitive client information will be served by it; but it should not be accessible publicly.
-	StatsPort int `yaml:"statsPort"`
-	// Cookies defines the parameters used for issuing and processing cookies from clients. Cookies are used for
-	// authentication.
-	Cookies Cookies `yaml:"cookies"`
-	// UICacheHours is the number of hours that UI files should be cached by the client. This is done by including an
-	// Expires and Cache-Control header in the response for all UI related requests. If this is 0 then the headers will
-	// not be included. Defaults to 12 hours.
-	UICacheHours int `yaml:"uiCacheHours"`
-}
-
-type Cookies struct {
-	// SameSiteStrict allows the host of monetr to define whether the cookie used for authentication is limited to same
-	// site. This might impact use cases where the UI is on a different domain than the API. In general, it is
-	// recommended that this is enabled and that the UI and API are served from the same domain.
-	SameSiteStrict bool `yaml:"sameSiteStrict"`
-	// Secure specifies that the authentication cookie issued and required by API endpoints is a secure cookie. This
-	// defaults to true, but requires that the host of monetr use HTTPS. If you are not using HTTPS then this must be
-	// disabled for API calls to succeed.
-	Secure bool `yaml:"secure"`
-	// Name defines the name of the cookie to use for authentication. This defaults to `M-Token` but can be customized
-	// if the host wants to.
-	Name string `yaml:"name"`
 }
 
 type Beta struct {
@@ -440,9 +390,7 @@ func LoadConfigurationEx(v *viper.Viper) (config Configuration) {
 }
 
 func setupDefaults(v *viper.Viper) {
-	v.SetDefault("APIDomainName", "0.0.0.0:4000")
 	v.SetDefault("AllowSignUp", true)
-	v.SetDefault("ExternalURLProtocol", "https")
 	v.SetDefault("Email.ForgotPassword.TokenLifetime", 10*time.Minute)
 	v.SetDefault("Email.Verification.TokenLifetime", 10*time.Minute)
 	v.SetDefault("Environment", "development")
@@ -473,16 +421,11 @@ func setupDefaults(v *viper.Viper) {
 	v.SetDefault("Server.StatsPort", 9000)
 	v.SetDefault("Server.UICacheHours", 12)
 	v.SetDefault("Stripe.FreeTrialDays", 30)
-	v.SetDefault("UIDomainName", "0.0.0.0:4000")
 }
 
 func setupEnv(v *viper.Viper) {
 	_ = v.BindEnv("Environment", "MONETR_ENVIRONMENT")
-	_ = v.BindEnv("UIDomainName", "MONETR_UI_DOMAIN_NAME")
-	_ = v.BindEnv("APIDomainName", "MONETR_API_DOMAIN_NAME")
 	_ = v.BindEnv("AllowSignUp", "MONETR_ALLOW_SIGN_UP")
-	_ = v.BindEnv("ExternalURLProtocol", "MONETR_EXTERNAL_PROTOCOL")
-	_ = v.BindEnv("EnableWebhooks", "MONETR_ENABLE_WEBHOOKS")
 	_ = v.BindEnv("Beta.EnableBetaCodes", "MONETR_ENABLE_BETA_CODES")
 	_ = v.BindEnv("Cors.AllowedOrigins", "MONETR_CORS_ALLOWED_ORIGINS")
 	_ = v.BindEnv("Cors.Debug", "MONETR_CORS_DEBUG")
@@ -537,6 +480,7 @@ func setupEnv(v *viper.Viper) {
 	_ = v.BindEnv("Sentry.ExternalDSN", "MONETR_SENTRY_EXTERNAL_DSN")
 	_ = v.BindEnv("Sentry.SampleRate", "MONETR_SENTRY_SAMPLE_RATE")
 	_ = v.BindEnv("Sentry.TraceSampleRate", "MONETR_SENTRY_TRACE_SAMPLE_RATE")
+	_ = v.BindEnv("Server.ExternalURL", "MONETR_SERVER_EXTERNAL_URL")
 	_ = v.BindEnv("Stripe.Enabled", "MONETR_STRIPE_ENABLED")
 	_ = v.BindEnv("Stripe.APIKey", "MONETR_STRIPE_API_KEY")
 	_ = v.BindEnv("Stripe.PublicKey", "MONETR_STRIPE_PUBLIC_KEY")

--- a/server/config/server.go
+++ b/server/config/server.go
@@ -1,0 +1,133 @@
+package config
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type Cookies struct {
+	// SameSiteStrict allows the host of monetr to define whether the cookie used
+	// for authentication is limited to same site. This might impact use cases
+	// where the UI is on a different domain than the API. In general, it is
+	// recommended that this is enabled and that the UI and API are served from
+	// the same domain.
+	SameSiteStrict bool `yaml:"sameSiteStrict"`
+	// Secure specifies that the authentication cookie issued and required by API
+	// endpoints is a secure cookie. This defaults to true, but requires that the
+	// host of monetr use HTTPS. If you are not using HTTPS then this must be
+	// disabled for API calls to succeed.
+	Secure bool `yaml:"secure"`
+	// Name defines the name of the cookie to use for authentication. This
+	// defaults to `M-Token` but can be customized if the host wants to.
+	Name string `yaml:"name"`
+}
+
+type Server struct {
+	// ListenPort defines the port that monetr will listen for HTTP requests on.
+	// This port should be forwarded such that it is accessible to the desired
+	// clients. Be that on a local network, or forwarded to the public internet.
+	ListenPort int `yaml:"listenPort"`
+	// ListenAddress defines the IP address that monetr should listen on for HTTP
+	// requests.
+	ListenAddress string `yaml:"listenAddress"`
+	// StatsPort is the port that our prometheus metrics are served on. This port
+	// should not be publicly accessible and should only be accessible by the
+	// prometheus server scraping for metrics. It is not an endpoint that needs to
+	// be secured as no sensitive client information will be served by it; but it
+	// should not be accessible publicly.
+	StatsPort int `yaml:"statsPort"`
+	// Cookies defines the parameters used for issuing and processing cookies from
+	// clients. Cookies are used for authentication.
+	Cookies Cookies `yaml:"cookies"`
+	// UICacheHours is the number of hours that UI files should be cached by the
+	// client. This is done by including an Expires and Cache-Control header in
+	// the response for all UI related requests. If this is 0 then the headers
+	// will not be included. Defaults to 12 hours.
+	UICacheHours int `yaml:"uiCacheHours"`
+	// ExternalURL tells monetr what protocol, hostname and path it should expect
+	// traffic from externally. For example: `http://my.monetr.local` tells monetr
+	// that it should not expect secure traffic, and thus should not use things
+	// like secure cookies (as they will not work). Where as
+	// `https://my.monetr.local` tells monetr that all traffic will be via HTTPS
+	// and secure cookies will work. Another example would be something like
+	// `https://homelab.local/monetr` where monetr is on the same domain as
+	// potentially other applications, but is under a specific sub path.
+	ExternalURL string `yaml:"externalUrl"`
+}
+
+// GetIsSecureProtocol will return true if the ExternalURL specified is a secure
+// url using HTTPS.
+func (s Server) GetIsSecureProtocol() bool {
+	return strings.HasPrefix(s.ExternalURL, "https://")
+}
+
+// GetIsCookieSecure will return true when both Cookies.Secure is true and the
+// ExternalURL has been configured to use HTTPS. This is used to determine
+// whether or not to set `secure` on the authentication cookies monetr issues to
+// clients.
+func (s Server) GetIsCookieSecure() bool {
+	return s.Cookies.Secure && s.GetIsSecureProtocol()
+}
+
+// AssertExternalURLValid will return an error if the specified ExternalURL is
+// not valid.
+func (s Server) AssertExternalURLValid() error {
+	_, err := url.Parse(s.ExternalURL)
+	if err != nil {
+		return errors.Wrap(err, "external URL is not valid")
+	}
+
+	return nil
+}
+
+// GetHostname will return the hostname derived from the ExternalURL, it will
+// not include a port if one was specified. This is used for setting cookies.
+func (s Server) GetHostname() string {
+	url := s.GetBaseURL()
+	return url.Hostname()
+}
+
+func (s Server) GetBaseURL() *url.URL {
+	url, err := url.Parse(s.ExternalURL)
+	if err != nil {
+		address := s.GetListenAddress()
+		url, _ = url.Parse(fmt.Sprintf("http://%s:%d", address, s.ListenPort))
+	}
+
+	return url
+}
+
+// GetListenAddress returns a valid IP address that will be used to determine
+// the listen address for the server. Or localhost if the address is not valid
+// or not provided.
+func (s Server) GetListenAddress() string {
+	if s.ListenAddress == "" {
+		return "localhost"
+	}
+
+	addr := net.ParseIP(s.ListenAddress)
+	if addr == nil {
+		return "localhost"
+	}
+
+	return addr.String()
+}
+
+// GetURL should be used to generate URLs with paths and parameters that are
+// safe to use outside the application. For example, if you are sending an email
+// with a link to a page in monetr, this function should be used to generate
+// that URL.
+func (s Server) GetURL(relativePath string, params map[string]string) string {
+	baseUrl := s.GetBaseURL().JoinPath(relativePath)
+	query := baseUrl.Query()
+	for key, value := range params {
+		query.Set(key, value)
+	}
+	baseUrl.RawQuery = query.Encode()
+
+	return baseUrl.String()
+}

--- a/server/controller/communication_helpers.go
+++ b/server/controller/communication_helpers.go
@@ -1,0 +1,67 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/monetr/monetr/server/communication"
+	"github.com/monetr/monetr/server/models"
+)
+
+func (c *Controller) sendVerificationEmail(
+	ctx echo.Context,
+	login *models.Login,
+	token string,
+) error {
+	baseUrl := c.configuration.Server.GetBaseURL()
+	verifyUrl := c.configuration.Server.GetURL("/verify/email", map[string]string{
+		"token": token,
+	})
+	err := c.email.SendVerification(c.getContext(ctx), communication.VerifyEmailParams{
+		BaseURL:      baseUrl.String(),
+		Email:        login.Email,
+		FirstName:    login.FirstName,
+		LastName:     login.LastName,
+		SupportEmail: "support@monetr.app",
+		VerifyURL:    verifyUrl,
+	})
+	if err != nil {
+		return c.wrapAndReturnError(
+			ctx,
+			err,
+			http.StatusInternalServerError,
+			"failed to send verification email",
+		)
+	}
+
+	return nil
+}
+
+func (c *Controller) sendPasswordReset(
+	ctx echo.Context,
+	login *models.Login,
+	token string,
+) error {
+	baseUrl := c.configuration.Server.GetBaseURL()
+	resetUrl := c.configuration.Server.GetURL("/password/reset", map[string]string{
+		"token": token,
+	})
+	err := c.email.SendPasswordReset(c.getContext(ctx), communication.PasswordResetParams{
+		BaseURL:      baseUrl.String(),
+		Email:        login.Email,
+		FirstName:    login.FirstName,
+		LastName:     login.LastName,
+		SupportEmail: "support@monetr.app",
+		ResetURL:     resetUrl,
+	})
+	if err != nil {
+		return c.wrapAndReturnError(
+			ctx,
+			err,
+			http.StatusInternalServerError,
+			"Failed to send password reset email",
+		)
+	}
+
+	return nil
+}

--- a/server/controller/errors.go
+++ b/server/controller/errors.go
@@ -18,9 +18,14 @@ func (c *Controller) wrapPgError(ctx echo.Context, err error, msg string, args .
 	case pg.ErrNoRows:
 		friendlyError := fmt.Sprintf("%s: record does not exist", fmt.Sprintf(msg, args...))
 
-		crumbs.Error(c.getContext(ctx), fmt.Sprintf(msg, args...), c.configuration.APIDomainName, map[string]interface{}{
-			"error": friendlyError,
-		})
+		crumbs.Error(
+			c.getContext(ctx),
+			fmt.Sprintf(msg, args...),
+			ctx.Request().URL.Hostname(),
+			map[string]interface{}{
+				"error": friendlyError,
+			},
+		)
 
 		return echo.NewHTTPError(
 			http.StatusNotFound,
@@ -64,7 +69,7 @@ func (c *Controller) wrapAndReturnError(ctx echo.Context, err error, status int,
 		crumbs.Error(
 			c.getContext(ctx),
 			fmt.Sprintf(msg, args...),
-			c.configuration.APIDomainName,
+			ctx.Request().URL.Hostname(),
 			map[string]interface{}{
 				"error": wrapped.Error(),
 			},
@@ -74,9 +79,14 @@ func (c *Controller) wrapAndReturnError(ctx echo.Context, err error, status int,
 }
 
 func (c *Controller) failure(ctx echo.Context, status int, error GenericAPIError) error {
-	crumbs.Error(c.getContext(ctx), error.FriendlyMessage(), c.configuration.APIDomainName, map[string]interface{}{
-		"error": error,
-	})
+	crumbs.Error(
+		c.getContext(ctx),
+		error.FriendlyMessage(),
+		ctx.Request().URL.Hostname(),
+		map[string]interface{}{
+			"error": error,
+		},
+	)
 
 	return echo.NewHTTPError(status, error.Error()).WithInternal(error)
 }
@@ -87,7 +97,7 @@ func (c *Controller) returnError(ctx echo.Context, status int, msg string, args 
 	crumbs.Error(
 		c.getContext(ctx),
 		fmt.Sprintf(msg, args...),
-		c.configuration.APIDomainName,
+		ctx.Request().URL.Hostname(),
 		map[string]interface{}{
 			"error": err.Error(),
 		},

--- a/server/controller/main_test.go
+++ b/server/controller/main_test.go
@@ -53,7 +53,7 @@ func NewTestApplicationConfig(t *testing.T) config.Configuration {
 	return config.Configuration{
 		AllowSignUp: true,
 		Server: config.Server{
-			ExternalURL: "http://monetr.local",
+			ExternalURL: "https://monetr.local",
 			Cookies: config.Cookies{
 				SameSiteStrict: true,
 				Secure:         true,

--- a/server/controller/routes.go
+++ b/server/controller/routes.go
@@ -153,7 +153,7 @@ func (c *Controller) RegisterRoutes(app *echo.Echo) {
 
 				hub.AddBreadcrumb(&sentry.Breadcrumb{
 					Type:     "http",
-					Category: c.configuration.APIDomainName,
+					Category: ctx.Request().URL.Hostname(),
 					Data: map[string]interface{}{
 						"url":    ctx.Request().URL.String(),
 						"method": ctx.Request().Method,
@@ -214,7 +214,7 @@ func (c *Controller) RegisterRoutes(app *echo.Echo) {
 	repoParty.POST("/authentication/register", c.postRegister)
 	repoParty.POST("/authentication/verify", c.verifyEndpoint)
 	repoParty.POST("/authentication/verify/resend", c.resendVerification)
-	repoParty.POST("/authentication/forgot", c.sendForgotPassword)
+	repoParty.POST("/authentication/forgot", c.postForgotPassword)
 	repoParty.POST("/authentication/reset", c.resetPassword)
 
 	authed := repoParty.Group("", c.authenticationMiddleware)

--- a/server/controller/user.go
+++ b/server/controller/user.go
@@ -112,7 +112,7 @@ func (c *Controller) changePassword(ctx echo.Context) error {
 		return c.returnError(ctx, http.StatusUnauthorized, "current password provided is not correct")
 	case nil:
 		if err := c.email.SendPasswordChanged(c.getContext(ctx), communication.PasswordChangedParams{
-			BaseURL:      c.configuration.GetUIURL(),
+			BaseURL:      c.configuration.Server.GetBaseURL().String(),
 			Email:        user.Login.Email,
 			FirstName:    user.Login.FirstName,
 			LastName:     user.Login.LastName,

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -57,12 +57,6 @@ metadata:
   {{- include "api.labels" . | nindent 4 }}
 data:
   config.yaml: |
-    backgroundJobs:
-      engine: {{ quote .Values.api.backgroundJobs.engine }}
-      scheduler: {{ quote .Values.api.backgroundJobs.scheduler }}
-      jobSchedule:
-    {{- toYaml .Values.api.backgroundJobs.jobSchedule | nindent 8 }}
-
     reCaptcha:
       enabled: {{ .Values.api.reCaptcha.enabled }}
       verifyLogin: {{ .Values.api.reCaptcha.verifyLogin }}

--- a/values.my.monetr.app.yaml
+++ b/values.my.monetr.app.yaml
@@ -56,15 +56,11 @@ api:
   customEnv:
     - name: MONETR_ENVIRONMENT
       value: "my.monetr.app"
-  uiDomainName: my.monetr.app
-  apiDomainName: my.monetr.app
   allowSignUp: true
-  enableWebhooks: true # Will be deprecated soon.
+  server:
+    externalUrl: https://my.monetr.app
   beta:
     enableBetaCodes: true
-  backgroundJobs:
-    engine: postgresql
-    scheduler: internal
   postgreSql:
     address: postgres.production.monetr.in
     port: 5432

--- a/values.my.monetr.dev.yaml
+++ b/values.my.monetr.dev.yaml
@@ -68,13 +68,9 @@ api:
     - name: MONETR_ENVIRONMENT
       value: "my.monetr.dev"
   additionalConfigFilePaths: []
-  uiDomainName: my.monetr.dev
-  apiDomainName: my.monetr.dev
   allowSignUp: true
-  enableWebhooks: true # Will be deprecated soon.
-  backgroundJobs:
-    engine: postgresql
-    scheduler: internal
+  server:
+    externalUrl: https://my.monetr.dev
   beta:
     enableBetaCodes: true
   postgreSql:

--- a/values.yaml
+++ b/values.yaml
@@ -94,14 +94,9 @@ api:
   additionalConfigFilePaths: [ ]
   includeSecrets: false
   name: monetr
-  uiDomainName: localhost:4000
-  apiDomainName: localhost:4000
   allowSignUp: true
-  backgroundJobs:
-    engine: gocraft
-    scheduler: internal
-    jobSchedule: { }
   server:
+    externalUrl: http://localhost:4000
     listenPort: 4000
     statsPort: 9000
     cookies:


### PR DESCRIPTION
Previously monetr would rely on 3 fields to determine the external URL
and protocol used to access the application. This was confusing and was
inconsistent throughout the application.

This transitions monetr to using a single setting,
`$.server.externalUrl` which is a simple URL. monetr then parses this
URL and derives the protocol, hostname, and path prefix if there is one.
URLs for monetr are then built based on this base URL.

Resolves #1800
