### PR TITLE
Fix/1601: Scroll restoration

### DIFF
--- a/interface/src/hooks/useScrollRestoration.tsx
+++ b/interface/src/hooks/useScrollRestoration.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+
+interface ScrollPositionProviderProps {
+  children: React.ReactNode;
+}
+
+interface IScrollPositionContext {
+  saveScrollPosition: (key: string, position: number) => void;
+  getScrollPosition: (key: string) => number;
+}
+
+const ScrollPositionContext = React.createContext<
+  IScrollPositionContext | undefined
+>(undefined);
+
+function useScrollPosition(): IScrollPositionContext {
+  const context = React.useContext(ScrollPositionContext);
+  if (!context) {
+    throw new Error(
+      'useScrollPosition must be used within a ScrollPositionProvider',
+    );
+  }
+  return context;
+}
+
+export function ScrollPositionProvider({
+  children,
+}: ScrollPositionProviderProps): JSX.Element {
+  const scrollPositionsRef = React.useRef<{ [key: string]: number }>({});
+
+  const saveScrollPosition = React.useCallback(
+    (key: string, position: number) => {
+      scrollPositionsRef.current = {
+        ...scrollPositionsRef.current,
+        [key]: position,
+      };
+    },
+    [],
+  );
+
+  const getScrollPosition = React.useCallback(
+    (key: string) => scrollPositionsRef.current[key] || 0,
+    [scrollPositionsRef],
+  );
+
+  const value = React.useMemo(
+    () => ({
+      saveScrollPosition,
+      getScrollPosition,
+    }),
+    [saveScrollPosition, getScrollPosition],
+  );
+
+  return (
+    <ScrollPositionContext.Provider value={ value }>
+      {children}
+    </ScrollPositionContext.Provider>
+  );
+}
+
+/**
+ * Hook that restores the position in the current URL path.
+ * @param {React.RefObject<HTMLElement>} ref - the reference to the scrollable element
+ * @param {boolean} viewLoaded - whether the view already exists in the DOM. Useful when content is loaded dynamically.
+ */
+export function useScrollRestoration(
+  ref: React.RefObject<HTMLElement>,
+  viewLoaded: boolean,
+): void {
+  const { saveScrollPosition, getScrollPosition } = useScrollPosition();
+  const { pathname } = useLocation();
+
+  React.useEffect(() => {
+    if (ref.current) {
+      const position = getScrollPosition(pathname || '');
+      ref.current.scrollTo(0, position);
+    }
+  }, [pathname, ref, getScrollPosition]);
+
+  React.useEffect(() => {
+    function scrollHandler(): void {
+      if (ref.current) {
+        saveScrollPosition(pathname || '', ref.current.scrollTop);
+      }
+    }
+
+    const element: HTMLElement = ref.current;
+    if (element) {
+      element.addEventListener('scroll', scrollHandler);
+    }
+
+    return () => {
+      if (element) {
+        element.removeEventListener('scroll', scrollHandler);
+      }
+    };
+  }, [pathname, viewLoaded, ref, saveScrollPosition]);
+}

--- a/interface/src/monetr.tsx
+++ b/interface/src/monetr.tsx
@@ -10,6 +10,7 @@ import { useBankAccounts } from '@monetr/interface/hooks/bankAccounts';
 import { useLinks } from '@monetr/interface/hooks/links';
 import { useAppConfigurationSink } from '@monetr/interface/hooks/useAppConfiguration';
 import { useAuthenticationSink } from '@monetr/interface/hooks/useAuthentication';
+import { ScrollPositionProvider } from '@monetr/interface/hooks/useScrollRestoration';
 import Loading from '@monetr/interface/loading';
 import SubscribePage from '@monetr/interface/pages/account/subscribe';
 import AfterCheckoutPage from '@monetr/interface/pages/account/subscribe/after';
@@ -149,7 +150,9 @@ function BudgetingLayout(): JSX.Element {
     <Fragment>
       <BudgetingSidebar className='hidden lg:flex' />
       <div className='w-full h-full min-w-0 flex flex-col'>
-        <Outlet />
+        <ScrollPositionProvider>
+          <Outlet />
+        </ScrollPositionProvider>
       </div>
     </Fragment>
   );

--- a/interface/src/pages/transactions.tsx
+++ b/interface/src/pages/transactions.tsx
@@ -1,6 +1,5 @@
-import React, { Fragment, useCallback, useEffect, useRef } from 'react';
+import React, { Fragment, useRef } from 'react';
 import useInfiniteScroll from 'react-infinite-scroll-hook';
-import { useNavigationType } from 'react-router-dom';
 import { HeartBroken, ShoppingCartOutlined, UploadOutlined } from '@mui/icons-material';
 import { format, getUnixTime, parse } from 'date-fns';
 import * as R from 'ramda';
@@ -10,13 +9,13 @@ import MSpan from '@monetr/interface/components/MSpan';
 import MTopNavigation from '@monetr/interface/components/MTopNavigation';
 import { useCurrentLink } from '@monetr/interface/hooks/links';
 import { useTransactions } from '@monetr/interface/hooks/transactions';
+import { useAppConfigurationSink } from '@monetr/interface/hooks/useAppConfiguration';
+import { useScrollRestoration } from '@monetr/interface/hooks/useScrollRestoration';
 import { showUploadTransactionsModal } from '@monetr/interface/modals/UploadTransactions/UploadTransactionsModal';
 import Transaction from '@monetr/interface/models/Transaction';
 import TransactionDateItem from '@monetr/interface/pages/new/TransactionDateItem';
 import TransactionItem from '@monetr/interface/pages/new/TransactionItem';
-import { useAppConfigurationSink } from '@monetr/interface/hooks/useAppConfiguration';
 
-let evilScrollPosition: number = 0;
 
 export default function Transactions(): JSX.Element {
   const { result: config } = useAppConfigurationSink();
@@ -29,31 +28,10 @@ export default function Transactions(): JSX.Element {
   } = useTransactions();
 
   const { data: link } = useCurrentLink();
-
-  // Scroll restoration code.
-  const ref = useRef<HTMLUListElement>(null);
-  const navigationType = useNavigationType();
-  const onScroll = useCallback(() => {
-    evilScrollPosition = ref.current.scrollTop;
-  }, [ref]);
-  useEffect(() => {
-    if (!ref.current) {
-      return undefined;
-    }
-
-    if (navigationType === 'POP') {
-      ref.current.scrollTop = evilScrollPosition;
-    }
-    const current = ref.current;
-    ref.current.addEventListener('scroll', onScroll);
-    return () => {
-      current.removeEventListener('scroll', onScroll);
-    };
-  // Fix bug with current impl.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ref.current, navigationType, onScroll]);
-
   const loading = isLoading || isFetching;
+
+  const ref = useRef<HTMLUListElement>(null);
+  useScrollRestoration(ref, !loading);
 
   const [sentryRef] = useInfiniteScroll({
     loading,


### PR DESCRIPTION
This adds a reusable hook to restore positioning in any route with an scrollable element.
The scroll positioning will be restored regardless of the navigation type.

An enhancement could be implemented for the following scenario:
Say we have route `foo/bar`, if it accessed through a POP navigation type, then scroll is restored
to the the last positioning. Otherwise, if navigation type is PUSH, then scroll is restored to zero (top).

Let me know your thoughts.