### PR TITLE
fix(plaid): Reduce number of Plaid API calls necessary for syncing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/mileusna/useragent v1.3.4
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pkg/errors v0.9.1
-	github.com/plaid/plaid-go/v20 v20.1.0
+	github.com/plaid/plaid-go/v26 v26.0.0
 	github.com/prometheus/client_golang v1.17.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -400,8 +400,8 @@ github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTw
 github.com/pkg/diff v0.0.0-20200914180035-5b29258ca4f7/go.mod h1:zO8QMzTeZd5cpnIkz/Gn6iK0jDfGicM1nynOkkPIl28=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/plaid/plaid-go/v20 v20.1.0 h1:iSMItS3VtYG54YXq07l8xJOUl1Bqu1oKT+ngNLRF92c=
-github.com/plaid/plaid-go/v20 v20.1.0/go.mod h1:QT2ELTZm74Md9FDFR9nN53qoM/076A7B5Tabqotp0zw=
+github.com/plaid/plaid-go/v26 v26.0.0 h1:GY9eTOMPxCQ2wo2afaT9pG4Aa1BwhDllvC90iQOt8YM=
+github.com/plaid/plaid-go/v26 v26.0.0/go.mod h1:a5VNWkmS8AnVA1J3bVgyNmoPVlbnjH/eXCz/beywDMA=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=

--- a/server/application/app_test.go
+++ b/server/application/app_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/monetr/monetr/server/config"
 	"github.com/monetr/monetr/server/internal/testutils"
 	"github.com/monetr/monetr/server/ui"
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/server/background/sync_plaid_test.go
+++ b/server/background/sync_plaid_test.go
@@ -54,26 +54,6 @@ func TestSyncPlaidJob_Run(t *testing.T) {
 			Return(plaidClient, nil).
 			AnyTimes()
 
-		plaidClient.EXPECT().
-			GetAccounts(
-				gomock.Any(),
-			).
-			Return([]platypus.BankAccount{
-				platypus.PlaidBankAccount{
-					AccountId: plaidBankAccount.PlaidBankAccount.PlaidId,
-					Balances: platypus.PlaidBankAccountBalances{
-						Available: 100,
-						Current:   100,
-					},
-					Mask:         plaidBankAccount.Mask,
-					Name:         plaidBankAccount.Name,
-					OfficialName: plaidBankAccount.PlaidBankAccount.OfficialName,
-					Type:         "depository",
-					SubType:      "checking",
-				},
-			}, nil).
-			AnyTimes()
-
 		nextCursor := gofakeit.UUID()
 		pendingTxnId := gofakeit.UUID()
 		firstSyncCall := plaidClient.EXPECT().
@@ -102,6 +82,20 @@ func TestSyncPlaidJob_Run(t *testing.T) {
 				},
 				Updated: []platypus.Transaction{},
 				Deleted: []string{},
+				Accounts: []platypus.BankAccount{
+					platypus.PlaidBankAccount{
+						AccountId: plaidBankAccount.PlaidBankAccount.PlaidId,
+						Balances: platypus.PlaidBankAccountBalances{
+							Available: 100,
+							Current:   100,
+						},
+						Mask:         plaidBankAccount.Mask,
+						Name:         plaidBankAccount.Name,
+						OfficialName: plaidBankAccount.PlaidBankAccount.OfficialName,
+						Type:         "depository",
+						SubType:      "checking",
+					},
+				},
 			}, nil)
 
 		firstCalculateCall := enqueuer.EXPECT().
@@ -179,6 +173,20 @@ func TestSyncPlaidJob_Run(t *testing.T) {
 				Updated: []platypus.Transaction{},
 				Deleted: []string{
 					pendingTxnId,
+				},
+				Accounts: []platypus.BankAccount{
+					platypus.PlaidBankAccount{
+						AccountId: plaidBankAccount.PlaidBankAccount.PlaidId,
+						Balances: platypus.PlaidBankAccountBalances{
+							Available: 100,
+							Current:   100,
+						},
+						Mask:         plaidBankAccount.Mask,
+						Name:         plaidBankAccount.Name,
+						OfficialName: plaidBankAccount.PlaidBankAccount.OfficialName,
+						Type:         "depository",
+						SubType:      "checking",
+					},
 				},
 			}, nil)
 

--- a/server/config/configuration.go
+++ b/server/config/configuration.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/monetr/monetr/server/util"
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 	"github.com/spf13/viper"
 )
 

--- a/server/consts/plaid.go
+++ b/server/consts/plaid.go
@@ -1,7 +1,7 @@
 package consts
 
 import (
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 )
 
 var (

--- a/server/controller/main_test.go
+++ b/server/controller/main_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/monetr/monetr/server/security"
 	"github.com/monetr/monetr/server/storage"
 	"github.com/monetr/monetr/server/stripe_helper"
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/server/controller/plaid_test.go
+++ b/server/controller/plaid_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/monetr/monetr/server/internal/mock_plaid"
 	"github.com/monetr/monetr/server/internal/mockgen"
 	"github.com/monetr/monetr/server/internal/testutils"
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )

--- a/server/internal/mock_plaid/accounts.go
+++ b/server/internal/mock_plaid/accounts.go
@@ -11,7 +11,7 @@ import (
 	"github.com/monetr/monetr/server/internal/mock_http_helper"
 	"github.com/monetr/monetr/server/internal/myownsanity"
 	"github.com/monetr/monetr/server/internal/testutils"
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 	"github.com/stretchr/testify/require"
 )
 

--- a/server/internal/mock_plaid/link.go
+++ b/server/internal/mock_plaid/link.go
@@ -11,7 +11,7 @@ import (
 	"github.com/monetr/monetr/server/consts"
 	"github.com/monetr/monetr/server/internal/mock_http_helper"
 	"github.com/monetr/monetr/server/internal/myownsanity"
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 	"github.com/stretchr/testify/require"
 )
 

--- a/server/internal/mock_plaid/mock_exchange.go
+++ b/server/internal/mock_plaid/mock_exchange.go
@@ -8,7 +8,7 @@ import (
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/monetr/monetr/server/internal/mock_http_helper"
 	"github.com/monetr/monetr/server/internal/myownsanity"
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 	"github.com/stretchr/testify/require"
 )
 

--- a/server/internal/mock_plaid/path.go
+++ b/server/internal/mock_plaid/path.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 	"github.com/stretchr/testify/require"
 )
 

--- a/server/internal/mock_plaid/transactions.go
+++ b/server/internal/mock_plaid/transactions.go
@@ -9,7 +9,7 @@ import (
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/monetr/monetr/server/internal/mock_http_helper"
 	"github.com/monetr/monetr/server/internal/myownsanity"
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 	"github.com/stretchr/testify/require"
 )
 

--- a/server/internal/mock_plaid/verification.go
+++ b/server/internal/mock_plaid/verification.go
@@ -9,7 +9,7 @@ import (
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/monetr/monetr/server/internal/mock_http_helper"
 	"github.com/monetr/monetr/server/internal/myownsanity"
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 	"github.com/stretchr/testify/require"
 )
 

--- a/server/internal/mockgen/platypus.go
+++ b/server/internal/mockgen/platypus.go
@@ -15,7 +15,7 @@ import (
 
 	models "github.com/monetr/monetr/server/models"
 	platypus "github.com/monetr/monetr/server/platypus"
-	plaid "github.com/plaid/plaid-go/v20/plaid"
+	plaid "github.com/plaid/plaid-go/v26/plaid"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/server/internal/testutils/plaid.go
+++ b/server/internal/testutils/plaid.go
@@ -2,7 +2,7 @@ package testutils
 
 import (
 	"github.com/monetr/monetr/server/models"
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 )
 
 type MockPlaidData struct {

--- a/server/platypus/account.go
+++ b/server/platypus/account.go
@@ -1,6 +1,6 @@
 package platypus
 
-import "github.com/plaid/plaid-go/v20/plaid"
+import "github.com/plaid/plaid-go/v26/plaid"
 
 type (
 	BankAccount interface {

--- a/server/platypus/account_test.go
+++ b/server/platypus/account_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/monetr/monetr/server/internal/myownsanity"
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/server/platypus/client.go
+++ b/server/platypus/client.go
@@ -11,7 +11,7 @@ import (
 	"github.com/monetr/monetr/server/crumbs"
 	"github.com/monetr/monetr/server/internal/myownsanity"
 	"github.com/monetr/monetr/server/models"
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 	"github.com/sirupsen/logrus"
 )
 

--- a/server/platypus/client_test.go
+++ b/server/platypus/client_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/monetr/monetr/server/models"
 	"github.com/monetr/monetr/server/repository"
 	"github.com/monetr/monetr/server/secrets"
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/server/platypus/institutions.go
+++ b/server/platypus/institutions.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/monetr/monetr/server/cache"
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 	"github.com/sirupsen/logrus"
 )
 

--- a/server/platypus/platypus.go
+++ b/server/platypus/platypus.go
@@ -18,7 +18,7 @@ import (
 	"github.com/monetr/monetr/server/repository"
 	"github.com/monetr/monetr/server/secrets"
 	"github.com/pkg/errors"
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 	"github.com/sirupsen/logrus"
 )
 

--- a/server/platypus/platypus_test.go
+++ b/server/platypus/platypus_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/monetr/monetr/server/internal/mock_plaid"
 	"github.com/monetr/monetr/server/internal/testutils"
 	"github.com/monetr/monetr/server/secrets"
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/server/platypus/token.go
+++ b/server/platypus/token.go
@@ -3,7 +3,7 @@ package platypus
 import (
 	"time"
 
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 )
 
 type ItemToken struct {

--- a/server/platypus/transaction.go
+++ b/server/platypus/transaction.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/monetr/monetr/server/util"
 	"github.com/pkg/errors"
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 )
 
 type Transaction interface {

--- a/server/platypus/webhook.go
+++ b/server/platypus/webhook.go
@@ -11,7 +11,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/monetr/monetr/server/internal/myownsanity"
 	"github.com/pkg/errors"
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 	"github.com/sirupsen/logrus"
 )
 

--- a/server/platypus/webhook_test.go
+++ b/server/platypus/webhook_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/monetr/monetr/server/internal/mock_plaid"
 	"github.com/monetr/monetr/server/internal/testutils"
 	"github.com/monetr/monetr/server/secrets"
-	"github.com/plaid/plaid-go/v20/plaid"
+	"github.com/plaid/plaid-go/v26/plaid"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
The Plaid sync functionality no longer makes an additional API call to
the bank account endpoint. Instead it relies on the accounts returned
from the sync API call itself.

Resolves #1809
