### PR TITLE
fix(forecast): Make the forecasting code return a proper error

### DIFF
--- a/server/controller/forecast.go
+++ b/server/controller/forecast.go
@@ -61,22 +61,12 @@ func (c *Controller) getForecast(ctx echo.Context) error {
 	timeout, cancel := context.WithTimeout(c.getContext(ctx), 15*time.Second)
 	defer cancel()
 
-	result, err := func() (result forecast.Forecast, err error) {
-		defer func() {
-			switch panicResult := recover().(type) {
-			case error:
-				err = panicResult
-				return
-			}
-		}()
-		result = forecaster.GetForecast(
-			timeout,
-			now,
-			endDate,
-			timezone,
-		)
-		return result, nil
-	}()
+	result, err := forecaster.GetForecast(
+		timeout,
+		now,
+		endDate,
+		timezone,
+	)
 	if err == context.DeadlineExceeded {
 		return c.returnError(ctx, http.StatusRequestTimeout, "timeout forecasting")
 	} else if err != nil {
@@ -149,22 +139,12 @@ func (c *Controller) postForecastNewSpending(ctx echo.Context) error {
 	timeout, cancel := context.WithTimeout(c.getContext(ctx), 25*time.Second)
 	defer cancel()
 
-	result, err := func() (result int64, err error) {
-		defer func() {
-			switch panicResult := recover().(type) {
-			case error:
-				err = panicResult
-				return
-			}
-		}()
-		result = afterForecast.GetAverageContribution(
-			timeout,
-			request.NextRecurrence.AddDate(0, 0, -1),
-			end,
-			timezone,
-		)
-		return result, nil
-	}()
+	result, err := afterForecast.GetAverageContribution(
+		timeout,
+		request.NextRecurrence.AddDate(0, 0, -1),
+		end,
+		timezone,
+	)
 	if err == context.DeadlineExceeded {
 		return c.returnError(ctx, http.StatusRequestTimeout, "timeout forecasting")
 	} else if err != nil {
@@ -216,22 +196,12 @@ func (c *Controller) postForecastNextFunding(ctx echo.Context) error {
 	timezone := c.mustGetTimezone(ctx)
 	timeout, cancel := context.WithTimeout(c.getContext(ctx), 25*time.Second)
 	defer cancel()
-	result, err := func() (result int64, err error) {
-		defer func() {
-			switch panicResult := recover().(type) {
-			case error:
-				err = panicResult
-				return
-			}
-		}()
-		result = fundingForecast.GetNextContribution(
-			timeout,
-			time.Now(),
-			request.FundingScheduleId,
-			timezone,
-		)
-		return result, nil
-	}()
+	result, err := fundingForecast.GetNextContribution(
+		timeout,
+		c.clock.Now(),
+		request.FundingScheduleId,
+		timezone,
+	)
 	if err == context.DeadlineExceeded {
 		return c.returnError(ctx, http.StatusRequestTimeout, "timeout forecasting")
 	} else if err != nil {

--- a/server/forecast/forecast.go
+++ b/server/forecast/forecast.go
@@ -30,9 +30,22 @@ type Forecast struct {
 }
 
 type Forecaster interface {
-	GetForecast(ctx context.Context, start, end time.Time, timezone *time.Location) Forecast
-	GetAverageContribution(ctx context.Context, start, end time.Time, timezone *time.Location) int64
-	GetNextContribution(ctx context.Context, start time.Time, fundingScheduleId ID[FundingSchedule], timezone *time.Location) int64
+	GetForecast(
+		ctx context.Context,
+		start, end time.Time,
+		timezone *time.Location,
+	) (Forecast, error)
+	GetAverageContribution(
+		ctx context.Context,
+		start, end time.Time,
+		timezone *time.Location,
+	) (int64, error)
+	GetNextContribution(
+		ctx context.Context,
+		start time.Time,
+		fundingScheduleId ID[FundingSchedule],
+		timezone *time.Location,
+	) (int64, error)
 }
 
 type forecasterBase struct {
@@ -74,13 +87,19 @@ func NewForecaster(log *logrus.Entry, spending []Spending, funding []FundingSche
 	return forecaster
 }
 
-// GetForecast combines the instructions from the spending and funding objects and returns a timeline of events that are
-// expected to happen based on those instructions. All dates returned by this function will be in UTC. Dates returned by
-// other functions may be in the timezone provided by the caller. Timezones are converted in this function because they
-// will likely be surfaced via an API to a client. For the sake of consistency they should be in UTC. Events are
-// returned in order, with the most recent event being first. Objects related to a date are sorted in ascending order by
-// their ID.
-func (f *forecasterBase) GetForecast(ctx context.Context, start, end time.Time, timezone *time.Location) Forecast {
+// GetForecast combines the instructions from the spending and funding objects
+// and returns a timeline of events that are expected to happen based on those
+// instructions. All dates returned by this function will be in UTC. Dates
+// returned by other functions may be in the timezone provided by the caller.
+// Timezones are converted in this function because they will likely be surfaced
+// via an API to a client. For the sake of consistency they should be in UTC.
+// Events are returned in order, with the most recent event being first. Objects
+// related to a date are sorted in ascending order by their ID.
+func (f *forecasterBase) GetForecast(
+	ctx context.Context,
+	start, end time.Time,
+	timezone *time.Location,
+) (Forecast, error) {
 	span := crumbs.StartFnTrace(ctx)
 	defer span.Finish()
 	span.Data = map[string]interface{}{
@@ -96,13 +115,18 @@ func (f *forecasterBase) GetForecast(ctx context.Context, start, end time.Time, 
 		Events:          make([]Event, 0),
 	}
 
-	linq.From(f.spending).
-		SelectT(func(item linq.KeyValue) SpendingInstructions {
-			return item.Value.(SpendingInstructions)
-		}).
-		SelectManyT(func(spending SpendingInstructions) linq.Query {
-			return linq.From(spending.GetSpendingEventsBetween(span.Context(), start, end, timezone))
-		}).
+	// Gather all of our spending events
+	events := make([]SpendingEvent, 0)
+	for i := range f.spending {
+		spending := f.spending[i]
+		result, err := spending.GetSpendingEventsBetween(span.Context(), start, end, timezone)
+		if err != nil {
+			return forecast, err
+		}
+		events = append(events, result...)
+	}
+
+	linq.From(events).
 		GroupByT(
 			func(item SpendingEvent) int64 {
 				return item.Date.Unix()
@@ -182,10 +206,14 @@ func (f *forecasterBase) GetForecast(ctx context.Context, start, end time.Time, 
 		forecast.EndingBalance = forecast.Events[len(forecast.Events)-1].Balance
 	}
 
-	return forecast
+	return forecast, nil
 }
 
-func (f *forecasterBase) GetAverageContribution(ctx context.Context, start, end time.Time, timezone *time.Location) int64 {
+func (f *forecasterBase) GetAverageContribution(
+	ctx context.Context,
+	start, end time.Time,
+	timezone *time.Location,
+) (int64, error) {
 	span := crumbs.StartFnTrace(ctx)
 	defer span.Finish()
 	span.Data = map[string]interface{}{
@@ -193,7 +221,11 @@ func (f *forecasterBase) GetAverageContribution(ctx context.Context, start, end 
 		"end":      end,
 		"timezone": timezone.String(),
 	}
-	forecast := f.GetForecast(span.Context(), start, end, timezone)
+	forecast, err := f.GetForecast(span.Context(), start, end, timezone)
+	if err != nil {
+		return 0, err
+	}
+
 	contributionAmounts := map[int64]int64{}
 	for _, event := range forecast.Events {
 		if event.Contribution == 0 {
@@ -210,14 +242,26 @@ func (f *forecasterBase) GetAverageContribution(ctx context.Context, start, end 
 		}
 	}
 
-	return popularContribution
+	return popularContribution, nil
 }
 
-func (f *forecasterBase) GetNextContribution(ctx context.Context, start time.Time, fundingScheduleId ID[FundingSchedule], timezone *time.Location) int64 {
+func (f *forecasterBase) GetNextContribution(
+	ctx context.Context,
+	start time.Time,
+	fundingScheduleId ID[FundingSchedule],
+	timezone *time.Location,
+) (int64, error) {
 	span := crumbs.StartFnTrace(ctx)
 	defer span.Finish()
 
-	end := f.funding[fundingScheduleId].GetNextFundingEventAfter(span.Context(), start, timezone)
+	end, err := f.funding[fundingScheduleId].GetNextFundingEventAfter(
+		span.Context(),
+		start,
+		timezone,
+	)
+	if err != nil {
+		return 0, err
+	}
 
 	span.Data = map[string]interface{}{
 		"start":             start,
@@ -226,14 +270,22 @@ func (f *forecasterBase) GetNextContribution(ctx context.Context, start time.Tim
 		"timezone":          timezone.String(),
 	}
 
-	forecast := f.GetForecast(span.Context(), start, end.Date.AddDate(0, 0, 1), timezone)
+	forecast, err := f.GetForecast(
+		span.Context(),
+		start, end.Date.AddDate(0, 0, 1),
+		timezone,
+	)
+	if err != nil {
+		return 0, err
+	}
+
 	for _, event := range forecast.Events {
 		if len(event.Funding) == 0 {
 			continue
 		}
 
-		return event.Contribution
+		return event.Contribution, nil
 	}
 
-	return 0
+	return 0, nil
 }

--- a/server/forecast/forecast_test.go
+++ b/server/forecast/forecast_test.go
@@ -67,9 +67,11 @@ func TestForecasterBase_GetForecast(t *testing.T) {
 		var firstAverage, secondAverage int64
 		{ // Initial
 			forecaster := NewForecaster(log, spending, fundingSchedules)
-			forecast := forecaster.GetForecast(context.Background(), now, now.AddDate(0, 1, 4), timezone)
+			forecast, err := forecaster.GetForecast(context.Background(), now, now.AddDate(0, 1, 4), timezone)
+			assert.NoError(t, err, "should not return an error")
 			assert.Greater(t, forecast.StartingBalance, int64(0))
-			firstAverage = forecaster.GetAverageContribution(context.Background(), now, now.AddDate(0, 1, 4), timezone)
+			firstAverage, err = forecaster.GetAverageContribution(context.Background(), now, now.AddDate(0, 1, 4), timezone)
+			assert.NoError(t, err, "should not return an error")
 		}
 
 		{ // With added expense
@@ -79,9 +81,11 @@ func TestForecasterBase_GetForecast(t *testing.T) {
 				CurrentAmount:  0,
 				NextRecurrence: util.Midnight(now.AddDate(1, 0, 0), timezone),
 			}), fundingSchedules)
-			forecast := forecaster.GetForecast(context.Background(), now, now.AddDate(0, 1, 4), timezone)
+			forecast, err := forecaster.GetForecast(context.Background(), now, now.AddDate(0, 1, 4), timezone)
+			assert.NoError(t, err, "should not return an error")
 			assert.Greater(t, forecast.StartingBalance, int64(0))
-			secondAverage = forecaster.GetAverageContribution(context.Background(), now, now.AddDate(0, 1, 4), timezone)
+			secondAverage, err = forecaster.GetAverageContribution(context.Background(), now, now.AddDate(0, 1, 4), timezone)
+			assert.NoError(t, err, "should not return an error")
 		}
 		assert.Greater(t, secondAverage, firstAverage, "should need to contribute more per funding")
 	})
@@ -120,7 +124,8 @@ func TestForecasterBase_GetForecast(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		assert.NotPanics(t, func() {
-			result := forecaster.GetForecast(ctx, now, end, timezone)
+			result, err := forecaster.GetForecast(ctx, now, end, timezone)
+			assert.NoError(t, err, "should not return an error")
 			assert.NotNil(t, result, "just make sure something is returned, this is to make sure we dont timeout")
 		})
 	})
@@ -165,7 +170,8 @@ func TestForecasterBase_GetForecast(t *testing.T) {
 		//ctx := context.Background()
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		result := forecaster.GetForecast(ctx, now, end, timezone)
+		result, err := forecaster.GetForecast(ctx, now, end, timezone)
+		assert.NoError(t, err, "should not return an error")
 		expected := Forecast{
 			StartingTime:    now,
 			EndingTime:      end,
@@ -287,7 +293,8 @@ func TestForecasterBase_GetForecast(t *testing.T) {
 		forecaster := NewForecaster(log, spending, funding)
 		ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Second)
 		defer cancel()
-		result := forecaster.GetForecast(ctx, now, end, timezone)
+		result, err := forecaster.GetForecast(ctx, now, end, timezone)
+		assert.NoError(t, err, "should not return an error")
 		assert.NotNil(t, result, "just make sure something is returned, this is to make sure we dont timeout")
 		pretty, err := json.MarshalIndent(result, "", "  ")
 		assert.NoError(t, err, "must be able to convert the forecast into a pretty json")
@@ -332,7 +339,8 @@ func TestForecasterBase_GetForecast(t *testing.T) {
 		forecaster := NewForecaster(log, spending, fundingSchedules)
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		result := forecaster.GetForecast(ctx, now, end, timezone)
+		result, err := forecaster.GetForecast(ctx, now, end, timezone)
+		assert.NoError(t, err, "should not return an error")
 		expected := Forecast{
 			StartingTime:    now,
 			EndingTime:      end,

--- a/server/forecast/funding_test.go
+++ b/server/forecast/funding_test.go
@@ -25,7 +25,8 @@ func TestFundingScheduleBase_GetNextContributionDateAfter(t *testing.T) {
 		now := time.Date(2022, 5, 1, 0, 0, 0, 0, timezone)
 		expected := time.Date(2022, 5, 15, 0, 0, 0, 0, timezone)
 		instructions := NewFundingScheduleFundingInstructions(log, fundingSchedule)
-		next := instructions.GetNextFundingEventAfter(context.Background(), now, timezone)
+		next, err := instructions.GetNextFundingEventAfter(context.Background(), now, timezone)
+		assert.NoError(t, err, "should not return an error")
 		assert.Equal(t, expected, next.Date, "should contribute next on sunday the 15th of may")
 	})
 
@@ -43,7 +44,8 @@ func TestFundingScheduleBase_GetNextContributionDateAfter(t *testing.T) {
 		now := time.Date(2022, 5, 1, 0, 0, 0, 0, time.UTC)
 		expected := time.Date(2022, 5, 13, 0, 0, 0, 0, time.UTC)
 		instructions := NewFundingScheduleFundingInstructions(log, fundingSchedule)
-		next := instructions.GetNextFundingEventAfter(context.Background(), now, time.UTC)
+		next, err := instructions.GetNextFundingEventAfter(context.Background(), now, time.UTC)
+		assert.NoError(t, err, "should not return an error")
 		assert.Equal(t, expected, next.Date, "should contribute next on the 13th, which is a friday")
 	})
 
@@ -62,13 +64,15 @@ func TestFundingScheduleBase_GetNextContributionDateAfter(t *testing.T) {
 		now := time.Date(2022, 9, 31, 0, 23, 10, 0, timezone)
 		expected := time.Date(2022, 10, 14, 0, 0, 0, 0, timezone)
 		instructions := NewFundingScheduleFundingInstructions(log, fundingSchedule)
-		next := instructions.GetNextFundingEventAfter(context.Background(), now, timezone)
+		next, err := instructions.GetNextFundingEventAfter(context.Background(), now, timezone)
+		assert.NoError(t, err, "should not return an error")
 		assert.Equal(t, expected, next.Date, "should contribute next on the 14th, which is a friday")
 
 		fundingSchedule.ExcludeWeekends = false
 		expected = time.Date(2022, 10, 15, 0, 0, 0, 0, timezone)
 		instructions = NewFundingScheduleFundingInstructions(log, fundingSchedule)
-		next = instructions.GetNextFundingEventAfter(context.Background(), now, timezone)
+		next, err = instructions.GetNextFundingEventAfter(context.Background(), now, timezone)
+		assert.NoError(t, err, "should not return an error")
 		assert.Equal(t, expected, next.Date, "should contribute next on the 15th when we are not excluding weekends")
 	})
 
@@ -91,7 +95,8 @@ func TestFundingScheduleBase_GetNextContributionDateAfter(t *testing.T) {
 		now := time.Date(2022, 5, 14, 0, 0, 0, 0, timezone)
 		expected := time.Date(2022, 5, 31, 0, 0, 0, 0, timezone)
 		instructions := NewFundingScheduleFundingInstructions(log, fundingSchedule)
-		next := instructions.GetNextFundingEventAfter(context.Background(), now, timezone)
+		next, err := instructions.GetNextFundingEventAfter(context.Background(), now, timezone)
+		assert.NoError(t, err, "should not return an error")
 		assert.Equal(t, expected, next.Date, "should not show the 15th, instead should show the 31st")
 	})
 
@@ -110,7 +115,8 @@ func TestFundingScheduleBase_GetNextContributionDateAfter(t *testing.T) {
 			NextRecurrence:  next,
 		}
 		instructions := NewFundingScheduleFundingInstructions(log, fundingSchedule)
-		nextFundingOccurrence := instructions.GetNextFundingEventAfter(context.Background(), now, timezone)
+		nextFundingOccurrence, err := instructions.GetNextFundingEventAfter(context.Background(), now, timezone)
+		assert.NoError(t, err, "should not return an error")
 		assert.Equal(t, expected, nextFundingOccurrence.Date, "should be on friday the 30th of september next")
 	})
 
@@ -127,7 +133,8 @@ func TestFundingScheduleBase_GetNextContributionDateAfter(t *testing.T) {
 			NextRecurrence:  time.Time{},
 		}
 		instructions := NewFundingScheduleFundingInstructions(log, fundingSchedule)
-		nextFundingOccurrence := instructions.GetNextFundingEventAfter(context.Background(), now, timezone)
+		nextFundingOccurrence, err := instructions.GetNextFundingEventAfter(context.Background(), now, timezone)
+		assert.NoError(t, err, "should not return an error")
 		assert.Equal(t, expected, nextFundingOccurrence.Date, "should be on friday the 30th of september next")
 	})
 
@@ -144,7 +151,8 @@ func TestFundingScheduleBase_GetNextContributionDateAfter(t *testing.T) {
 			NextRecurrence:  next,
 		}
 		instructions := NewFundingScheduleFundingInstructions(log, fundingSchedule)
-		nextFundingOccurrence := instructions.GetNextFundingEventAfter(context.Background(), now, timezone)
+		nextFundingOccurrence, err := instructions.GetNextFundingEventAfter(context.Background(), now, timezone)
+		assert.NoError(t, err, "should not return an error")
 		assert.Equal(t, next, nextFundingOccurrence.Date, "should be on friday the 30th of september next")
 	})
 }
@@ -173,7 +181,8 @@ func TestFundingScheduleBase_GetNContributionDatesAfter(t *testing.T) {
 			NextRecurrence:  expected[0].Date,
 		}
 		instructions := NewFundingScheduleFundingInstructions(log, fundingSchedule)
-		nextN := instructions.GetNFundingEventsAfter(context.Background(), 2, now, timezone)
+		nextN, err := instructions.GetNFundingEventsAfter(context.Background(), 2, now, timezone)
+		assert.NoError(t, err, "should not return an error")
 		assert.Equal(t, expected, nextN, "should have the next two be the 15th and the 30th of september")
 	})
 
@@ -210,7 +219,8 @@ func TestFundingScheduleBase_GetNContributionDatesAfter(t *testing.T) {
 			NextRecurrence:  expected[0].Date,
 		}
 		instructions := NewFundingScheduleFundingInstructions(log, fundingSchedule)
-		nextN := instructions.GetNFundingEventsAfter(context.Background(), 4, now, timezone)
+		nextN, err := instructions.GetNFundingEventsAfter(context.Background(), 4, now, timezone)
+		assert.NoError(t, err, "should not return an error")
 		assert.Equal(t, expected, nextN)
 	})
 
@@ -247,7 +257,8 @@ func TestFundingScheduleBase_GetNContributionDatesAfter(t *testing.T) {
 			NextRecurrence:  expected[0].Date,
 		}
 		instructions := NewFundingScheduleFundingInstructions(log, fundingSchedule)
-		nextN := instructions.GetNFundingEventsAfter(context.Background(), 4, now, timezone)
+		nextN, err := instructions.GetNFundingEventsAfter(context.Background(), 4, now, timezone)
+		assert.NoError(t, err, "should not return an error")
 		assert.Equal(t, expected, nextN)
 	})
 }
@@ -268,7 +279,8 @@ func TestFundingScheduleBase_GetNumberOfContributionsBetween(t *testing.T) {
 		}
 
 		instructions := NewFundingScheduleFundingInstructions(log, fundingSchedule)
-		count := instructions.GetNumberOfFundingEventsBetween(context.Background(), now, end, timezone)
+		count, err := instructions.GetNumberOfFundingEventsBetween(context.Background(), now, end, timezone)
+		assert.NoError(t, err, "should not return an error")
 		assert.EqualValues(t, 7, count, "should have seven contributions")
 	})
 
@@ -287,7 +299,8 @@ func TestFundingScheduleBase_GetNumberOfContributionsBetween(t *testing.T) {
 		}
 
 		instructions := NewFundingScheduleFundingInstructions(log, fundingSchedule)
-		count := instructions.GetNumberOfFundingEventsBetween(context.Background(), now, end, timezone)
+		count, err := instructions.GetNumberOfFundingEventsBetween(context.Background(), now, end, timezone)
+		assert.NoError(t, err, "should not return an error")
 		assert.EqualValues(t, 24, count, "should have 24 contributions")
 	})
 
@@ -306,7 +319,8 @@ func TestFundingScheduleBase_GetNumberOfContributionsBetween(t *testing.T) {
 		}
 
 		instructions := NewFundingScheduleFundingInstructions(log, fundingSchedule)
-		count := instructions.GetNumberOfFundingEventsBetween(context.Background(), now, end, timezone)
+		count, err := instructions.GetNumberOfFundingEventsBetween(context.Background(), now, end, timezone)
+		assert.NoError(t, err, "should not return an error")
 		assert.EqualValues(t, 12, count, "should have 12 contributions")
 	})
 }

--- a/server/forecast/spending_test.go
+++ b/server/forecast/spending_test.go
@@ -39,7 +39,8 @@ func TestSpendingInstructionBase_GetNextSpendingEventAfter(t *testing.T) {
 			fundingInstructions,
 		)
 
-		events := spendingInstructions.GetNextNSpendingEventsAfter(context.Background(), 3, now, timezone)
+		events, err := spendingInstructions.GetNextNSpendingEventsAfter(context.Background(), 3, now, timezone)
+		assert.NoError(t, err, "should not return an error")
 		for i, item := range events {
 			if !assert.GreaterOrEqual(t, item.RollingAllocation, int64(0), "rolling allocation must be greater than zero: [%d] %s", i, item.Date) {
 				j, _ := json.MarshalIndent(item, "                        \t", "  ")
@@ -110,7 +111,8 @@ func TestSpendingInstructionBase_GetNextSpendingEventAfter(t *testing.T) {
 
 		{ // If we do the forecase before the expenses due date, then we will get an event showing it was spent.
 			now := time.Date(2024, 3, 1, 0, 0, 1, 0, timezone).UTC()
-			events := spendingInstructions.GetNextNSpendingEventsAfter(context.Background(), 4, now, timezone)
+			events, err := spendingInstructions.GetNextNSpendingEventsAfter(context.Background(), 4, now, timezone)
+			assert.NoError(t, err, "should not return an error")
 			for i, item := range events {
 				if !assert.GreaterOrEqual(t, item.RollingAllocation, int64(0), "rolling allocation must be greater than zero: [%d] %s", i, item.Date) {
 					j, _ := json.MarshalIndent(item, "                        \t", "  ")
@@ -164,7 +166,8 @@ func TestSpendingInstructionBase_GetNextSpendingEventAfter(t *testing.T) {
 
 		{ // But if it hasn't been spent after its due date then we want the same contributions.
 			now := time.Date(2024, 3, 4, 0, 0, 1, 0, timezone).UTC()
-			events := spendingInstructions.GetNextNSpendingEventsAfter(context.Background(), 3, now, timezone)
+			events, err := spendingInstructions.GetNextNSpendingEventsAfter(context.Background(), 3, now, timezone)
+			assert.NoError(t, err, "should not return an error")
 			for i, item := range events {
 				if !assert.GreaterOrEqual(t, item.RollingAllocation, int64(0), "rolling allocation must be greater than zero: [%d] %s", i, item.Date) {
 					j, _ := json.MarshalIndent(item, "                        \t", "  ")
@@ -235,7 +238,8 @@ func TestSpendingInstructionBase_GetNextSpendingEventAfter(t *testing.T) {
 			fundingInstructions,
 		)
 
-		events := spendingInstructions.GetNextNSpendingEventsAfter(context.Background(), 7, now, timezone)
+		events, err := spendingInstructions.GetNextNSpendingEventsAfter(context.Background(), 7, now, timezone)
+		assert.NoError(t, err, "should not return an error")
 		for i, item := range events {
 			if !assert.GreaterOrEqual(t, item.RollingAllocation, int64(0), "rolling allocation must be greater than zero: [%d] %s", i, item.Date) {
 				j, _ := json.MarshalIndent(item, "                        \t", "  ")
@@ -339,7 +343,8 @@ func TestSpendingInstructionBase_GetNextSpendingEventAfter(t *testing.T) {
 			fundingInstructions,
 		)
 
-		events := spendingInstructions.GetNextNSpendingEventsAfter(context.Background(), 8, now, timezone)
+		events, err := spendingInstructions.GetNextNSpendingEventsAfter(context.Background(), 8, now, timezone)
+		assert.NoError(t, err, "should not return an error")
 		for i, item := range events {
 			if !assert.GreaterOrEqual(t, item.RollingAllocation, int64(0), "rolling allocation must be greater than zero: [%d] %s", i, item.Date) {
 				j, _ := json.MarshalIndent(item, "                        \t", "  ")
@@ -452,7 +457,8 @@ func TestSpendingInstructionBase_GetSpendingEventsBetween(t *testing.T) {
 			fundingInstructions,
 		)
 
-		events := spendingInstructions.GetSpendingEventsBetween(context.Background(), now, now.AddDate(1, 0, 0), timezone)
+		events, err := spendingInstructions.GetSpendingEventsBetween(context.Background(), now, now.AddDate(1, 0, 0), timezone)
+		assert.NoError(t, err, "should not return an error")
 		// Should have 36 events, 12 spending events and 24 funding events.
 		assert.Len(t, events, 12+24, "should have 36 events")
 		for i, item := range events {
@@ -489,7 +495,8 @@ func TestSpendingInstructionBase_GetSpendingEventsBetween(t *testing.T) {
 			fundingInstructions,
 		)
 
-		events := spendingInstructions.GetSpendingEventsBetween(context.Background(), now, now.AddDate(1, 0, 0), timezone)
+		events, err := spendingInstructions.GetSpendingEventsBetween(context.Background(), now, now.AddDate(1, 0, 0), timezone)
+		assert.NoError(t, err, "should not return an error")
 		assert.Len(t, events, 45, "should have 45 events")
 		for i, item := range events {
 			if !assert.GreaterOrEqual(t, item.RollingAllocation, int64(0), "rolling allocation must be greater than zero: [%d] %s", i, item.Date) {
@@ -524,7 +531,8 @@ func TestSpendingInstructionBase_GetSpendingEventsBetween(t *testing.T) {
 			fundingInstructions,
 		)
 
-		events := spendingInstructions.GetSpendingEventsBetween(context.Background(), now, now.AddDate(1, 0, 0), timezone)
+		events, err := spendingInstructions.GetSpendingEventsBetween(context.Background(), now, now.AddDate(1, 0, 0), timezone)
+		assert.NoError(t, err, "should not return an error")
 		assert.Empty(t, events, "there should be no spending events for paused spending")
 	})
 
@@ -557,7 +565,8 @@ func TestSpendingInstructionBase_GetSpendingEventsBetween(t *testing.T) {
 			fundingInstructions,
 		).(*spendingInstructionBase)
 
-		result := spendingInstructions.getNextSpendingEventAfter(context.Background(), start, timezone, 0)
+		result, err := spendingInstructions.getNextSpendingEventAfter(context.Background(), start, timezone, 0)
+		assert.NoError(t, err, "should not return an error")
 		assert.Nil(t, result, "result should be nil because the goal is completed as of the start timestamp")
 	})
 
@@ -593,7 +602,8 @@ func TestSpendingInstructionBase_GetSpendingEventsBetween(t *testing.T) {
 			fundingInstructions,
 		).(*spendingInstructionBase)
 
-		events := spendingInstructions.GetNextNSpendingEventsAfter(context.Background(), 8, now, timezone)
+		events, err := spendingInstructions.GetNextNSpendingEventsAfter(context.Background(), 8, now, timezone)
+		assert.NoError(t, err, "should not return an error")
 		j, _ := json.MarshalIndent(events, "", "  ")
 		fmt.Println(string(j))
 	})


### PR DESCRIPTION
This code previously would just panic if there was a problem, which
sucked because it did handle timeouts. So if it did timeout it would
simply panic which was not helpful.

This corrects all of the interfaces such that they now properly return
an error to the caller when there is a timeout or other problem.

Resolves #1793
