### PR TITLE
fix(ui): Fixing uncontrolled path bug in UI router

### DIFF
--- a/server/internal/testutils/http.go
+++ b/server/internal/testutils/http.go
@@ -1,0 +1,51 @@
+package testutils
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+type DebugPrinter struct {
+	logger *logrus.Entry
+	body   bool
+}
+
+// NewDebugPrinter returns a new DebugPrinter given a logger and body
+// flag. If body is true, request and response body is also printed.
+func NewDebugPrinter(logger *logrus.Entry, body bool) DebugPrinter {
+	return DebugPrinter{logger, body}
+}
+
+// Request implements Printer.Request.
+func (p DebugPrinter) Request(req *http.Request) {
+	if req == nil {
+		return
+	}
+
+	dump, err := httputil.DumpRequest(req, p.body)
+	if err != nil {
+		panic(err)
+	}
+	p.logger.Debug("Logging Request\n" + string(dump) + "\n\t")
+}
+
+// Response implements Printer.Response.
+func (p DebugPrinter) Response(resp *http.Response, duration time.Duration) {
+	if resp == nil {
+		return
+	}
+
+	dump, err := httputil.DumpResponse(resp, p.body)
+	if err != nil {
+		panic(err)
+	}
+
+	text := strings.ReplaceAll(string(dump), "\r\n", "\n")
+	lines := strings.SplitN(text, "\n", 2)
+
+	p.logger.Debugf("Logging Response\n%s %s\n%s\t", lines[0], duration, lines[1])
+}

--- a/server/ui/routes.go
+++ b/server/ui/routes.go
@@ -70,6 +70,12 @@ func (c *UIController) RegisterRoutes(app *echo.Echo) {
 		}(ctx)
 		requestedPath := ctx.Request().URL.Path
 
+		// Even though we are using an embedded filesystem for the UI, we still want
+		// to make sure we do not use relative paths.
+		if !path.IsAbs(requestedPath) {
+			return ctx.NoContent(http.StatusNotFound)
+		}
+
 		// If they request `/index.html` simply redirect them to `/`.
 		if requestedPath == indexFile {
 			url := ctx.Request().URL.String()

--- a/server/ui/routes.go
+++ b/server/ui/routes.go
@@ -68,7 +68,7 @@ func (c *UIController) RegisterRoutes(app *echo.Echo) {
 				_ = ctx.String(http.StatusInternalServerError, "Something went very wrong!")
 			}
 		}(ctx)
-		requestedPath := ctx.Request().URL.Path
+		requestedPath := path.Clean(ctx.Request().URL.Path)
 
 		// Even though we are using an embedded filesystem for the UI, we still want
 		// to make sure we do not use relative paths.


### PR DESCRIPTION
Github's security thing is complaining about using a raw path from the
user's input to load files. But there really is no risk because the
filesystem that the UI is loaded from is embeded and is basically
sandboxed. There are no extra files that could possibly be requested
maliciously.

But I'm going to try to improve it anyway to keep the alert from comming
up again and again.
