### PR TITLE
feat(api): Correctly mark accounts as inactive via Plaid.

### DIFF
--- a/server/background/jobs.go
+++ b/server/background/jobs.go
@@ -82,6 +82,7 @@ func NewBackgroundJobs(
 		NewProcessSpendingHandler(log, db, clock),
 		NewRemoveFileHandler(log, db, clock, fileStorage),
 		NewRemoveLinkHandler(log, db, clock, publisher),
+		NewSyncPlaidAccountsHandler(log, db, clock, kms, plaidPlatypus),
 		NewSyncPlaidHandler(log, db, clock, kms, plaidPlatypus, publisher, enqueuer),
 	}
 

--- a/server/background/sync_plaid_accounts.go
+++ b/server/background/sync_plaid_accounts.go
@@ -1,0 +1,192 @@
+package background
+
+import (
+	"context"
+
+	"github.com/benbjohnson/clock"
+	"github.com/getsentry/sentry-go"
+	"github.com/go-pg/pg/v10"
+	"github.com/monetr/monetr/server/crumbs"
+	. "github.com/monetr/monetr/server/models"
+	"github.com/monetr/monetr/server/platypus"
+	"github.com/monetr/monetr/server/repository"
+	"github.com/monetr/monetr/server/secrets"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	SyncPlaidAccounts = "SyncPlaidAccounts"
+)
+
+type (
+	SyncPlaidAccountsHandler struct {
+		log           *logrus.Entry
+		db            *pg.DB
+		kms           secrets.KeyManagement
+		plaidPlatypus platypus.Platypus
+		unmarshaller  JobUnmarshaller
+		clock         clock.Clock
+	}
+
+	SyncPlaidAccountsArguments struct {
+		AccountId ID[Account] `json:"accountId"`
+		LinkId    ID[Link]    `json:"linkId"`
+	}
+
+	SyncPlaidAccountsJob struct {
+		args          SyncPlaidAccountsArguments
+		log           *logrus.Entry
+		repo          repository.BaseRepository
+		secrets       repository.SecretsRepository
+		plaidPlatypus platypus.Platypus
+		clock         clock.Clock
+	}
+)
+
+func TriggerSyncPlaidAccounts(
+	ctx context.Context,
+	backgroundJobs JobController,
+	arguments SyncPlaidAccountsArguments,
+) error {
+	return backgroundJobs.EnqueueJob(ctx, SyncPlaidAccounts, arguments)
+}
+
+func NewSyncPlaidAccountsHandler(
+	log *logrus.Entry,
+	db *pg.DB,
+	clock clock.Clock,
+	kms secrets.KeyManagement,
+	plaidPlatypus platypus.Platypus,
+) *SyncPlaidAccountsHandler {
+	return &SyncPlaidAccountsHandler{
+		log:           log,
+		db:            db,
+		kms:           kms,
+		plaidPlatypus: plaidPlatypus,
+		unmarshaller:  DefaultJobUnmarshaller,
+		clock:         clock,
+	}
+}
+
+func (s SyncPlaidAccountsHandler) QueueName() string {
+	return SyncPlaidAccounts
+}
+
+func (s *SyncPlaidAccountsJob) Run(ctx context.Context) error {
+	span := sentry.StartSpan(ctx, "job.exec")
+	defer span.Finish()
+	crumbs.AddTag(span.Context(), "accountId", s.args.AccountId.String())
+	crumbs.AddTag(span.Context(), "linkId", s.args.LinkId.String())
+
+	log := s.log.WithContext(span.Context()).WithFields(logrus.Fields{
+		"accountId": s.args.AccountId,
+		"linkId":    s.args.LinkId,
+	})
+
+	link, err := s.repo.GetLink(span.Context(), s.args.LinkId)
+	if err = errors.Wrap(err, "failed to retrieve link to sync with plaid"); err != nil {
+		log.WithError(err).Error("cannot sync without link")
+		return err
+	}
+
+	if link.PlaidLink == nil {
+		log.Warn("provided link does not have any plaid credentials")
+		crumbs.IndicateBug(
+			span.Context(),
+			"BUG: Link was queued to sync with plaid, but has no plaid details",
+			map[string]interface{}{
+				"link": link,
+			},
+		)
+		span.Status = sentry.SpanStatusFailedPrecondition
+		return nil
+	}
+
+	log = log.WithFields(logrus.Fields{
+		"plaidLinkId": link.PlaidLink.PlaidLinkId,
+		"plaid": logrus.Fields{
+			"institutionId":   link.PlaidLink.InstitutionId,
+			"institutionName": link.PlaidLink.InstitutionName,
+			"itemId":          link.PlaidLink.PlaidId,
+		},
+	})
+
+	// This way other methods will have these log fields too.
+	s.log = log
+
+	plaidLink := link.PlaidLink
+
+	bankAccounts, err := s.repo.GetBankAccountsWithPlaidByLinkId(
+		span.Context(),
+		link.LinkId,
+	)
+	if err = errors.Wrap(err, "failed to read bank accounts for plaid sync"); err != nil {
+		log.WithError(err).Error("cannot sync without bank accounts")
+		return err
+	}
+	crumbs.IncludePlaidItemIDTag(span, link.PlaidLink.PlaidId)
+	crumbs.AddTag(span.Context(), "plaid.institution_id", link.PlaidLink.InstitutionId)
+	crumbs.AddTag(span.Context(), "plaid.institution_name", link.PlaidLink.InstitutionName)
+
+	if len(bankAccounts) == 0 {
+		log.Warn("no bank accounts for plaid link")
+		crumbs.Debug(span.Context(), "No bank accounts setup for plaid link", nil)
+		return nil
+	}
+
+	secret, err := s.secrets.Read(span.Context(), plaidLink.SecretId)
+	if err = errors.Wrap(err, "failed to retrieve access token for plaid link"); err != nil {
+		log.WithError(err).Error("could not retrieve API credentials for Plaid for link, this job will be retried")
+		return err
+	}
+
+	plaidClient, err := s.plaidPlatypus.NewClient(
+		span.Context(),
+		link,
+		secret.Value,
+		plaidLink.PlaidId,
+	)
+	if err != nil {
+		log.WithError(err).Error("failed to create plaid client for link")
+		return err
+	}
+
+	plaidBankAccounts, err := plaidClient.GetAccounts(span.Context())
+	if err != nil {
+		log.WithError(err).Error("failed to retrieve bank accounts from plaid")
+		return err
+	}
+
+	{ // Handle missing or inactive accounts
+		missingAccounts := map[ID[BankAccount]]*BankAccount{}
+	MissingAccounts:
+		for x := range bankAccounts {
+			bankAccount := bankAccounts[x]
+			for y := range plaidBankAccounts {
+				plaidBankAccount := plaidBankAccounts[y]
+				if plaidBankAccount.GetAccountId() == bankAccount.PlaidBankAccount.PlaidId {
+					log.WithFields(logrus.Fields{
+						"bankAccountId": bankAccount.BankAccountId,
+					}).Debug("bank account is still present in plaid and is considered active")
+					// TODO Check bank account status here too, if the status is inactive
+					// but we see the account again then that means it is active again.
+					continue MissingAccounts
+				}
+			}
+
+			if bankAccount.Status == InactiveBankAccountStatus {
+				// Bank account is already considered missing, skip it.
+				continue
+			}
+
+			log.WithFields(logrus.Fields{
+				"bankAccountId":       bankAccount.BankAccountId,
+				"plaid_bankAccountId": bankAccount.PlaidBankAccount.PlaidId,
+			}).Info("bank account is no longer present in plaid and is considered inactive")
+			missingAccounts[bankAccount.BankAccountId] = &bankAccount
+		}
+	}
+
+	return nil
+}

--- a/server/background/sync_plaid_accounts_test.go
+++ b/server/background/sync_plaid_accounts_test.go
@@ -3,6 +3,7 @@ package background_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/benbjohnson/clock"
 	"github.com/monetr/monetr/server/background"
@@ -15,9 +16,21 @@ import (
 	"github.com/monetr/monetr/server/repository"
 	"github.com/monetr/monetr/server/secrets"
 	"github.com/plaid/plaid-go/v26/plaid"
+	"github.com/robfig/cron"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
+
+func TestSyncPlaidAccountsHandler_DefaultSchedule(t *testing.T) {
+	t.Run("validate cron schedule", func(t *testing.T) {
+		handler := &background.SyncPlaidAccountsHandler{}
+		schedule, err := cron.Parse(handler.DefaultSchedule())
+		assert.NoError(t, err, "must be able too parse the schedule")
+		now := time.Now()
+		next := schedule.Next(now)
+		assert.GreaterOrEqual(t, next, now, "next cron should always be greater or equal than now")
+	})
+}
 
 func TestSyncPlaidAccountsHandler_EnqueueTriggeredJob(t *testing.T) {
 	t.Run("will sync accounts who have never been synced", func(t *testing.T) {

--- a/server/background/sync_plaid_accounts_test.go
+++ b/server/background/sync_plaid_accounts_test.go
@@ -1,0 +1,121 @@
+package background_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/benbjohnson/clock"
+	"github.com/monetr/monetr/server/background"
+	"github.com/monetr/monetr/server/internal/fixtures"
+	"github.com/monetr/monetr/server/internal/mockgen"
+	"github.com/monetr/monetr/server/internal/myownsanity"
+	"github.com/monetr/monetr/server/internal/testutils"
+	"github.com/monetr/monetr/server/models"
+	"github.com/monetr/monetr/server/secrets"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestSyncPlaidAccountsHandler_EnqueueTriggeredJob(t *testing.T) {
+	t.Run("will sync accounts who have never been synced", func(t *testing.T) {
+		clock := clock.NewMock()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		log := testutils.GetLog(t)
+		db := testutils.GetPgDatabase(t, testutils.IsolatedDatabase)
+		kms := secrets.NewPlaintextKMS()
+
+		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
+		plaidLink := fixtures.GivenIHaveAPlaidLink(t, clock, user)
+		fixtures.GivenIHaveAPlaidBankAccount(
+			t,
+			clock,
+			&plaidLink,
+			models.DepositoryBankAccountType,
+			models.CheckingBankAccountSubType,
+		)
+
+		plaidPlatypus := mockgen.NewMockPlatypus(ctrl)
+		enqueuer := mockgen.NewMockJobEnqueuer(ctrl)
+
+		// Make sure that we trigger a sync job for the link that hasn't been
+		// updated before.
+		enqueuer.EXPECT().
+			EnqueueJob(
+				gomock.Any(),
+				gomock.Eq(background.SyncPlaidAccounts),
+				testutils.NewGenericMatcher(func(args background.SyncPlaidAccountsArguments) bool {
+					return assert.EqualValues(t, plaidLink.LinkId, args.LinkId) &&
+						assert.EqualValues(t, plaidLink.AccountId, args.AccountId)
+				}),
+			).
+			Times(1).
+			Return(nil)
+
+		handler := background.NewSyncPlaidAccountsHandler(
+			log,
+			db,
+			clock,
+			kms,
+			plaidPlatypus,
+		)
+
+		err := handler.EnqueueTriggeredJob(context.Background(), enqueuer)
+		assert.NoError(t, err, "should not return an error")
+	})
+
+	t.Run("will not sync accounts that have been synced", func(t *testing.T) {
+		clock := clock.NewMock()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		log := testutils.GetLog(t)
+		db := testutils.GetPgDatabase(t, testutils.IsolatedDatabase)
+		kms := secrets.NewPlaintextKMS()
+
+		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
+		plaidLink := fixtures.GivenIHaveAPlaidLink(t, clock, user)
+		fixtures.GivenIHaveAPlaidBankAccount(
+			t,
+			clock,
+			&plaidLink,
+			models.DepositoryBankAccountType,
+			models.CheckingBankAccountSubType,
+		)
+
+		{ // Set a timestamp on the last account sync and store it.
+			plaidLink.PlaidLink.LastAccountSync = myownsanity.TimeP(clock.Now())
+			testutils.MustDBUpdate(t, plaidLink.PlaidLink)
+		}
+
+		plaidPlatypus := mockgen.NewMockPlatypus(ctrl)
+		enqueuer := mockgen.NewMockJobEnqueuer(ctrl)
+
+		// Make sure that we trigger a sync job for the link that hasn't been
+		// updated before.
+		enqueuer.EXPECT().
+			EnqueueJob(
+				gomock.Any(),
+				gomock.Eq(background.SyncPlaidAccounts),
+				testutils.NewGenericMatcher(func(args background.SyncPlaidAccountsArguments) bool {
+					return assert.EqualValues(t, plaidLink.LinkId, args.LinkId) &&
+						assert.EqualValues(t, plaidLink.AccountId, args.AccountId)
+				}),
+			).
+			Times(0).
+			Return(nil)
+
+		handler := background.NewSyncPlaidAccountsHandler(
+			log,
+			db,
+			clock,
+			kms,
+			plaidPlatypus,
+		)
+
+		err := handler.EnqueueTriggeredJob(context.Background(), enqueuer)
+		assert.NoError(t, err, "should not return an error")
+	})
+}
+

--- a/server/background/sync_plaid_accounts_test.go
+++ b/server/background/sync_plaid_accounts_test.go
@@ -11,7 +11,10 @@ import (
 	"github.com/monetr/monetr/server/internal/myownsanity"
 	"github.com/monetr/monetr/server/internal/testutils"
 	"github.com/monetr/monetr/server/models"
+	"github.com/monetr/monetr/server/platypus"
+	"github.com/monetr/monetr/server/repository"
 	"github.com/monetr/monetr/server/secrets"
+	"github.com/plaid/plaid-go/v26/plaid"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -119,3 +122,190 @@ func TestSyncPlaidAccountsHandler_EnqueueTriggeredJob(t *testing.T) {
 	})
 }
 
+func TestSyncPlaidAccountsJob_Run(t *testing.T) {
+	t.Run("deactivate an account", func(t *testing.T) {
+		clock := clock.NewMock()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		log := testutils.GetLog(t)
+		db := testutils.GetPgDatabase(t, testutils.IsolatedDatabase)
+		kms := secrets.NewPlaintextKMS()
+
+		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
+		plaidLink := fixtures.GivenIHaveAPlaidLink(t, clock, user)
+		checkingAccount := fixtures.GivenIHaveAPlaidBankAccount(
+			t,
+			clock,
+			&plaidLink,
+			models.DepositoryBankAccountType,
+			models.CheckingBankAccountSubType,
+		)
+
+		savingsAccount := fixtures.GivenIHaveAPlaidBankAccount(
+			t,
+			clock,
+			&plaidLink,
+			models.DepositoryBankAccountType,
+			models.SavingsBankAccountSubType,
+		)
+
+		plaidPlatypus := mockgen.NewMockPlatypus(ctrl)
+		plaidClient := mockgen.NewMockClient(ctrl)
+
+		plaidPlatypus.EXPECT().
+			NewClient(
+				gomock.Any(),
+				gomock.AssignableToTypeOf(new(models.Link)),
+				gomock.Any(),
+				gomock.Eq(plaidLink.PlaidLink.PlaidId),
+			).
+			Return(plaidClient, nil).
+			AnyTimes()
+
+		plaidClient.EXPECT().
+			GetAccounts(
+				gomock.Any(),
+				gomock.Len(0), // No account IDs should be passed
+			).
+			Return(
+				[]platypus.BankAccount{
+					// Since we only return the checking account, the savings account should
+					// get deactivated.
+					testutils.Must(t, platypus.NewPlaidBankAccount, plaid.AccountBase{
+						AccountId: checkingAccount.PlaidBankAccount.PlaidId,
+					}),
+				},
+				nil,
+			).
+			Times(1)
+
+		job, err := background.NewSyncPlaidAccountsJob(
+			log,
+			repository.NewRepositoryFromSession(clock, "user_system", user.AccountId, db),
+			clock,
+			repository.NewSecretsRepository(log, clock, db, kms, user.AccountId),
+			plaidPlatypus,
+			background.SyncPlaidAccountsArguments{
+				AccountId: user.AccountId,
+				LinkId:    plaidLink.LinkId,
+			},
+		)
+		assert.NoError(t, err)
+		assert.NotNil(t, job)
+
+		{ // Checking account and savings account should be active before the job
+			checkingAccountBefore := testutils.MustRetrieve(t, checkingAccount)
+			assert.Equal(t, checkingAccountBefore.Status, models.ActiveBankAccountStatus)
+			savingsAccountBefore := testutils.MustRetrieve(t, savingsAccount)
+			assert.Equal(t, savingsAccountBefore.Status, models.ActiveBankAccountStatus)
+		}
+
+		// Then we run the job
+		err = job.Run(context.Background())
+		assert.NoError(t, err)
+
+		{ // Now the checking is active but the savings is inactive
+			checkingAccountBefore := testutils.MustRetrieve(t, checkingAccount)
+			assert.Equal(t, checkingAccountBefore.Status, models.ActiveBankAccountStatus)
+			savingsAccountBefore := testutils.MustRetrieve(t, savingsAccount)
+			assert.Equal(t, savingsAccountBefore.Status, models.InactiveBankAccountStatus)
+		}
+	})
+
+	t.Run("should reactivate an account", func(t *testing.T) {
+		clock := clock.NewMock()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		log := testutils.GetLog(t)
+		db := testutils.GetPgDatabase(t, testutils.IsolatedDatabase)
+		kms := secrets.NewPlaintextKMS()
+
+		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
+		plaidLink := fixtures.GivenIHaveAPlaidLink(t, clock, user)
+		checkingAccount := fixtures.GivenIHaveAPlaidBankAccount(
+			t,
+			clock,
+			&plaidLink,
+			models.DepositoryBankAccountType,
+			models.CheckingBankAccountSubType,
+		)
+
+		savingsAccount := fixtures.GivenIHaveAPlaidBankAccount(
+			t,
+			clock,
+			&plaidLink,
+			models.DepositoryBankAccountType,
+			models.SavingsBankAccountSubType,
+		)
+
+		{ // Update the savings account to have an inactive status.
+			savingsAccount.Status = models.InactiveBankAccountStatus
+			testutils.MustDBUpdate(t, &savingsAccount)
+		}
+
+		plaidPlatypus := mockgen.NewMockPlatypus(ctrl)
+		plaidClient := mockgen.NewMockClient(ctrl)
+
+		plaidPlatypus.EXPECT().
+			NewClient(
+				gomock.Any(),
+				gomock.AssignableToTypeOf(new(models.Link)),
+				gomock.Any(),
+				gomock.Eq(plaidLink.PlaidLink.PlaidId),
+			).
+			Return(plaidClient, nil).
+			AnyTimes()
+
+		plaidClient.EXPECT().
+			GetAccounts(
+				gomock.Any(),
+				gomock.Len(0), // No account IDs should be passed
+			).
+			Return(
+				[]platypus.BankAccount{
+					testutils.Must(t, platypus.NewPlaidBankAccount, plaid.AccountBase{
+						AccountId: checkingAccount.PlaidBankAccount.PlaidId,
+					}),
+					testutils.Must(t, platypus.NewPlaidBankAccount, plaid.AccountBase{
+						AccountId: savingsAccount.PlaidBankAccount.PlaidId,
+					}),
+				},
+				nil,
+			).
+			Times(1)
+
+		job, err := background.NewSyncPlaidAccountsJob(
+			log,
+			repository.NewRepositoryFromSession(clock, "user_system", user.AccountId, db),
+			clock,
+			repository.NewSecretsRepository(log, clock, db, kms, user.AccountId),
+			plaidPlatypus,
+			background.SyncPlaidAccountsArguments{
+				AccountId: user.AccountId,
+				LinkId:    plaidLink.LinkId,
+			},
+		)
+		assert.NoError(t, err)
+		assert.NotNil(t, job)
+
+		{ // Only checking should be active befre the job runs
+			checkingAccountBefore := testutils.MustRetrieve(t, checkingAccount)
+			assert.Equal(t, checkingAccountBefore.Status, models.ActiveBankAccountStatus)
+			savingsAccountBefore := testutils.MustRetrieve(t, savingsAccount)
+			assert.Equal(t, savingsAccountBefore.Status, models.InactiveBankAccountStatus)
+		}
+
+		// Then we run the job
+		err = job.Run(context.Background())
+		assert.NoError(t, err)
+
+		{ // Now both accounts should be active
+			checkingAccountBefore := testutils.MustRetrieve(t, checkingAccount)
+			assert.Equal(t, checkingAccountBefore.Status, models.ActiveBankAccountStatus)
+			savingsAccountBefore := testutils.MustRetrieve(t, savingsAccount)
+			assert.Equal(t, savingsAccountBefore.Status, models.ActiveBankAccountStatus)
+		}
+	})
+}

--- a/server/migrations/schema/2024100700_PlaidAccountSync.tx.up.sql
+++ b/server/migrations/schema/2024100700_PlaidAccountSync.tx.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "plaid_links" ADD COLUMN "last_account_sync" TIMESTAMP WITH TIME ZONE;

--- a/server/models/plaid_link.go
+++ b/server/models/plaid_link.go
@@ -39,6 +39,7 @@ type PlaidLink struct {
 	LastManualSync       *time.Time      `json:"lastManualSync" pg:"last_manual_sync"`
 	LastSuccessfulUpdate *time.Time      `json:"lastSuccessfulUpdate" pg:"last_successful_update"`
 	LastAttemptedUpdate  *time.Time      `json:"lastAttemptedUpdate" pg:"last_attempted_update"`
+	LastAccountSync      *time.Time      `json:"lastAccountSync" pg:"last_account_sync"`
 	UpdatedAt            time.Time       `json:"updatedAt" pg:"updated_at,notnull"`
 	CreatedAt            time.Time       `json:"createdAt" pg:"created_at,notnull"`
 	CreatedBy            ID[User]        `json:"createdBy" pg:"created_by,notnull"`

--- a/server/platypus/client.go
+++ b/server/platypus/client.go
@@ -80,22 +80,23 @@ func (p *PlaidClient) GetAccounts(ctx context.Context, accountIds ...string) ([]
 		"accountIds": "ALL_BANK_ACCOUNTS",
 	}
 
+	log.Trace("retrieving bank accounts from plaid")
+
+	var options *plaid.AccountsGetRequestOptions
 	// If however we are requesting specific accounts, overwrite the value.
 	if len(accountIds) > 0 {
 		span.Data["accountIds"] = accountIds
+		options = &plaid.AccountsGetRequestOptions{
+			AccountIds: &accountIds,
+		}
 	}
-
-	log.Trace("retrieving bank accounts from plaid")
 
 	// Build the get accounts request.
 	request := p.client.PlaidApi.
 		AccountsGet(span.Context()).
 		AccountsGetRequest(plaid.AccountsGetRequest{
 			AccessToken: p.accessToken,
-			Options: &plaid.AccountsGetRequestOptions{
-				// This might not work, if it does not we should just add a nil check somehow here.
-				AccountIds: &accountIds,
-			},
+			Options:     options,
 		})
 
 	// Send the request.


### PR DESCRIPTION
Periodically sync bank accounts to find out which ones are no longer
active in Plaid.

Resolves #1830
