### PR TITLE
fix(storage): Improved path validation in filesystem storage provider

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -21,6 +21,7 @@
         "MONETR_EMAIL_VERIFICATION_ENABLED": "true",
         "MONETR_STRIPE_TAXES_ENABLED": "true",
         "MONETR_KMS_PROVIDER": "plaintext",
+        "MONETR_STORAGE_PROVIDER": "s3",
         "DISABLE_GO_RELOAD": "false"
       }
     },

--- a/cmake/development.cmake
+++ b/cmake/development.cmake
@@ -115,6 +115,7 @@ else()
   message(STATUS "No ngrok credentials detected, webhooks will not be enabled for local development.")
 endif()
 
+# Setup the KMS backend based on the config.
 if("${MONETR_KMS_PROVIDER}" STREQUAL "aws")
   message(STATUS "AWS KMS (Local) will be used for local development as the KMS provider")
   list(APPEND COMPOSE_FILE_TEMPLATES ${CMAKE_SOURCE_DIR}/compose/docker-compose.aws-kms.yaml.in)
@@ -144,6 +145,21 @@ else()
   message(FATAL "Invalid KMS provider specified, MONETR_KMS_PROVIDER=${MONETR_KMS_PROVIDER}\nValid options are: aws, vault, plaintext")
 endif()
 
+# Setup the storage backend based on the config.
+if("${MONETR_STORAGE_PROVIDER}" STREQUAL "s3")
+  set(MONETR_STORAGE_ENABLED "true")
+  message(STATUS "S3 storage will be used for local development")
+  message(STATUS "  Uploaded files will be available at: http://localhost:9001")
+  message(STATUS "  Username: monetr Password: password")
+  list(APPEND COMPOSE_FILE_TEMPLATES ${CMAKE_SOURCE_DIR}/compose/docker-compose.s3-storage.yaml.in)
+elseif("${MONETR_STORAGE_PROVIDER}" STREQUAL "filesystem")
+  set(MONETR_STORAGE_ENABLED "true")
+  file(MAKE_DIRECTORY ${COMPOSE_OUTPUT_DIRECTORY}/storage)
+  message(STATUS "Filesystem storage will be used for local development")
+  message(STATUS "  Uploaded files will be available at: ${COMPOSE_OUTPUT_DIRECTORY}/storage")
+elseif("${MONETR_STORAGE_PROVIDER}" STREQUAL "")
+  set(MONETR_STORAGE_ENABLED "false")
+endif()
 
 # Once the list of compose file templates has been built, actually generate the template files and build our arguments
 # for docker compose.

--- a/compose/docker-compose.monetr.yaml.in
+++ b/compose/docker-compose.monetr.yaml.in
@@ -1,26 +1,5 @@
 # vim: set ft=yaml
 services:
-  s3:
-    image: quay.io/minio/minio:RELEASE.2023-12-09T18-17-51Z
-    restart: always # If something goes wrong just restart the container, this is for development only.
-    volumes:
-      - s3Data:/data
-    ports:
-      - 9001:9001
-    healthcheck:
-      test: timeout 10s bash -c ':> /dev/tcp/127.0.0.1/9000' || exit 1
-      interval: 3s
-      timeout: 15s
-      retries: 10
-      start_period: 5s
-    environment:
-      MINIO_ROOT_USER: monetr
-      MINIO_ROOT_PASSWORD: password
-    entrypoint: >
-      /bin/sh -c "
-      mkdir -p /data/monetr-storage;
-      minio server /data --console-address ':9001';
-      "
   mail:
     # Mailhog is used for testing email sending from the application. This is for things like forgot password or email
     # verification. It can be accessed by navigating to `http://localhost/mail`
@@ -132,12 +111,9 @@ services:
       MONETR_SENTRY_EXTERNAL_DSN: "@MONETR_SENTRY_DSN@"
       MONETR_EMAIL_VERIFICATION_ENABLED: "@MONETR_EMAIL_VERIFICATION_ENABLED@"
       # If vault is the KMS provider then these settings will be used
-      MONETR_VAULT_AUTH_METHOD: "token"
       MONETR_VAULT_TOKEN: "@VAULT_ROOT_TOKEN@"
-      MONETR_VAULT_ENDPOINT: "http://vault:80"
-      # Storage settings
-      AWS_ACCESS_KEY: monetr
-      AWS_SECRET_KEY: password
+      MONETR_STORAGE_ENABLED: "@MONETR_STORAGE_ENABLED@"
+      MONETR_STORAGE_PROVIDER: "@MONETR_STORAGE_PROVIDER@"
     command:
       - bash
       - -c
@@ -145,7 +121,6 @@ services:
     links:
       - redis
       - postgres
-      - s3
       - mail
     ports:
       # This port is used for editors to connect to dlv remotely to do step debugging.
@@ -160,11 +135,8 @@ services:
         condition: service_started
       postgres:
         condition: service_started
-      # kms:
-      #   condition: service_started
 
 volumes:
   kmsData:
   tmpData:
   goData:
-  s3Data:

--- a/compose/docker-compose.s3-storage.yaml.in
+++ b/compose/docker-compose.s3-storage.yaml.in
@@ -1,0 +1,33 @@
+# vim: set ft=yaml
+services:
+  s3:
+    image: quay.io/minio/minio:RELEASE.2023-12-09T18-17-51Z
+    restart: always # If something goes wrong just restart the container, this is for development only.
+    volumes:
+      - s3Data:/data
+    ports:
+      - 9001:9001
+    healthcheck:
+      test: timeout 10s bash -c ':> /dev/tcp/127.0.0.1/9000' || exit 1
+      interval: 3s
+      timeout: 15s
+      retries: 10
+      start_period: 5s
+    environment:
+      MINIO_ROOT_USER: monetr
+      MINIO_ROOT_PASSWORD: password
+    entrypoint: >
+      /bin/sh -c "
+      mkdir -p /data/monetr-storage;
+      minio server /data --console-address ':9001';
+      "
+  monetr:
+    links:
+      - s3
+    environment:
+      # Storage settings
+      AWS_ACCESS_KEY: monetr
+      AWS_SECRET_KEY: password
+
+volumes:
+  s3Data:

--- a/compose/monetr.yaml
+++ b/compose/monetr.yaml
@@ -59,11 +59,15 @@ keyManagement:
     authMethod: token
     endpoint: http://vault:80
 storage:
-  enabled: true
-  provider: s3
+  # Enabled will be specified via MONETR_STORAGE_ENABLED
+  # enabled: true
+  # Provider will be specified via MONETR_STORAGE_PROVIDER
+  # provider: s3
   s3:
     endpoint: http://s3:9000
     bucket: monetr-storage
     region: us-east-1
     forcePathStyle: true
     useEnvCredentials: true # Use the AWS_ACCESS_KEY and AWS_SECRET_KEY env variables in development.
+  filesystem:
+    basePath: /build/build/development/storage 

--- a/compose/nginx.conf
+++ b/compose/nginx.conf
@@ -17,10 +17,6 @@ http {
         server mail:8025;
     }
 
-    upstream docker-s3 {
-        server s3:9001;
-    }
-
     map $http_upgrade $connection_upgrade {
         default Upgrade;
         ''      close;

--- a/server/cmd/storage.go
+++ b/server/cmd/storage.go
@@ -16,6 +16,10 @@ import (
 	"google.golang.org/api/option"
 )
 
+// setupStorage is called when the monetr application starts running, it takes
+// the configuration and sets up the appropriate storage interface based on that
+// config. It also performs some basic validation of that storage configuration
+// and if there is a problem it will return an error.
 func setupStorage(
 	log *logrus.Entry,
 	configuration config.Configuration,
@@ -106,7 +110,7 @@ func setupStorage(
 		fileStorage = storage.NewGCSStorageBackend(log, gcsConfig.Bucket, client)
 	case "filesystem":
 		log.Trace("setting up file storage interface using local filesystem")
-		fileStorage = storage.NewFilesystemStorage(
+		fileStorage, err = storage.NewFilesystemStorage(
 			log,
 			configuration.Storage.Filesystem.BasePath,
 		)

--- a/server/config/configuration.go
+++ b/server/config/configuration.go
@@ -445,6 +445,8 @@ func setupEnv(v *viper.Viper) {
 	_ = v.BindEnv("Sentry.SampleRate", "MONETR_SENTRY_SAMPLE_RATE")
 	_ = v.BindEnv("Sentry.TraceSampleRate", "MONETR_SENTRY_TRACE_SAMPLE_RATE")
 	_ = v.BindEnv("Server.ExternalURL", "MONETR_SERVER_EXTERNAL_URL")
+	_ = v.BindEnv("Storage.Enabled", "MONETR_STORAGE_ENABLED")
+	_ = v.BindEnv("Storage.Provider", "MONETR_STORAGE_PROVIDER")
 	_ = v.BindEnv("Stripe.Enabled", "MONETR_STRIPE_ENABLED")
 	_ = v.BindEnv("Stripe.APIKey", "MONETR_STRIPE_API_KEY")
 	_ = v.BindEnv("Stripe.PublicKey", "MONETR_STRIPE_PUBLIC_KEY")

--- a/server/controller/main_test.go
+++ b/server/controller/main_test.go
@@ -144,7 +144,8 @@ func NewTestApplicationPatched(t *testing.T, configuration config.Configuration,
 	require.NoError(t, err, "must be able to create a temp directory for uploads")
 	log.Debugf("[TEST] created temporary directory for uploads: %s", tempDirectory)
 
-	fileStorage := storage.NewFilesystemStorage(log, tempDirectory)
+	fileStorage, err := storage.NewFilesystemStorage(log, tempDirectory)
+	require.NoError(t, err, "must not have an error when creating the filesystem storage")
 
 	var jobRunner background.JobController
 	if patched.JobController != nil {


### PR DESCRIPTION
The filesystem storage provider now provides better validation for the
provided base path. Requiring that the path is an absolute path and that
the process has permissions to access the directory.

This also adds MONETR_STORAGE_PROVIDER to the cmake configuration,
allowing the storage provider to be customized between S3 and the
filesystem provider.

Resolves #1798
