### PR TITLE
fix(locale): Improving currency formatting on the frontend

### DIFF
--- a/interface/src/components/Layout/BudgetingSidebar.tsx
+++ b/interface/src/components/Layout/BudgetingSidebar.tsx
@@ -16,6 +16,7 @@ import { useCurrentBalance } from '@monetr/interface/hooks/balances';
 import { useSelectedBankAccount } from '@monetr/interface/hooks/bankAccounts';
 import { useNextFundingDate } from '@monetr/interface/hooks/fundingSchedules';
 import { useLink } from '@monetr/interface/hooks/links';
+import { useAuthentication } from '@monetr/interface/hooks/useAuthentication';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 
 export interface BudgetingSidebarProps {
@@ -23,6 +24,7 @@ export interface BudgetingSidebarProps {
 }
 
 export default function BudgetingSidebar(props: BudgetingSidebarProps): JSX.Element {
+  const user = useAuthentication();
   const { data: bankAccount, isLoading, isError } = useSelectedBankAccount();
   const { data: link } = useLink(bankAccount?.linkId);
   const balance = useCurrentBalance();
@@ -56,7 +58,7 @@ export default function BudgetingSidebar(props: BudgetingSidebarProps): JSX.Elem
               Free-To-Use:
             </MSpan>
             <MSpan size='lg' weight='semibold' className={ valueClassName }>
-              {balance?.getFreeToUseString()}
+              { balance?.getFreeToUseString(user.account.locale) }
             </MSpan>
           </div>
         );
@@ -76,7 +78,7 @@ export default function BudgetingSidebar(props: BudgetingSidebarProps): JSX.Elem
               Available:
             </MSpan>
             <MSpan size='lg' weight='semibold' className='dark:text-dark-monetr-content-emphasis'>
-              {balance?.getAvailableString()}
+              { balance?.getAvailableString(user.account.locale) }
             </MSpan>
           </div>
         );
@@ -95,7 +97,7 @@ export default function BudgetingSidebar(props: BudgetingSidebarProps): JSX.Elem
               Limit:
             </MSpan>
             <MSpan size='lg' weight='semibold' className='dark:text-dark-monetr-content-emphasis'>
-              {balance?.getAvailableString()}
+              { balance?.getAvailableString(user.account.locale) }
             </MSpan>
           </div>
         );
@@ -120,7 +122,7 @@ export default function BudgetingSidebar(props: BudgetingSidebarProps): JSX.Elem
               Current:
             </MSpan>
             <MSpan size='lg' weight='semibold' className='dark:text-dark-monetr-content-emphasis'>
-              { balance?.getCurrentString() }
+              { balance?.getCurrentString(user.account.locale) }
             </MSpan>
           </div>
           <Limit />
@@ -140,7 +142,7 @@ export default function BudgetingSidebar(props: BudgetingSidebarProps): JSX.Elem
               Expenses
             </MSpan>
             <MBadge className='ml-auto' size='sm'>
-              {balance?.getExpensesString()}
+              { balance?.getExpensesString(user.account.locale) }
             </MBadge>
           </NavigationItem>
           <NavigationItem to={ `/bank/${bankAccount?.bankAccountId}/goals` }>
@@ -149,7 +151,7 @@ export default function BudgetingSidebar(props: BudgetingSidebarProps): JSX.Elem
               Goals
             </MSpan>
             <MBadge className='ml-auto' size='sm'>
-              {balance?.getGoalsString()}
+              { balance?.getGoalsString(user.account.locale) }
             </MBadge>
           </NavigationItem>
           <NavigationItem to={ `/bank/${bankAccount?.bankAccountId}/funding` }>
@@ -199,7 +201,7 @@ function NavigationItem(props: NavigationItemProps): JSX.Element {
 
   return (
     <Link className={ className } to={ props.to }>
-      {props.children}
+      { props.children }
     </Link>
   );
 }
@@ -211,7 +213,7 @@ function NextFundingBadge(): JSX.Element {
 
   return (
     <MBadge className='ml-auto' size='sm'>
-      {next}
+      { next }
     </MBadge>
   );
 }

--- a/interface/src/components/expenses/ExpenseItem.tsx
+++ b/interface/src/components/expenses/ExpenseItem.tsx
@@ -7,6 +7,7 @@ import { format, isThisYear } from 'date-fns';
 import MBadge from '@monetr/interface/components/MBadge';
 import MerchantIcon from '@monetr/interface/components/MerchantIcon';
 import { useFundingSchedule } from '@monetr/interface/hooks/fundingSchedules';
+import { useAuthentication } from '@monetr/interface/hooks/useAuthentication';
 import Spending from '@monetr/interface/models/Spending';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 
@@ -17,6 +18,7 @@ export interface ExpenseItemProps {
 }
 
 export default function ExpenseItem({ spending }: ExpenseItemProps): JSX.Element {
+  const user = useAuthentication();
   const { data: fundingSchedule } = useFundingSchedule(spending.fundingScheduleId);
   const navigate = useNavigate();
   const rule = rrulestr(spending.ruleset!);
@@ -61,7 +63,7 @@ export default function ExpenseItem({ spending }: ExpenseItemProps): JSX.Element
               { rule.toText() }
             </span>
             <span className='md:hidden text-zinc-200 text-sm w-full overflow-hidden text-ellipsis whitespace-nowrap min-w-0'>
-              { spending.getNextContributionAmountString() } / { fundingSchedule?.name }
+              { spending.getNextContributionAmountString(user.account.locale) } / { fundingSchedule?.name }
             </span>
           </div>
         </div>
@@ -69,7 +71,7 @@ export default function ExpenseItem({ spending }: ExpenseItemProps): JSX.Element
         { /* This block only shows on mobile screens */ }
         <div className='hidden md:flex w-1/2 overflow-hidden flex-1 min-w-0 items-center'>
           <span className='text-zinc-50/75 font-medium text-base text-ellipsis whitespace-nowrap overflow-hidden min-w-0'>
-            { spending.getNextContributionAmountString() } / { fundingSchedule?.name }
+            { spending.getNextContributionAmountString(user.account.locale) } / { fundingSchedule?.name }
           </span>
         </div>
 
@@ -77,11 +79,11 @@ export default function ExpenseItem({ spending }: ExpenseItemProps): JSX.Element
         <div className='flex md:hidden shrink-0 items-center gap-2'>
           <div className='flex flex-col'>
             <span className={ amountClass }>
-              { spending.getCurrentAmountString() }
+              { spending.getCurrentAmountString(user.account.locale) }
             </span>
             <hr className='w-full border-0 border-b-[thin] border-zinc-600' />
             <span className='text-end text-zinc-400 group-hover:text-zinc-300 font-medium'>
-              { spending.getTargetAmountString() }
+              { spending.getTargetAmountString(user.account.locale) }
             </span>
           </div>
           <KeyboardArrowRight className='text-zinc-600 group-hover:text-zinc-50 flex-none md:cursor-pointer' />
@@ -92,7 +94,7 @@ export default function ExpenseItem({ spending }: ExpenseItemProps): JSX.Element
           <div className='flex flex-col'>
             <div className='flex justify-end'>
               <span className={ amountClass }>
-                { spending.getCurrentAmountString() }
+                { spending.getCurrentAmountString(user.account.locale) }
               </span>
               &nbsp;
               <span className='text-end text-zinc-500 group-hover:text-zinc-400 font-medium'>
@@ -100,7 +102,7 @@ export default function ExpenseItem({ spending }: ExpenseItemProps): JSX.Element
               </span>
               &nbsp;
               <span className='text-end text-zinc-400 group-hover:text-zinc-300 font-medium'>
-                { spending.getTargetAmountString() }
+                { spending.getTargetAmountString(user.account.locale) }
               </span>
             </div>
           </div>

--- a/interface/src/components/goals/GoalItem.tsx
+++ b/interface/src/components/goals/GoalItem.tsx
@@ -6,6 +6,7 @@ import { KeyboardArrowRight } from '@mui/icons-material';
 import MBadge from '@monetr/interface/components/MBadge';
 import MerchantIcon from '@monetr/interface/components/MerchantIcon';
 import { useFundingSchedule } from '@monetr/interface/hooks/fundingSchedules';
+import { useAuthentication } from '@monetr/interface/hooks/useAuthentication';
 import Spending from '@monetr/interface/models/Spending';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 
@@ -14,6 +15,7 @@ export interface GoalItemProps {
 }
 
 export default function GoalItem({ spending }: GoalItemProps): JSX.Element {
+  const user = useAuthentication();
   const { data: fundingSchedule } = useFundingSchedule(spending.fundingScheduleId);
   const navigate = useNavigate();
 
@@ -24,7 +26,7 @@ export default function GoalItem({ spending }: GoalItemProps): JSX.Element {
 
   // By default the contribution string should simply be the amount that will be added to this goal per funding schedule
   // it is associated with.
-  let contributionString = `${spending.getNextContributionAmountString()} / ${ fundingSchedule?.name }`;
+  let contributionString = `${spending.getNextContributionAmountString(user.account.locale)} / ${ fundingSchedule?.name }`;
   // But if the goal is no longer in progress (it is complete). Then indicate that.
   if (!spending.getGoalIsInProgress()) {
     contributionString = 'Complete';
@@ -81,6 +83,7 @@ interface GoalProps {
 }
 
 function GoalAmount({ spending }: GoalProps): JSX.Element {
+  const user = useAuthentication();
   const amountClass = mergeTailwind(
     {
       'text-green-500': spending.targetAmount <= spending.currentAmount,
@@ -96,11 +99,11 @@ function GoalAmount({ spending }: GoalProps): JSX.Element {
         <div className='flex md:hidden shrink-0 items-center gap-2'>
           <div className='flex flex-col'>
             <span className={ amountClass }>
-              { spending.getCurrentAmountString() }
+              { spending.getCurrentAmountString(user.account.locale) }
             </span>
             <hr className='w-full border-0 border-b-[thin] border-zinc-600' />
             <span className='text-end text-zinc-400 group-hover:text-zinc-300 font-medium'>
-              { spending.getTargetAmountString() }
+              { spending.getTargetAmountString(user.account.locale) }
             </span>
           </div>
         </div>
@@ -108,7 +111,7 @@ function GoalAmount({ spending }: GoalProps): JSX.Element {
           <div className='flex flex-col'>
             <div className='flex justify-end'>
               <span className={ amountClass }>
-                { spending.getCurrentAmountString() }
+                { spending.getCurrentAmountString(user.account.locale) }
               </span>
               &nbsp;
               <span className='text-end text-zinc-500 group-hover:text-zinc-400 font-medium'>
@@ -116,7 +119,7 @@ function GoalAmount({ spending }: GoalProps): JSX.Element {
               </span>
               &nbsp;
               <span className='text-end text-zinc-400 group-hover:text-zinc-300 font-medium'>
-                { spending.getTargetAmountString() }
+                { spending.getTargetAmountString(user.account.locale) }
               </span>
             </div>
           </div>
@@ -128,7 +131,7 @@ function GoalAmount({ spending }: GoalProps): JSX.Element {
   return (
     <div className='flex md:min-w-[12em] shrink-0 justify-end gap-2 items-center'>
       <MBadge className='w-fit justify-end dark:bg-green-600' weight='medium'>
-        { spending.getCurrentAmountString() }
+        { spending.getCurrentAmountString(user.account.locale) }
       </MBadge>
     </div>
   );

--- a/interface/src/components/transactions/TransactionItem.tsx
+++ b/interface/src/components/transactions/TransactionItem.tsx
@@ -93,10 +93,10 @@ export default function TransactionItem({ transaction }: TransactionItemProps): 
           <TransactionMerchantIcon name={ transaction.getName() } pending={ transaction.isPending } />
           <div className='flex min-w-0 flex-col overflow-hidden'>
             <span className='w-full min-w-0 truncate text-base font-semibold dark:text-dark-monetr-content-emphasis'>
-              {transaction.getName()}
+              { transaction.getName() }
             </span>
             <span className='hidden w-full min-w-0 truncate text-sm font-medium dark:text-dark-monetr-content md:block'>
-              {transaction.getMainCategory()}
+              { transaction.getMainCategory() }
             </span>
             <BudgetingInfo className='flex w-full text-sm md:hidden' />
           </div>

--- a/interface/src/models/Balance.ts
+++ b/interface/src/models/Balance.ts
@@ -1,7 +1,8 @@
-import { formatAmount } from '@monetr/interface/util/amounts';
+import { AmountType, formatAmount } from '@monetr/interface/util/amounts';
 
 export default class Balance {
   bankAccountId: string;
+  currency: string;
   available: number;
   current: number;
   free: number;
@@ -12,23 +13,23 @@ export default class Balance {
     if (data) Object.assign(this, data);
   }
 
-  getFreeToUseString(): string {
-    return formatAmount(this.free);
+  getFreeToUseString(locale: string = 'en_US'): string {
+    return formatAmount(this.free, AmountType.Stored, locale, this.currency);
   }
 
-  getAvailableString(): string {
-    return formatAmount(this.available);
+  getAvailableString(locale: string = 'en_US'): string {
+    return formatAmount(this.available, AmountType.Stored, locale, this.currency);
   }
 
-  getCurrentString(): string {
-    return formatAmount(this.current);
+  getCurrentString(locale: string = 'en_US'): string {
+    return formatAmount(this.current, AmountType.Stored, locale, this.currency);
   }
 
-  getExpensesString(): string {
-    return formatAmount(this.expenses);
+  getExpensesString(locale: string = 'en_US'): string {
+    return formatAmount(this.expenses, AmountType.Stored, locale, this.currency);
   }
 
-  getGoalsString(): string {
-    return formatAmount(this.goals);
+  getGoalsString(locale: string = 'en_US'): string {
+    return formatAmount(this.goals, AmountType.Stored, locale, this.currency);
   }
 }

--- a/interface/src/models/BankAccount.ts
+++ b/interface/src/models/BankAccount.ts
@@ -1,6 +1,6 @@
 
 import PlaidBankAccount from '@monetr/interface/models/PlaidBankAccount';
-import { formatAmount } from '@monetr/interface/util/amounts';
+import { AmountType, formatAmount } from '@monetr/interface/util/amounts';
 import parseDate from '@monetr/interface/util/parseDate';
 
 export type BankAccountStatus = 'unknown' | 'active' | 'inactive';
@@ -40,6 +40,7 @@ export default class BankAccount {
   status: BankAccountStatus;
   accountType: BankAccountType;
   accountSubType: BankAccountSubType;
+  currency: string;
   lastUpdated: Date;
   createdAt: Date;
   createdBy: string;
@@ -57,15 +58,15 @@ export default class BankAccount {
     }
   }
 
-  getAvailableBalanceString() {
-    return formatAmount(this.availableBalance);
+  getAvailableBalanceString(locale: string = 'en_US') {
+    return formatAmount(this.availableBalance, AmountType.Stored, locale, this.currency);
   }
 
-  getCurrentBalanceString() {
-    return formatAmount(this.currentBalance);
+  getCurrentBalanceString(locale: string = 'en_US') {
+    return formatAmount(this.currentBalance, AmountType.Stored, locale, this.currency);
   }
 
-  getLimitBalanceString() {
-    return formatAmount(this.limitBalance);
+  getLimitBalanceString(locale: string = 'en_US') {
+    return formatAmount(this.limitBalance, AmountType.Stored, locale, this.currency);
   }
 }

--- a/interface/src/models/Spending.ts
+++ b/interface/src/models/Spending.ts
@@ -47,8 +47,8 @@ export default class Spending {
       format(this.nextRecurrence, 'MMM do, yyyy');
   }
 
-  getTargetAmountString(): string {
-    return formatAmount(this.targetAmount);
+  getTargetAmountString(locale: string = 'en_US'): string {
+    return formatAmount(this.targetAmount, AmountType.Stored, locale);
   }
 
   getTargetAmountDollars(): number {
@@ -59,12 +59,12 @@ export default class Spending {
     return formatAmount(this.currentAmount, AmountType.Stored, locale);
   }
 
-  getUsedAmountString(): string {
-    return formatAmount(this.usedAmount);
+  getUsedAmountString(locale: string = 'en_US'): string {
+    return formatAmount(this.usedAmount, AmountType.Stored, locale);
   }
 
-  getNextContributionAmountString(): string {
-    return formatAmount(this.nextContributionAmount);
+  getNextContributionAmountString(locale: string = 'en_US'): string {
+    return formatAmount(this.nextContributionAmount, AmountType.Stored, locale);
   }
 
   getIsExpense(): boolean {
@@ -82,7 +82,7 @@ export default class Spending {
     return (this.currentAmount + this.usedAmount) < this.targetAmount;
   }
 
-  getGoalSavedAmountString(): string {
-    return formatAmount(this.currentAmount + this.usedAmount);
+  getGoalSavedAmountString(locale: string = 'en_US'): string {
+    return formatAmount(this.currentAmount + this.usedAmount, AmountType.Stored, locale);
   }
 }

--- a/interface/src/models/Transaction.ts
+++ b/interface/src/models/Transaction.ts
@@ -33,7 +33,8 @@ export default class Transaction {
   getAmountString(locale: string = 'en_US'): string {
     const amount = Math.abs(this.amount);
     if (this.amount < 0) {
-      return `+ ${ formatAmount(amount, AmountType.Stored, locale, this.currency) }`;
+      // Show the number sign on deposits only.
+      return formatAmount(amount, AmountType.Stored, locale, this.currency, true);
     }
 
     return formatAmount(amount, AmountType.Stored, locale, this.currency);

--- a/interface/src/pages/register.tsx
+++ b/interface/src/pages/register.tsx
@@ -66,7 +66,6 @@ function validator(values: RegisterValues): FormikErrors<RegisterValues> {
     errors['confirmPassword'] = 'Password confirmation must match.';
   }
 
-  // TODO No restriction on agree?
   return errors;
 }
 
@@ -108,7 +107,7 @@ export default function Register(): JSX.Element {
   async function submit(values: RegisterValues, helpers: FormikHelpers<RegisterValues>): Promise<void> {
     helpers.setSubmitting(true);
 
-    return signUp({
+    return await signUp({
       betaCode: values.betaCode,
       captcha: values.captcha,
       email: values.email,

--- a/interface/src/util/amounts.spec.ts
+++ b/interface/src/util/amounts.spec.ts
@@ -90,8 +90,11 @@ describe('amounts', () => {
     });
 
     it('US with foreign transaction', () => {
-      const euroNetherlands = formatAmount(-1001234, AmountType.Stored, 'en-US', 'EUR');
-      expect(euroNetherlands).toBe('-€10,012.34');
+      const euro = formatAmount(-1001234, AmountType.Stored, 'en-US', 'EUR');
+      expect(euro).toBe('-€10,012.34');
+
+      const yen = formatAmount(-1001234, AmountType.Stored, 'en-US', 'JPY');
+      expect(yen).toBe('-¥1,001,234');
     });
 
     it('will format JPY properly', () => {

--- a/interface/src/util/amounts.spec.ts
+++ b/interface/src/util/amounts.spec.ts
@@ -81,6 +81,19 @@ describe('amounts', () => {
       expect(foo).toBe('$12.34');
     });
 
+    it('will format euro', () => {
+      const euroNetherlands = formatAmount(-1001234, AmountType.Stored, 'nl-NL', 'EUR');
+      expect(euroNetherlands).toBe('€ -10.012,34');
+
+      const euroUK = formatAmount(-1001234, AmountType.Stored, 'en-UK', 'EUR');
+      expect(euroUK).toBe('-€10,012.34');
+    });
+
+    it('US with foreign transaction', () => {
+      const euroNetherlands = formatAmount(-1001234, AmountType.Stored, 'en-US', 'EUR');
+      expect(euroNetherlands).toBe('-€10,012.34');
+    });
+
     it('will format JPY properly', () => {
       const foo = formatAmount(1234, AmountType.Stored, 'ja-JP', 'JPY');
       expect(foo).toMatch(/.1,234/);

--- a/interface/src/util/amounts.ts
+++ b/interface/src/util/amounts.ts
@@ -1,3 +1,25 @@
+
+/**
+ * intlNumberFormat takes a locale and a currency code and returns a ResolvedNumberFormatOptions object containing
+ * information about the currency and how it should be formatted for the current locale.
+ *
+ * **NOTE**: This function will eventually be replaced by a single source of truth for locale information from the
+ * backend.
+ *
+ * @param {string} locale The local code for the current user's perspective. Defaults to `en-US`.
+ * @param {string} currency The ISO currency code of the current the amount is in. Defaults to `USD`.
+ */
+export function intlNumberFormat(locale: string = 'en_US', currency: string = 'USD'): Intl.ResolvedNumberFormatOptions {
+  const localeAdjusted = locale.replace('_', '-');
+  return new Intl.NumberFormat(
+    localeAdjusted,
+    {
+      style: 'currency',
+      currency: currency,
+    },
+  ).resolvedOptions();
+}
+
 /**
  * amountToFriendly takes an amount as it is stored in the API and database and converts it to the amount that is used
  * in the UI. Amounts are stored in their smallest unit. For example; USD is stored in cents. This way the amounts are
@@ -10,14 +32,7 @@
  * @param {string} currency The ISO currency code of the current the amount is in. Defaults to `USD`.
  */
 export function amountToFriendly(amount: number, locale: string = 'en_US', currency: string = 'USD'): number {
-  const localeAdjusted = locale.replace('_', '-');
-  const specs = new Intl.NumberFormat(
-    localeAdjusted,
-    {
-      style: 'currency',
-      currency: currency,
-    },
-  ).resolvedOptions();
+  const specs = intlNumberFormat(locale, currency);
 
   // Determine the multiplier by how many decimal places the final unit would have. For example USD would have 2 decimal
   // places so this would be 10^2 or 100. Where as JPY would have 0 because it is already in the smallest increment.
@@ -41,14 +56,7 @@ export function amountToFriendly(amount: number, locale: string = 'en_US', curre
  * @param {string} currency The ISO currency code of the currency the amount is in. Defaults to `USD`.
  */
 export function friendlyToAmount(friendly: number, locale: string = 'en_US', currency: string = 'USD'): number {
-  const localeAdjusted = locale.replace('_', '-');
-  const specs = new Intl.NumberFormat(
-    localeAdjusted,
-    {
-      style: 'currency',
-      currency: currency,
-    },
-  ).resolvedOptions();
+  const specs = intlNumberFormat(locale, currency);
 
   // Determine the multiplier by how many decimal places the final unit would have. For example USD would have 2 decimal
   // places so this would be 10^2 or 100. Where as JPY would have 0 because it is already in the smallest increment.

--- a/interface/src/util/amounts.ts
+++ b/interface/src/util/amounts.ts
@@ -82,12 +82,15 @@ export enum AmountType {
  *                          then it is likely `AmountType.Friendly`.
  * @param {string} locale The locale code for the current user's perspective. Defaults to `en-US`.
  * @param {string} currency The ISO currency code of the currency the amount is in. Defaults to `USD`.
+ * @param {boolean} signDisplay Whether or not to indicate positive/negative signs on the formatted output. Will not
+ *                              apply a sign to a 0 value. `false` is equivalent to auto.
  */
 export function formatAmount(
   amount: number,
   type: AmountType = AmountType.Stored,
   locale: string = 'en_US',
   currency: string = 'USD',
+  signDisplay: boolean = false,
 ): string {
   const localeAdjusted = locale.replace('_', '-');
   const intl = new Intl.NumberFormat(
@@ -95,6 +98,7 @@ export function formatAmount(
     {
       style: 'currency',
       currency: currency,
+      signDisplay: signDisplay ? 'exceptZero' : 'auto',
     },
   );
 

--- a/server/consts/currency.go
+++ b/server/consts/currency.go
@@ -1,0 +1,12 @@
+package consts
+
+// DefaultCurrencyCode is monetr's default currency code that will be used if an
+// actual currency code cannot be derived from the datasource the transactions
+// or balances are coming from.
+const DefaultCurrencyCode = "USD"
+
+// DefaultLocale is similar to the default currency code, when a locale cannot
+// be determined then we fall back to this. This may also be used if a valid
+// locale is provided to monetr but monetr does not posses the data to use that
+// locale code.
+const DefaultLocale = "en_US"

--- a/server/controller/plaid.go
+++ b/server/controller/plaid.go
@@ -313,8 +313,10 @@ func (c *Controller) updatePlaidTokenCallback(ctx echo.Context) error {
 		}
 
 		// Retrieve the details for those bank accounts from Plaid.
-		// TODO We should just retrieve all the accounts, any that are missing in this list were probably removed during the
-		// account update selection anyway. Don't delete those bank accounts, but mark them as no longer in sync.
+		// TODO We should just retrieve all the accounts, any that are missing in
+		// this list were probably removed during the account update selection
+		// anyway. Don't delete those bank accounts, but mark them as no longer in
+		// sync.
 		plaidAccounts, err := client.GetAccounts(c.getContext(ctx), newBankAccountPlaidIds...)
 		if err != nil {
 			return c.wrapAndReturnError(ctx, err, http.StatusInternalServerError, "failed to retrieve new bank accounts")
@@ -332,6 +334,8 @@ func (c *Controller) updatePlaidTokenCallback(ctx echo.Context) error {
 				Mask:             plaidAccount.GetMask(),
 				AvailableBalance: plaidAccount.GetBalances().GetAvailable(),
 				CurrentBalance:   plaidAccount.GetBalances().GetCurrent(),
+				LimitBalance:     plaidAccount.GetBalances().GetLimit(),
+				Currency:         plaidAccount.GetCurrencyCode(),
 			}
 			if err := repo.CreatePlaidBankAccount(c.getContext(ctx), &plaidBankAccount); err != nil {
 				return c.wrapPgError(ctx, err, "failed to create plaid bank account")
@@ -344,10 +348,12 @@ func (c *Controller) updatePlaidTokenCallback(ctx echo.Context) error {
 				PlaidBankAccount:   &plaidBankAccount,
 				AvailableBalance:   plaidAccount.GetBalances().GetAvailable(),
 				CurrentBalance:     plaidAccount.GetBalances().GetCurrent(),
+				LimitBalance:       plaidAccount.GetBalances().GetLimit(),
 				Name:               plaidAccount.GetName(),
 				Mask:               plaidAccount.GetMask(),
 				Type:               BankAccountType(plaidAccount.GetType()),
 				SubType:            BankAccountSubType(plaidAccount.GetSubType()),
+				Currency:           plaidAccount.GetCurrencyCode(),
 				LastUpdated:        now,
 			}
 		}
@@ -478,6 +484,8 @@ func (c *Controller) postPlaidTokenCallback(ctx echo.Context) error {
 			Mask:             plaidAccount.GetMask(),
 			AvailableBalance: plaidAccount.GetBalances().GetAvailable(),
 			CurrentBalance:   plaidAccount.GetBalances().GetCurrent(),
+			LimitBalance:     plaidAccount.GetBalances().GetLimit(),
+			Currency:         plaidAccount.GetCurrencyCode(),
 		}
 		if err := repo.CreatePlaidBankAccount(
 			c.getContext(ctx),
@@ -491,10 +499,12 @@ func (c *Controller) postPlaidTokenCallback(ctx echo.Context) error {
 			PlaidBankAccountId: &plaidBankAccount.PlaidBankAccountId,
 			AvailableBalance:   plaidAccount.GetBalances().GetAvailable(),
 			CurrentBalance:     plaidAccount.GetBalances().GetCurrent(),
+			LimitBalance:       plaidAccount.GetBalances().GetLimit(),
 			Name:               plaidAccount.GetName(),
 			Mask:               plaidAccount.GetMask(),
 			Type:               BankAccountType(plaidAccount.GetType()),
 			SubType:            BankAccountSubType(plaidAccount.GetSubType()),
+			Currency:           plaidAccount.GetCurrencyCode(),
 			LastUpdated:        now,
 			Status:             ActiveBankAccountStatus,
 		}

--- a/server/migrations/schema/2025011300_BankCurrency.tx.up.sql
+++ b/server/migrations/schema/2025011300_BankCurrency.tx.up.sql
@@ -1,0 +1,33 @@
+ALTER TABLE "bank_accounts" ADD COLUMN "currency" TEXT NOT NULL DEFAULT 'USD';
+ALTER TABLE "plaid_bank_accounts" ADD COLUMN "currency" TEXT NOT NULL DEFAULT 'USD';
+
+DROP VIEW "balances";
+CREATE VIEW balances AS
+ SELECT 
+    bank_account.bank_account_id,
+    bank_account.account_id,
+    bank_account.currency,
+    bank_account.current_balance AS current,
+    bank_account.available_balance AS available,
+    bank_account.limit_balance AS limit,
+    bank_account.available_balance::numeric - sum(COALESCE(expense.current_amount, 0::numeric)) - sum(COALESCE(goal.current_amount, 0::numeric)) AS free,
+    sum(COALESCE(expense.current_amount, 0::numeric)) AS expenses,
+    sum(COALESCE(goal.current_amount, 0::numeric)) AS goals
+   FROM bank_accounts bank_account
+     LEFT JOIN ( 
+       SELECT spending.bank_account_id,
+              spending.account_id,
+              sum(spending.current_amount) AS current_amount
+       FROM spending
+       WHERE spending.spending_type = 0 -- 0 = expenses
+       GROUP BY spending.bank_account_id, spending.account_id
+     ) expense ON expense.bank_account_id = bank_account.bank_account_id AND expense.account_id = bank_account.account_id
+     LEFT JOIN (
+       SELECT spending.bank_account_id,
+              spending.account_id,
+              sum(spending.current_amount) AS current_amount
+       FROM spending
+       WHERE spending.spending_type = 1 -- 1 is goals
+       GROUP BY spending.bank_account_id, spending.account_id
+     ) goal ON goal.bank_account_id = bank_account.bank_account_id AND goal.account_id = bank_account.account_id
+  GROUP BY bank_account.bank_account_id, bank_account.account_id;

--- a/server/migrations/schema/2025011300_BankCurrency.tx.up.sql
+++ b/server/migrations/schema/2025011300_BankCurrency.tx.up.sql
@@ -3,7 +3,7 @@ ALTER TABLE "plaid_bank_accounts" ADD COLUMN "currency" TEXT NOT NULL DEFAULT 'U
 
 DROP VIEW "balances";
 CREATE VIEW balances AS
- SELECT 
+ SELECT
     bank_account.bank_account_id,
     bank_account.account_id,
     bank_account.currency,
@@ -13,21 +13,21 @@ CREATE VIEW balances AS
     bank_account.available_balance::numeric - sum(COALESCE(expense.current_amount, 0::numeric)) - sum(COALESCE(goal.current_amount, 0::numeric)) AS free,
     sum(COALESCE(expense.current_amount, 0::numeric)) AS expenses,
     sum(COALESCE(goal.current_amount, 0::numeric)) AS goals
-   FROM bank_accounts bank_account
-     LEFT JOIN ( 
-       SELECT spending.bank_account_id,
-              spending.account_id,
-              sum(spending.current_amount) AS current_amount
-       FROM spending
-       WHERE spending.spending_type = 0 -- 0 = expenses
-       GROUP BY spending.bank_account_id, spending.account_id
-     ) expense ON expense.bank_account_id = bank_account.bank_account_id AND expense.account_id = bank_account.account_id
-     LEFT JOIN (
-       SELECT spending.bank_account_id,
-              spending.account_id,
-              sum(spending.current_amount) AS current_amount
-       FROM spending
-       WHERE spending.spending_type = 1 -- 1 is goals
-       GROUP BY spending.bank_account_id, spending.account_id
-     ) goal ON goal.bank_account_id = bank_account.bank_account_id AND goal.account_id = bank_account.account_id
-  GROUP BY bank_account.bank_account_id, bank_account.account_id;
+ FROM bank_accounts bank_account
+   LEFT JOIN (
+     SELECT spending.bank_account_id,
+            spending.account_id,
+            sum(spending.current_amount) AS current_amount
+     FROM spending
+     WHERE spending.spending_type = 0 -- 0 = expenses
+     GROUP BY spending.bank_account_id, spending.account_id
+   ) expense ON expense.bank_account_id = bank_account.bank_account_id AND expense.account_id = bank_account.account_id
+   LEFT JOIN (
+     SELECT spending.bank_account_id,
+            spending.account_id,
+            sum(spending.current_amount) AS current_amount
+     FROM spending
+     WHERE spending.spending_type = 1 -- 1 is goals
+     GROUP BY spending.bank_account_id, spending.account_id
+   ) goal ON goal.bank_account_id = bank_account.bank_account_id AND goal.account_id = bank_account.account_id
+GROUP BY bank_account.bank_account_id, bank_account.account_id;

--- a/server/models/bank_account.go
+++ b/server/models/bank_account.go
@@ -109,6 +109,7 @@ type BankAccount struct {
 	Link               *Link                 `json:"-,omitempty" pg:"rel:has-one"`
 	PlaidBankAccountId *ID[PlaidBankAccount] `json:"-" pg:"plaid_bank_account_id"`
 	PlaidBankAccount   *PlaidBankAccount     `json:"plaidBankAccount,omitempty" pg:"rel:has-one"`
+	Currency           string                `json:"currency" pg:"currency,notnull"`
 	AvailableBalance   int64                 `json:"availableBalance" pg:"available_balance,notnull,use_zero"`
 	CurrentBalance     int64                 `json:"currentBalance" pg:"current_balance,notnull,use_zero"`
 	LimitBalance       int64                 `json:"limitBalance" pg:"limit_balance,notnull,use_zero"`

--- a/server/models/plaid_bank_account.go
+++ b/server/models/plaid_bank_account.go
@@ -19,6 +19,7 @@ type PlaidBankAccount struct {
 	Name               string               `json:"name" pg:"name,notnull"`
 	OfficialName       string               `json:"officialName" pg:"official_name"`
 	Mask               string               `json:"mask" pg:"mask"`
+	Currency           string               `json:"currency" pg:"currency,notnull"`
 	AvailableBalance   int64                `json:"availableBalance" pg:"available_balance,notnull,use_zero"`
 	CurrentBalance     int64                `json:"currentBalance" pg:"current_balance,notnull,use_zero"`
 	LimitBalance       int64                `json:"limitBalance" pg:"limit_balance,use_zero"`

--- a/server/repository/balances.go
+++ b/server/repository/balances.go
@@ -14,6 +14,7 @@ type Balances struct {
 
 	BankAccountId ID[BankAccount] `json:"bankAccountId" pg:"bank_account_id"`
 	AccountId     ID[Account]     `json:"-" pg:"account_id"`
+	Currency      string          `json:"currency" pg:"currency"`
 	Current       int64           `json:"current" pg:"current"`
 	Available     int64           `json:"available" pg:"available"`
 	Limit         int64           `json:"limit" pg:"limit"`


### PR DESCRIPTION
This is just some tweaks throughout the app for how we are formatting
currencies. ATM monetr officially only supports USD, but with these
changes its no longer that far off from being able to support whatever
currency someone wants.
