### PR TITLE
fix(plaid): Allow for larger transactions from Plaid

### DIFF
--- a/server/migrations/schema/2025011700_LongerTransactions.tx.up.sql
+++ b/server/migrations/schema/2025011700_LongerTransactions.tx.up.sql
@@ -1,6 +1,6 @@
-ALTER TABLE "plaid_transactions" ALTER COLUMN "name" SET DATA TYPE VARCHAR(300);
-ALTER TABLE "plaid_transactions" ALTER COLUMN "merchant_name" SET DATA TYPE VARCHAR(300);
-ALTER TABLE "transactions" ALTER COLUMN "name" SET DATA TYPE VARCHAR(300);
-ALTER TABLE "transactions" ALTER COLUMN "original_name" SET DATA TYPE VARCHAR(300);
-ALTER TABLE "transactions" ALTER COLUMN "merchant_name" SET DATA TYPE VARCHAR(300);
-ALTER TABLE "transactions" ALTER COLUMN "original_merchant_name" SET DATA TYPE VARCHAR(300);
+ALTER TABLE "plaid_transactions" ALTER COLUMN "name" SET DATA TYPE TEXT;
+ALTER TABLE "plaid_transactions" ALTER COLUMN "merchant_name" SET DATA TYPE TEXT;
+ALTER TABLE "transactions" ALTER COLUMN "name" SET DATA TYPE TEXT;
+ALTER TABLE "transactions" ALTER COLUMN "original_name" SET DATA TYPE TEXT;
+ALTER TABLE "transactions" ALTER COLUMN "merchant_name" SET DATA TYPE TEXT;
+ALTER TABLE "transactions" ALTER COLUMN "original_merchant_name" SET DATA TYPE TEXT;

--- a/server/migrations/schema/2025011700_LongerTransactions.tx.up.sql
+++ b/server/migrations/schema/2025011700_LongerTransactions.tx.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "plaid_transactions" ALTER COLUMN "name" SET DATA TYPE VARCHAR(300);
+ALTER TABLE "plaid_transactions" ALTER COLUMN "merchant_name" SET DATA TYPE VARCHAR(300);
+ALTER TABLE "transactions" ALTER COLUMN "name" SET DATA TYPE VARCHAR(300);
+ALTER TABLE "transactions" ALTER COLUMN "original_name" SET DATA TYPE VARCHAR(300);
+ALTER TABLE "transactions" ALTER COLUMN "merchant_name" SET DATA TYPE VARCHAR(300);
+ALTER TABLE "transactions" ALTER COLUMN "original_merchant_name" SET DATA TYPE VARCHAR(300);


### PR DESCRIPTION
I had limited data to only being 200 characters long, but some
transaction memo's from Plaid can be over 200 characters so I'm bumping
the limit to 300 instead. Maybe I should just use TEXT?

Resolves #2324
