### PR TITLE
fix(test): Fix documentation tests in CI

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -113,7 +113,7 @@ if(BUILD_TESTING)
   )
 
   set(HYPERLINK_GITHUB_ARGS "--check-anchors" "--sources" "${CMAKE_SOURCE_DIR}/docs/src/pages")
-  if(DEFINED ENV{CI})
+  if(NOT "$ENV{CI}" STREQUAL "")
     list(APPEND HYPERLINK_GITHUB_ARGS "--github-actions")
   endif()
   add_test(

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -114,7 +114,7 @@ if(BUILD_TESTING)
 
   set(HYPERLINK_GITHUB_ARGS "--check-anchors" "--sources" "${CMAKE_SOURCE_DIR}/docs/src/pages")
   if(DEFINED ENV{CI})
-    set(HYPERLINK_GITHUB_ARGS "--github-actions")
+    list(APPEND HYPERLINK_GITHUB_ARGS "--github-actions")
   endif()
   add_test(
     NAME docs/check-links


### PR DESCRIPTION
The cmake tests for documentation were incorrectly appening the flags.

Resolves #2351
