### PR TITLE
fix(locale): Don't prevent sign ups for uknown locales

### DIFF
--- a/server/controller/authentication.go
+++ b/server/controller/authentication.go
@@ -12,6 +12,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/labstack/echo/v4"
 	"github.com/monetr/monetr/server/communication"
+	"github.com/monetr/monetr/server/consts"
 	"github.com/monetr/monetr/server/crumbs"
 	"github.com/monetr/monetr/server/models"
 	"github.com/monetr/monetr/server/repository"
@@ -357,8 +358,8 @@ func (c *Controller) postRegister(ctx echo.Context) error {
 	if _, err := locale.GetLConv(registerRequest.Locale); err != nil {
 		log.WithFields(logrus.Fields{
 			"locale": registerRequest.Locale,
-		}).WithError(err).Warn("invalid locale in register request")
-		return c.badRequest(ctx, "Invalid or unrecognized locale")
+		}).WithError(err).Warn("invalid locale in register request, falling back to global default")
+		registerRequest.Locale = consts.DefaultLocale
 	}
 
 	if err := c.validateRegistration(


### PR DESCRIPTION
I had assumed that locale codes from browsers would match the format
that I was using on the server side, but it seems that is not always the
case. So I've changed the code to fall back to a known good default for
the mean time.

Resolves #2335
