### PR TITLE
feat(dev): Adding local development "lite" environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,9 @@ test:
 develop: | $(CMAKE_CONFIGURATION_DIRECTORY)
 	cmake --build $(CMAKE_CONFIGURATION_DIRECTORY) -t development.monetr.up $(BUILD_ARGS)
 
+develop-lite: | $(CMAKE_CONFIGURATION_DIRECTORY)
+	cmake --build $(CMAKE_CONFIGURATION_DIRECTORY) -t development.lite $(BUILD_ARGS)
+
 develop-docs: | $(CMAKE_CONFIGURATION_DIRECTORY)
 	cmake --build $(CMAKE_CONFIGURATION_DIRECTORY) -t development.documentation.up $(BUILD_ARGS)
 

--- a/compose/docker-compose.monetr.yaml.in
+++ b/compose/docker-compose.monetr.yaml.in
@@ -57,7 +57,7 @@ services:
     working_dir: /build
     restart: always
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:30000" ]
+      test: [ "CMD", "curl", "-f", "http://localhost:3000" ]
       interval: 10s
       timeout: 10s
       retries: 12

--- a/compose/nginx-cloud.conf
+++ b/compose/nginx-cloud.conf
@@ -10,7 +10,7 @@ http {
     }
 
     upstream docker-ui {
-        server ui:30000;
+        server ui:3000;
     }
 
     upstream docker-mail {

--- a/compose/nginx.conf
+++ b/compose/nginx.conf
@@ -10,7 +10,7 @@ http {
     }
 
     upstream docker-ui {
-        server ui:30000;
+        server ui:3000;
     }
 
     upstream docker-mail {

--- a/docs/src/pages/documentation/development/local_development.mdx
+++ b/docs/src/pages/documentation/development/local_development.mdx
@@ -123,6 +123,7 @@ Here is a sample of a user presets file with a few customized options:
         "MONETR_EMAIL_VERIFICATION_ENABLED": "true",
         "MONETR_KMS_PROVIDER": "vault",
         "MONETR_STORAGE_PROVIDER": "s3",
+        "MONETR_DEVELOPMENT_LITE_TARGET": "my.monetr.dev",
         "DISABLE_GO_RELOAD": "false"
       }
     }
@@ -146,6 +147,8 @@ This config specifically changes the following options:
 - `MONETR_STORAGE_PROVIDER`: A minio instance will be run as part of the local development stack. Valid values are `s3`
   or `filesystem`. When using `filesystem` uploaded files will be stored in your `$PWD/build/development/storage`
   folder.
+- `MONETR_DEVELOPMENT_LITE_TARGET`: When working on monetr's frontend only, specify an API server that you want to use
+  for the frontend to talk to. Requires an account on that API server.
 
 There are other options here that will be documented later, as well as other options that have not been covered here at
 all, but those options are the primary ones that change the local development stack the most.
@@ -279,6 +282,32 @@ make storybook
 ```
 
 This will output the storybook assets in `$PWD/build/stories/dist`
+
+### Frontend
+
+An alternative to running storybook to work on only the frontend components of monetr is to run a "lite" development
+environment. The lite environment only runs the frontend dev server and instead of requiring an active API server and
+additional services to be running locally, you can instead point the frontend at a desired API server.
+
+To start the "lite" development environment run the following command:
+
+```shell filename="Shell"
+make develop-lite
+```
+
+This will run the UI dev server locally and the frontend will be available at `http://localhost:3000`. You can now make
+any desired changes to monetr's frontend without needing to run all of the services monetr relies on.
+
+This development mode defaults to monetr's staging environment (`my.monetr.dev`), which while it is publicly accessible;
+you are not able to create new accounts on it at this time. If you want to change the API server that the lite
+development environment is using you can customize the domain name in your `CMakeUserPresets.json` file as noted above
+in the [CMake](#cmake) section.
+
+<Callout type="warning">
+    Be extremely conscious about what actions you perform in the lite development environment, if you have your
+    development environment pointed at the production instance for example; any actions you take locally will affect 
+    your real account. Any data modified or deleted will not be recoverable.
+</Callout>
 
 ### Documentation
 

--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -60,3 +60,15 @@ add_custom_target(
   DEPENDS ${UI_DIST}
 )
 
+add_custom_target(
+  development.lite
+  COMMAND ${CMAKE_COMMAND} -E env MONETR_DEVELOPMENT_LITE=true MONETR_DEVELOPMENT_LITE_TARGET=${MONETR_DEVELOPMENT_LITE_TARGET} ${RSPACK_EXECUTABLE} serve --mode development
+  COMMENT "Starting frontend lite local development"
+  WORKING_DIRECTORY ${UI_SRC_DIR}
+  DEPENDS
+    dependencies.node_modules
+    tools.rspack
+    ${APP_UI_FILES}
+    ${PUBLIC_FILES}
+    ${UI_CONFIG_FILES}
+)

--- a/interface/package.json
+++ b/interface/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "rspack build --mode=production",
     "start": "MONETR_ENV=${MONETR_ENV:=local} rspack serve --mode development",
+    "lite": "MONETR_ENV=${MONETR_ENV:=local} MONETR_DEVELOPMENT_LITE=true rspack serve --mode development",
     "test": "bun test",
     "coverage": "bun test"
   },


### PR DESCRIPTION
The "lite" development environment allows developers to only work on the
frontend of monetr but still use a real API backend without needing to
run the entire stack locally. This development environment proxies API
requests upstream to a specified API server such as the staging
environment.

This allows for bugs to be reproduced more easily or for changes to be
made on systems that may not want or need to run all of the extra
servives necessary.
