### PR TITLE
fix(api): Allow cookie http only to be configured

### DIFF
--- a/server/config/configuration.go
+++ b/server/config/configuration.go
@@ -366,6 +366,7 @@ func setupDefaults(v *viper.Viper) {
 	v.SetDefault("Server.Cookies.Name", "M-Token")
 	v.SetDefault("Server.Cookies.Secure", true)
 	v.SetDefault("Server.Cookies.SameSiteStrict", true)
+	v.SetDefault("Server.Cookies.HttpOnly", true)
 	v.SetDefault("Server.ListenPort", 4000)
 	v.SetDefault("Server.ListenAddress", "0.0.0.0")
 	v.SetDefault("Server.StatsPort", 9000)

--- a/server/config/server.go
+++ b/server/config/server.go
@@ -21,6 +21,12 @@ type Cookies struct {
 	// host of monetr use HTTPS. If you are not using HTTPS then this must be
 	// disabled for API calls to succeed.
 	Secure bool `yaml:"secure"`
+	// Determines whether or not the cookies issued to clients will be HTTP only
+	// cookies. HTTP only cookies cannot be read by the javascript executed in
+	// client browsers, as such they are slightly more secure. This setting
+	// defaults to true and should only be disabled if you understand what you are
+	// doing and need access to the token in a client side application.
+	HttpOnly bool `yaml:"httpOnly"`
 	// Name defines the name of the cookie to use for authentication. This
 	// defaults to `M-Token` but can be customized if the host wants to.
 	Name string `yaml:"name"`

--- a/server/controller/authentication.go
+++ b/server/controller/authentication.go
@@ -26,7 +26,10 @@ const ClearAuthentication = ""
 // with the API. When this is called with a token that token will be returned to the client in the response as a
 // Set-Cookie header. If a blank token is provided then the cookie is updated to expire immediately and the value of the
 // cookie is set to blank.
-func (c *Controller) updateAuthenticationCookie(ctx echo.Context, token string) {
+func (c *Controller) updateAuthenticationCookie(
+	ctx echo.Context,
+	token string,
+) {
 	sameSite := http.SameSiteDefaultMode
 	if c.Configuration.Server.Cookies.SameSiteStrict {
 		sameSite = http.SameSiteStrictMode
@@ -57,7 +60,7 @@ func (c *Controller) updateAuthenticationCookie(ctx echo.Context, token string) 
 		Expires:  expiration,
 		MaxAge:   0,
 		Secure:   c.Configuration.Server.GetIsCookieSecure(),
-		HttpOnly: true,
+		HttpOnly: c.Configuration.Server.Cookies.HttpOnly,
 		SameSite: sameSite,
 	})
 }


### PR DESCRIPTION
Allow whether or not the cookie is issued as HttpOnly to be configured.
This will allow clients to use the authentication token issued by monetr
for other API requests until a proper API key solution has been built.

Resolves #2320
