### PR TITLE
feat(api): Adding support for transaction attachments

### DIFF
--- a/server/controller/file_helpers.go
+++ b/server/controller/file_helpers.go
@@ -42,6 +42,14 @@ func (c *Controller) consumeFileUpload(ctx echo.Context, kind Uploadable) (*File
 		case ".qfx", ".ofx":
 			log.Debug("detected QFX/OFX file format")
 			contentType = string(storage.IntuitQFXContentType)
+		case ".pdf":
+			contentType = "application/pdf"
+		case ".png":
+			contentType = "image/png"
+		case ".jpeg", ".jpg":
+			contentType = "image/jpeg"
+		case ".heic", ".heif": // Apple's image format.
+			contentType = "image/heif"
 		default:
 			log.Warn("could not determine file format by file extension")
 		}
@@ -79,7 +87,8 @@ func (c *Controller) consumeFileUpload(ctx echo.Context, kind Uploadable) (*File
 		ContentType: contentType,
 		Size:        uint64(header.Size),
 		BlobUri:     fileUri,
-		ExpiresAt:   kind.FileExpiration(c.clock),
+		// May be nil, if it is nil then it never expires.
+		ExpiresAt: kind.FileExpiration(c.clock),
 	}
 
 	if err := repo.CreateFile(c.getContext(ctx), &file); err != nil {

--- a/server/controller/transaction_attachments.go
+++ b/server/controller/transaction_attachments.go
@@ -1,0 +1,35 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	. "github.com/monetr/monetr/server/models"
+)
+
+func (c *Controller) postTransactionAttachment(ctx echo.Context) error {
+	bankAccountId, err := ParseID[BankAccount](ctx.Param("bankAccountId"))
+	if err != nil || bankAccountId.IsZero() {
+		return c.badRequest(ctx, "must specify a valid bank account Id")
+	}
+
+	transactionId, err := ParseID[Transaction](ctx.Param("transactionId"))
+	if err != nil || transactionId.IsZero() {
+		return c.badRequest(ctx, "must specify a valid transaction Id")
+	}
+
+	attachment := TransactionAttachment{
+		BankAccountId: bankAccountId,
+		TransactionId: transactionId,
+	}
+
+	// Take the body and upload it as a file
+	file, err := c.consumeFileUpload(ctx, attachment)
+	if err != nil {
+		return err
+	}
+	attachment.FileId = file.FileId
+	attachment.File = file
+
+	return ctx.JSON(http.StatusOK, attachment)
+}

--- a/server/models/transaction_attachment.go
+++ b/server/models/transaction_attachment.go
@@ -1,0 +1,60 @@
+package models
+
+import (
+	"context"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/go-pg/pg/v10"
+)
+
+var (
+	_ pg.BeforeInsertHook = (*TransactionAttachment)(nil)
+	_ Identifiable        = TransactionAttachment{}
+	_ Uploadable          = TransactionAttachment{}
+)
+
+type TransactionAttachment struct {
+	tableName string `pg:"transaction_attachments"`
+
+	TransactionAttachmentId ID[TransactionAttachment] `json:"transactionAttachmentId" pg:"transaction_attachment_id,notnull,pk"`
+	AccountId               ID[Account]               `json:"-" pg:"account_id,notnull,pk"`
+	Account                 *Account                  `json:"-" pg:"rel:has-one"`
+	BankAccountId           ID[BankAccount]           `json:"bankAccountId" pg:"bank_account_id,notnull"`
+	BankAccount             *BankAccount              `json:"-" pg:"rel:has-one"`
+	TransactionId           ID[Transaction]           `json:"transactionId" pg:"transaction_id,notnull"`
+	Transaction             *Transaction              `json:"-" pg:"rel:has-one"`
+	FileId                  ID[File]                  `json:"fileId" pg:"file_id,notnull"`
+	File                    *File                     `json:"file,omitempty" pg:"rel:has-one"`
+	CreatedAt               time.Time                 `json:"createdAt" pg:"created_at,notnull"`
+	CreatedBy               ID[User]                  `json:"createdBy" pg:"created_by,notnull"`
+	CreatedByUser           *User                     `json:"-" pg:"rel:has-one,fk:created_by"`
+}
+
+func (TransactionAttachment) FileKind() string {
+	return "transactions/atttachments"
+}
+
+// TransactionAttachment files do not expire.
+func (TransactionAttachment) FileExpiration(clock clock.Clock) *time.Time {
+	expiration := clock.Now().Add(1 * time.Hour)
+	return &expiration
+}
+
+func (TransactionAttachment) IdentityPrefix() string {
+	return "txat"
+}
+
+// BeforeInsert implements orm.BeforeInsertHook.
+func (o *TransactionAttachment) BeforeInsert(ctx context.Context) (context.Context, error) {
+	if o.TransactionAttachmentId.IsZero() {
+		o.TransactionAttachmentId = NewID(o)
+	}
+
+	now := time.Now()
+	if o.CreatedAt.IsZero() {
+		o.CreatedAt = now
+	}
+
+	return ctx, nil
+}

--- a/server/models/transaction_uploads.go
+++ b/server/models/transaction_uploads.go
@@ -20,6 +20,7 @@ const (
 var (
 	_ pg.BeforeInsertHook = (*TransactionUpload)(nil)
 	_ Identifiable        = TransactionUpload{}
+	_ Uploadable          = TransactionUpload{}
 )
 
 type TransactionUpload struct {

--- a/server/storage/storage.go
+++ b/server/storage/storage.go
@@ -73,21 +73,31 @@ const (
 	TextCSVContentType      ContentType = "text/csv"
 	OpenXMLExcelContentType ContentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 	IntuitQFXContentType    ContentType = "application/vnd.intu.QFX"
+	PDFContentType          ContentType = "application/pdf"
+	PNGImageContentType     ContentType = "image/png"
+	JPEGImageContentType    ContentType = "image/jpeg"
+	AppleImageContentType   ContentType = "image/heic"
 )
 
 var (
-	contentTypeExtensions = map[ContentType]string{
-		TextCSVContentType:      "csv",
-		OpenXMLExcelContentType: "xlsx",
-		IntuitQFXContentType:    "qfx",
+	contentTypeExtensions = map[ContentType][]string{
+		TextCSVContentType:      {"csv"},
+		OpenXMLExcelContentType: {"xlsx"},
+		IntuitQFXContentType:    {"qfx", "ofx"},
+		PDFContentType:          {"pdf"},
+		PNGImageContentType:     {"png"},
+		JPEGImageContentType:    {"jpeg", "jpg"},
+		AppleImageContentType:   {"heic", "heif"},
 	}
 )
 
 func getContentTypeByPath(filePath string) (ContentType, error) {
 	extension := strings.TrimPrefix(path.Ext(filePath), ".")
-	for contentType, ext := range contentTypeExtensions {
-		if ext == extension {
-			return contentType, nil
+	for contentType, extensions := range contentTypeExtensions {
+		for _, ext := range extensions {
+			if ext == extension {
+				return contentType, nil
+			}
 		}
 	}
 


### PR DESCRIPTION
This adds support for users to attach various files to a transaction,
including things like images and PDFs.
