### PR TITLE
feat(billing): Allow users to subscribe before their trial ends

### DIFF
--- a/interface/src/hooks/useAuthentication.ts
+++ b/interface/src/hooks/useAuthentication.ts
@@ -75,14 +75,8 @@ export function useAfterCheckout(): (_checkoutSessionId: string) => Promise<Afte
   const mutation = useMutation(
     queryCheckoutSession,
     {
-      onSuccess: (result: AfterCheckoutResult) => Promise.all([
-        queryClient.setQueriesData(
-          ['/users/me'],
-          (previous: Partial<AuthenticationWrapper>) => ({
-            ...previous,
-            isActive: result.isActive,
-          })
-        ),
+      onSuccess: () => Promise.all([
+        queryClient.invalidateQueries(['/users/me']),
       ]),
     },
   );

--- a/interface/src/monetr.tsx
+++ b/interface/src/monetr.tsx
@@ -149,7 +149,7 @@ export default function Monetr(): JSX.Element {
           <Route path='/plaid/oauth-return' element={ <OauthReturn /> } />
           <Route path='/subscription' element={ <SubscriptionPage /> } />
           <Route path='/account/subscribe' element={ <Navigate replace to='/' /> } />
-          <Route path='/account/subscribe/after' element={ <Navigate replace to='/' /> } />
+          <Route path='/account/subscribe/after' element={ <AfterCheckoutPage /> } />
           <Route path='/setup' element={ <Navigate replace to='/' /> } />
           <Route path='/password/reset' element={ <Navigate replace to='/' /> } />
           <Route path='/register' element={ <Navigate replace to='/' /> } />

--- a/interface/src/pages/settings/CMakeLists.txt
+++ b/interface/src/pages/settings/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(NodeTestUtils)
+
+provision_node_tests(${CMAKE_CURRENT_SOURCE_DIR})

--- a/interface/src/pages/settings/billing.spec.tsx
+++ b/interface/src/pages/settings/billing.spec.tsx
@@ -1,0 +1,254 @@
+import React, { act } from 'react';
+import { waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MockAdapter from 'axios-mock-adapter';
+import { endOfMonth, endOfToday, startOfToday } from 'date-fns';
+
+import monetrClient from '@monetr/interface/api/api';
+import SettingsBilling from '@monetr/interface/pages/settings/billing';
+import testRenderer from '@monetr/interface/testutils/renderer';
+
+const oldWindowLocation = window.location;
+const locationAssignMock = jest.fn();
+
+describe('billing settings page', () => {
+  let mockAxios: MockAdapter;
+
+  beforeAll(() => {
+    delete window.location;
+    // @ts-ignore
+    window.location = Object.defineProperties(
+      {},
+      {
+        ...Object.getOwnPropertyDescriptors(oldWindowLocation),
+        assign: {
+          configurable: true,
+          value: locationAssignMock,
+        },
+      },
+    );
+  });
+
+  beforeEach(() => {
+    mockAxios = new MockAdapter(monetrClient);
+  });
+
+  afterEach(() => {
+    mockAxios.reset();
+  });
+
+  afterAll(() => { 
+    mockAxios.restore();
+    window.location = oldWindowLocation;
+  });
+
+  it('will show a trial subscription', async () => {
+    mockAxios.onGet('/api/config').reply(200, {
+      'requireLegalName': false,
+      'requirePhoneNumber': false,
+      'verifyLogin': false,
+      'verifyRegister': false,
+      'verifyEmailAddress': true,
+      'verifyForgotPassword': false,
+      'allowSignUp': true,
+      'allowForgotPassword': true,
+      'longPollPlaidSetup': true,
+      'requireBetaCode': false,
+      'initialPlan': {
+        'price': 499,
+      },
+      'billingEnabled': true,
+      'iconsEnabled': true,
+      'plaidEnabled': true,
+      'manualEnabled': true,
+      'uploadsEnabled': true,
+      'release': '',
+      'revision': '',
+      'buildType': 'development',
+      'buildTime': '2025-01-07T19:17:19Z',
+    });
+    mockAxios.onGet('/api/users/me').reply(200, {
+      'activeUntil': null,
+      'hasSubscription': false,
+      'isActive': true,
+      'isSetup': true,
+      'isTrialing': true,
+      'mfaPending': false,
+      'trialingUntil': endOfToday().toISOString(),
+      'user': {
+        'userId': 'user_01jh111mq7ev2wvnnxxn5etgn5',
+        'loginId': 'lgn_01jh111mq6hfhm750wsy3p897k',
+        'login': {
+          'loginId': 'lgn_01jh111mq6hfhm750wsy3p897k',
+          'email': 'example@example.com',
+          'firstName': 'Elliot',
+          'lastName': 'Courant',
+          'passwordResetAt': null,
+          'isEmailVerified': true,
+          'emailVerifiedAt': '2025-01-07T18:39:50.227236Z',
+          'totpEnabledAt': null,
+        },
+        'accountId': 'acct_01jh111mq7ev2wvnnxxjex24x3',
+        'account': {
+          'accountId': 'acct_01jh111mq7ev2wvnnxxjex24x3',
+          'timezone': 'America/Chicago',
+          'locale': 'en_US',
+          'trialEndsAt': '2025-01-08T18:39:46.406975Z',
+          'createdAt': '2025-01-07T18:39:46.40702Z',
+        },
+        'role': 'owner',
+      },
+    });
+    mockAxios.onPost('/api/billing/create_checkout').reply(200, {
+      url: 'http://localhost/bogus/portal',
+    });
+
+    const world = testRenderer(<SettingsBilling />, { initialRoute: '/settings/billing' });
+
+    await waitFor(() => expect(world.getByTestId('billing-subscription-trialing')).toBeVisible());
+    await waitFor(() => expect(world.getByText('Subscribe Early')).toBeVisible());
+    
+    await act(() => userEvent.click(world.getByTestId('billing-subscribe')));
+
+    await waitFor(() => expect(locationAssignMock).toHaveBeenCalledWith('http://localhost/bogus/portal'));
+  });
+
+  it('will show an active subscription', async () => {
+    mockAxios.onGet('/api/config').reply(200, {
+      'requireLegalName': false,
+      'requirePhoneNumber': false,
+      'verifyLogin': false,
+      'verifyRegister': false,
+      'verifyEmailAddress': true,
+      'verifyForgotPassword': false,
+      'allowSignUp': true,
+      'allowForgotPassword': true,
+      'longPollPlaidSetup': true,
+      'requireBetaCode': false,
+      'initialPlan': {
+        'price': 499,
+      },
+      'billingEnabled': true,
+      'iconsEnabled': true,
+      'plaidEnabled': true,
+      'manualEnabled': true,
+      'uploadsEnabled': true,
+      'release': '',
+      'revision': '',
+      'buildType': 'development',
+      'buildTime': '2025-01-07T19:17:19Z',
+    });
+    mockAxios.onGet('/api/users/me').reply(200, {
+      'activeUntil': endOfMonth(endOfToday()).toISOString(),
+      'hasSubscription': true,
+      'isActive': true,
+      'isSetup': true,
+      'isTrialing': false,
+      'mfaPending': false,
+      'trialingUntil': startOfToday().toISOString(),
+      'user': {
+        'userId': 'user_01jh111mq7ev2wvnnxxn5etgn5',
+        'loginId': 'lgn_01jh111mq6hfhm750wsy3p897k',
+        'login': {
+          'loginId': 'lgn_01jh111mq6hfhm750wsy3p897k',
+          'email': 'example@example.com',
+          'firstName': 'Elliot',
+          'lastName': 'Courant',
+          'passwordResetAt': null,
+          'isEmailVerified': true,
+          'emailVerifiedAt': '2025-01-07T18:39:50.227236Z',
+          'totpEnabledAt': null,
+        },
+        'accountId': 'acct_01jh111mq7ev2wvnnxxjex24x3',
+        'account': {
+          'accountId': 'acct_01jh111mq7ev2wvnnxxjex24x3',
+          'timezone': 'America/Chicago',
+          'locale': 'en_US',
+          'subscriptionActiveUntil': endOfMonth(endOfToday()).toISOString(),
+          'subscriptionStatus': 'active',
+          'trialEndsAt': startOfToday().toISOString(),
+          'createdAt': '2025-01-07T18:39:46.40702Z',
+        },
+        'role': 'owner',
+      },
+    });
+    mockAxios.onGet('/api/billing/portal').reply(200, {
+      url: 'http://localhost/bogus/portal',
+    });
+
+    const world = testRenderer(<SettingsBilling />, { initialRoute: '/settings/billing' });
+
+    await waitFor(() => expect(world.getByTestId('billing-subscription-active')).toBeVisible());
+    await waitFor(() => expect(world.getByText('Manage Your Subscription')).toBeVisible());
+
+    await act(() => userEvent.click(world.getByTestId('billing-subscribe')));
+
+    await waitFor(() => expect(locationAssignMock).toHaveBeenCalledWith('http://localhost/bogus/portal'));
+  });
+
+  it('will show an expired subscription', async () => {
+    mockAxios.onGet('/api/config').reply(200, {
+      'requireLegalName': false,
+      'requirePhoneNumber': false,
+      'verifyLogin': false,
+      'verifyRegister': false,
+      'verifyEmailAddress': true,
+      'verifyForgotPassword': false,
+      'allowSignUp': true,
+      'allowForgotPassword': true,
+      'longPollPlaidSetup': true,
+      'requireBetaCode': false,
+      'initialPlan': {
+        'price': 499,
+      },
+      'billingEnabled': true,
+      'iconsEnabled': true,
+      'plaidEnabled': true,
+      'manualEnabled': true,
+      'uploadsEnabled': true,
+      'release': '',
+      'revision': '',
+      'buildType': 'development',
+      'buildTime': '2025-01-07T19:17:19Z',
+    });
+    mockAxios.onGet('/api/users/me').reply(200, {
+      'activeUntil': startOfToday().toISOString(),
+      'hasSubscription': true,
+      'isActive': false,
+      'isSetup': true,
+      'isTrialing': false,
+      'mfaPending': false,
+      'trialingUntil': startOfToday().toISOString(),
+      'user': {
+        'userId': 'user_01jh111mq7ev2wvnnxxn5etgn5',
+        'loginId': 'lgn_01jh111mq6hfhm750wsy3p897k',
+        'login': {
+          'loginId': 'lgn_01jh111mq6hfhm750wsy3p897k',
+          'email': 'example@example.com',
+          'firstName': 'Elliot',
+          'lastName': 'Courant',
+          'passwordResetAt': null,
+          'isEmailVerified': true,
+          'emailVerifiedAt': '2025-01-07T18:39:50.227236Z',
+          'totpEnabledAt': null,
+        },
+        'accountId': 'acct_01jh111mq7ev2wvnnxxjex24x3',
+        'account': {
+          'accountId': 'acct_01jh111mq7ev2wvnnxxjex24x3',
+          'timezone': 'America/Chicago',
+          'locale': 'en_US',
+          'subscriptionActiveUntil': startOfToday().toISOString(),
+          'subscriptionStatus': 'active',
+          'trialEndsAt': startOfToday().toISOString(),
+          'createdAt': '2025-01-07T18:39:46.40702Z',
+        },
+        'role': 'owner',
+      },
+    });
+
+    const world = testRenderer(<SettingsBilling />, { initialRoute: '/settings/billing' });
+
+    await waitFor(() => expect(world.getByTestId('billing-subscription-expired')).toBeVisible());
+    await waitFor(() => expect(world.getByText('Manage Your Subscription')).toBeVisible());
+  });
+});

--- a/interface/src/pages/settings/billing.tsx
+++ b/interface/src/pages/settings/billing.tsx
@@ -2,11 +2,11 @@ import React, { useCallback, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { AccessTimeOutlined } from '@mui/icons-material';
 import { AxiosResponse } from 'axios';
-import { format, isPast, isThisYear } from 'date-fns';
+import { format, isFuture, isThisYear } from 'date-fns';
 import { useSnackbar } from 'notistack';
 
+import { Button } from '@monetr/interface/components/Button';
 import MBadge from '@monetr/interface/components/MBadge';
-import { MBaseButton } from '@monetr/interface/components/MButton';
 import MDivider from '@monetr/interface/components/MDivider';
 import MSpan from '@monetr/interface/components/MSpan';
 import { useAuthenticationSink } from '@monetr/interface/hooks/useAuthentication';
@@ -59,53 +59,49 @@ export default function SettingsBilling(): JSX.Element {
       </div>
       <MDivider />
 
-      <MBaseButton
+      <Button
         className='ml-auto mt-4 max-w-xs'
-        color='primary'
+        variant='primary'
         disabled={ loading }
         onClick={ handleManageSubscription }
+        data-testid='billing-subscribe'
       >
         { manageSubscriptionText }
-      </MBaseButton>
+      </Button>
     </div>
   );
 }
 
 function SubscriptionStatusBadge(): JSX.Element {
-  const { result: { hasSubscription, trialingUntil } } = useAuthenticationSink();
+  const { result: { isActive, hasSubscription, trialingUntil } } = useAuthenticationSink();
 
-  if (hasSubscription) {
+  // If they have a subscription and it is active then show active.
+  if (hasSubscription && isActive) {
     return (
-      <MBadge className='bg-green-600'>
+      <MBadge className='bg-green-600' data-testid='billing-subscription-active'>
         Active
       </MBadge>
     );
   }
 
-  if (trialingUntil && isPast(trialingUntil)) {
-    return (
-      <MBadge className='bg-red-600'>
-        Trial Expired
-      </MBadge>
-    );
-  }
-
-  if (trialingUntil) {
+  // If they have a trial end date that is in the future then they are trialing.
+  if (trialingUntil && isFuture(trialingUntil)) {
     const trialEndDate = isThisYear(trialingUntil) ?
       format(trialingUntil, 'MMMM do') :
       format(trialingUntil, 'MMMM do, yyyy');
 
     return (
-      <MBadge className='bg-yellow-600'>
+      <MBadge className='bg-yellow-600' data-testid='billing-subscription-trialing'>
         <AccessTimeOutlined />
         Trialing Until { trialEndDate }
       </MBadge>
     );
   }
 
+  // Anything else is considered expired.
   return (
-    <MBadge className='bg-pink-600'>
-      Unknown
+    <MBadge className='bg-red-600' data-testid='billing-subscription-expired'>
+      Expired
     </MBadge>
   );
 }

--- a/interface/src/pages/settings/billing.tsx
+++ b/interface/src/pages/settings/billing.tsx
@@ -1,5 +1,7 @@
-import React, { Fragment, useCallback, useState } from 'react';
+import React, { useCallback, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { AccessTimeOutlined } from '@mui/icons-material';
+import { AxiosResponse } from 'axios';
 import { format, isPast, isThisYear } from 'date-fns';
 import { useSnackbar } from 'notistack';
 
@@ -11,30 +13,25 @@ import { useAuthenticationSink } from '@monetr/interface/hooks/useAuthentication
 import request from '@monetr/interface/util/request';
 
 export default function SettingsBilling(): JSX.Element {
-  const { result: { trialingUntil } } = useAuthenticationSink();
-
-  return (
-    <div className='w-full flex flex-col p-4 max-w-xl'>
-      <MSpan size='2xl' weight='bold' color='emphasis' className='mb-4'>
-        Billing
-      </MSpan>
-      <MDivider />
-
-      <TrialingRow trialingUntil={ trialingUntil } />
-      <ActiveSubscriptionRow />
-    </div>
-  );
-}
-
-function ActiveSubscriptionRow(): JSX.Element {
+  const location = useLocation();
   const { enqueueSnackbar } = useSnackbar();
   const [loading, setLoading] = useState(false);
   const { result: { hasSubscription } } = useAuthenticationSink();
-  const handleManageSubscription = useCallback(() => {
+  const handleManageSubscription = useCallback(async () => {
     setLoading(true);
-    // If the customer has a subscription then we want to just manage it. This will allow a customer to fix a
-    // subscription for a card that has failed payment or something similar.
-    request().get('/billing/portal')
+    let promise: Promise<AxiosResponse<{ url: string }>>;
+    if (!hasSubscription) {
+      promise = request().post('/billing/create_checkout', {
+        // If the user backs out of the stripe checkout then return them to the current URL.
+        cancelPath: location.pathname,
+      });
+    } else {
+      // If the customer has a subscription then we want to just manage it. This will allow a customer to fix a
+      // subscription for a card that has failed payment or something similar.
+      promise = request().get('/billing/portal');
+    }
+
+    await promise
       .then(result => window.location.assign(result.data.url))
       .catch(error => {
         setLoading(false);
@@ -43,21 +40,22 @@ function ActiveSubscriptionRow(): JSX.Element {
           disableWindowBlurListener: true,
         });
       });
-  }, [enqueueSnackbar]);
+  }, [enqueueSnackbar, hasSubscription, location]);
 
-  if (!hasSubscription) {
-    return null;
-  }
+  const manageSubscriptionText = hasSubscription ? 'Manage Your Subscription' : 'Subscribe Early';
 
   return (
-    <Fragment>
+    <div className='w-full flex flex-col p-4 max-w-xl'>
+      <MSpan size='2xl' weight='bold' color='emphasis' className='mb-4'>
+        Billing
+      </MSpan>
+      <MDivider />
+
       <div className='flex justify-between py-4'>
         <MSpan>
           Subscription Status
         </MSpan>
-        <MBadge className='bg-green-600'>
-          Active
-        </MBadge>
+        <SubscriptionStatusBadge />
       </div>
       <MDivider />
 
@@ -67,43 +65,48 @@ function ActiveSubscriptionRow(): JSX.Element {
         disabled={ loading }
         onClick={ handleManageSubscription }
       >
-        Manage Your Subscription
+        { manageSubscriptionText }
       </MBaseButton>
-    </Fragment>
+    </div>
   );
 }
 
-interface TrialingRowProps {
-  trialingUntil: Date | null;
-}
+function SubscriptionStatusBadge(): JSX.Element {
+  const { result: { hasSubscription, trialingUntil } } = useAuthenticationSink();
 
-function TrialingRow(props: TrialingRowProps): JSX.Element {
-  if (!props.trialingUntil || isPast(props.trialingUntil)) {
-    return null;
+  if (hasSubscription) {
+    return (
+      <MBadge className='bg-green-600'>
+        Active
+      </MBadge>
+    );
   }
 
-  const trialEndDate = isThisYear(props.trialingUntil) ?
-    format(props.trialingUntil, 'MMMM do') :
-    format(props.trialingUntil, 'MMMM do, yyyy');
+  if (trialingUntil && isPast(trialingUntil)) {
+    return (
+      <MBadge className='bg-red-600'>
+        Trial Expired
+      </MBadge>
+    );
+  }
+
+  if (trialingUntil) {
+    const trialEndDate = isThisYear(trialingUntil) ?
+      format(trialingUntil, 'MMMM do') :
+      format(trialingUntil, 'MMMM do, yyyy');
+
+    return (
+      <MBadge className='bg-yellow-600'>
+        <AccessTimeOutlined />
+        Trialing Until { trialEndDate }
+      </MBadge>
+    );
+  }
 
   return (
-    <Fragment>
-      <div className='flex justify-between py-4'>
-        <MSpan>
-          Subscription Status
-        </MSpan>
-        <MBadge className='bg-yellow-600'>
-          <AccessTimeOutlined />
-          Trialing Until { trialEndDate }
-        </MBadge>
-      </div>
-      <MDivider />
-      <div className='flex justify-between py-4'>
-        <MSpan>
-          You can upgrade to a paid subscription at the end of your trial.
-        </MSpan>
-      </div>
-      <MDivider />
-    </Fragment>
+    <MBadge className='bg-pink-600'>
+      Unknown
+    </MBadge>
   );
 }
+

--- a/server/background/notification_trial_expiry.go
+++ b/server/background/notification_trial_expiry.go
@@ -85,6 +85,8 @@ func (h *NotificationTrialExpiryHandler) EnqueueTriggeredJob(
 	err := h.db.ModelContext(ctx, &accounts).
 		Where(`"account"."trial_expiry_notification_sent_at" IS NULL`).
 		Where(`"account"."trial_ends_at" < ?`, cutoff).
+		// Make sure to exclude users who have subscribed before their trial ends.
+		Where(`"account"."subscription_active_until" IS NULL`).
 		Select(&accounts)
 	if err != nil {
 		return errors.Wrap(err, "failed to query accounts who need a trial expiry notification")

--- a/server/billing/checkout.go
+++ b/server/billing/checkout.go
@@ -56,6 +56,10 @@ func (b *baseBilling) CreateCheckout(
 		return nil, errors.Wrap(err, "cannot determine if account subscription is active")
 	}
 
+	if account.IsSubscriptionActive(b.clock.Now()) && !account.IsTrialing(b.clock.Now()) {
+		return nil, errors.WithStack(ErrSubscriptionAlreadyActive)
+	}
+
 	if account.HasSubscription() {
 		// Even if the subscription isn't active, if they have a subscription then
 		// they need to use the billing portal instead.

--- a/server/billing/checkout.go
+++ b/server/billing/checkout.go
@@ -56,12 +56,6 @@ func (b *baseBilling) CreateCheckout(
 		return nil, errors.Wrap(err, "cannot determine if account subscription is active")
 	}
 
-	if account.IsSubscriptionActive(b.clock.Now()) {
-		// If the account's subscription is already active then we cannot use the
-		// checkout session. They instead need to create a billing portal.
-		return nil, errors.WithStack(ErrSubscriptionAlreadyActive)
-	}
-
 	if account.HasSubscription() {
 		// Even if the subscription isn't active, if they have a subscription then
 		// they need to use the billing portal instead.

--- a/server/controller/billing.go
+++ b/server/controller/billing.go
@@ -101,7 +101,7 @@ func (c *Controller) getBillingPortal(ctx echo.Context) error {
 
 	if err != nil {
 		if errors.Cause(err) == billing.ErrMissingSubscription {
-			return c.badRequest(ctx, "account does not have a subscription")
+			return c.badRequest(ctx, "Account does not have a subscription")
 		}
 		return c.wrapAndReturnError(ctx, err, http.StatusInternalServerError, "Failed to create new stripe portal session")
 	}

--- a/server/controller/billing.go
+++ b/server/controller/billing.go
@@ -8,21 +8,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Create Checkout Session
-// @Summary Create Checkout Session
-// @id create-checkout-session
-// @tags Billing
-// @description Create a checkout session for Stripe. This is used to manage new subscriptions to monetr and offload the
-// @description complexity of managing subscriptions. **Note:** You cannot create a checkout session if you already have
-// @description a subscription that is not canceled associated with the account.
-// @Accept json
-// @Produce json
-// @Security ApiKeyAuth
-// @Param createCheckoutSession body swag.CreateCheckoutSessionRequest true "New Checkout Session"
-// @Router /billing/create_checkout [post]
-// @Success 200 {object} swag.CreateCheckoutSessionResponse
-// @Failure 400 {object} ApiError A bad request can be returned if the account already has an active subscription, or an incomplete subscription already created.
-// @Failure 500 {object} ApiError Something went wrong on our end or when communicating with Stripe.
 func (c *Controller) handlePostCreateCheckout(ctx echo.Context) error {
 	if !c.Configuration.Stripe.IsBillingEnabled() {
 		return c.notFound(ctx, "billing is not enabled")
@@ -65,18 +50,6 @@ func (c *Controller) handlePostCreateCheckout(ctx echo.Context) error {
 	})
 }
 
-// Retrieve Post-Checkout Session Details
-// @Summary Get Post-Checkout Session Details
-// @id get-post-checkout-session-details
-// @tags Billing
-// @description After completing a checkout session, retrieve the outcome of the checkout session and persist it immediately.
-// @Produce json
-// @Security ApiKeyAuth
-// @Router /billing/checkout/{checkoutSessionId} [get]
-// @Param checkoutSessionId path string true "Stripe Checkout Session ID"
-// @Success 200 {object} swag.AfterCheckoutResponse
-// @Failure 400 {object} ApiError Invalid request.
-// @Failure 500 {object} ApiError Something went wrong on our end or when communicating with Stripe.
 func (c *Controller) handleGetAfterCheckout(ctx echo.Context) error {
 	if !c.Configuration.Stripe.IsBillingEnabled() {
 		return c.notFound(ctx, "billing is not enabled")

--- a/server/controller/billing_test.go
+++ b/server/controller/billing_test.go
@@ -161,4 +161,85 @@ func TestGetAfterCheckout(t *testing.T) {
 			result.JSON().Path("$.error").String().IsEqual("There is already an active subscription for your account")
 		}
 	})
+
+	t.Run("allowed to create checkout while trialing", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		stripeMock := mock_stripe.NewMockStripeHelper(t)
+
+		stripeMock.MockStripeCreateCustomerSuccess(t)
+		stripeMock.MockNewCheckoutSession(t)
+		stripeMock.MockGetCheckoutSession(t)
+		stripeMock.MockGetSubscription(t)
+
+		conf := NewTestApplicationConfig(t)
+		conf.Stripe.Enabled = true
+		conf.Stripe.APIKey = gofakeit.UUID()
+		conf.Stripe.FreeTrialDays = 1
+		conf.Stripe.InitialPlan = &config.Plan{
+			StripePriceId: mock_stripe.FakeStripePriceId(t),
+		}
+
+		_, e := NewTestApplicationWithConfig(t, conf)
+
+		token := GivenIHaveToken(t, e)
+
+		stripeMock.AssertNCustomersCreated(t, 0)
+
+		{ // Make sure that initially the customer's subscription is not present or active.
+			result := e.GET("/api/users/me").
+				WithCookie(TestCookieName, token).
+				Expect()
+
+			result.Status(http.StatusOK)
+			// When we initially start we are still in a trial status.
+			result.JSON().Path("$.isTrialing").Boolean().IsTrue()
+			result.JSON().Path("$.isActive").Boolean().IsTrue()
+			result.JSON().Path("$.hasSubscription").Boolean().IsFalse()
+		}
+
+		var checkoutSessionId string
+		{ // Create a checkout session
+			result := e.POST("/api/billing/create_checkout").
+				WithCookie(TestCookieName, token).
+				WithJSON(map[string]interface{}{
+					"cancelPath": nil,
+				}).
+				Expect()
+
+			result.Status(http.StatusOK)
+			result.JSON().Path("$.url").String().NotEmpty()
+			result.JSON().Path("$.sessionId").String().NotEmpty()
+			checkoutSessionId = result.JSON().Path("$.sessionId").String().Raw()
+		}
+
+		stripeMock.AssertNCustomersCreated(t, 1)
+
+		// Mark the checkout session as complete.
+		stripeMock.CompleteCheckoutSession(t, checkoutSessionId)
+
+		{ // Then do the callback from the frontend to complete the checkout session for our application.
+			result := e.GET("/api/billing/checkout/{checkoutSessionId}").
+				WithPath("checkoutSessionId", checkoutSessionId).
+				WithCookie(TestCookieName, token).
+				Expect()
+
+			result.Status(http.StatusOK)
+			result.JSON().Path("$.isActive").Boolean().IsTrue()
+			result.JSON().Path("$.nextUrl").String().IsEqual("/")
+		}
+
+		{ // Then once it's all said and done, make sure the customer's subscription shows as present and active.
+			result := e.GET("/api/users/me").
+				WithCookie(TestCookieName, token).
+				Expect()
+
+			result.Status(http.StatusOK)
+			// Now that we are subscribed we should not be trialing.
+			result.JSON().Path("$.isTrialing").Boolean().IsFalse()
+			result.JSON().Path("$.isActive").Boolean().IsTrue()
+			result.JSON().Path("$.hasSubscription").Boolean().IsTrue()
+		}
+	})
 }

--- a/server/models/account.go
+++ b/server/models/account.go
@@ -117,6 +117,12 @@ func (a *Account) HasSubscription() bool {
 	}
 }
 
+// IsTrialing returns true if the trial is the primary active form of access for
+// monetr. For example, if a user signs up for monetr but then subscribes
+// shortly after starting. Their trial will still be active, but they will not
+// be considered "trialing" because their subscription is active. They are
+// considered trialing only when the trial end timestamp is in the future
+// relative to the timestamp provided and there is not a subscription.
 func (a *Account) IsTrialing(now time.Time) bool {
 	// We are in a trial state when we do not have a subscription and the trial
 	// ends at date is in the future.

--- a/server/models/account.go
+++ b/server/models/account.go
@@ -118,5 +118,9 @@ func (a *Account) HasSubscription() bool {
 }
 
 func (a *Account) IsTrialing(now time.Time) bool {
-	return a.TrialEndsAt != nil && a.TrialEndsAt.After(now)
+	// We are in a trial state when we do not have a subscription and the trial
+	// ends at date is in the future.
+	return !a.HasSubscription() &&
+		a.TrialEndsAt != nil &&
+		a.TrialEndsAt.After(now)
 }


### PR DESCRIPTION
If someone wants to subscribe to monetr before their trial has ended
they will now be able to do so. This will not trample the trial data,
but will make the subscription status take priority. It also makes sure
that we don't send trial expiry notifications when we don't need to.
