### PR TITLE
fix(api): Detect AVX and AVX512F instruction sets using runtime

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/gomodule/redigo v1.9.2
 	github.com/google/uuid v1.6.0
 	github.com/jarcoal/httpmock v1.3.1
-	github.com/klauspost/cpuid/v2 v2.2.9
 	github.com/labstack/echo/v4 v4.13.3
 	github.com/mileusna/useragent v1.3.5
 	github.com/monetr/validation v1.0.2
@@ -163,7 +162,7 @@ require (
 	golang.org/x/net v0.34.0
 	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
-	golang.org/x/sys v0.29.0 // indirect
+	golang.org/x/sys v0.29.0
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.8.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241118233622-e639e219e697 // indirect

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.1
 	github.com/gomodule/redigo v1.9.2
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/vault/api v1.15.0
 	github.com/jarcoal/httpmock v1.3.1
 	github.com/labstack/echo/v4 v4.13.3
 	github.com/mileusna/useragent v1.3.5
@@ -33,6 +34,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/plaid/plaid-go/v30 v30.0.0
 	github.com/prometheus/client_golang v1.20.5
+	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
@@ -42,7 +44,10 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	github.com/wneessen/go-mail v0.4.4
 	github.com/xlzd/gotp v0.1.0
+	go.uber.org/mock v0.5.0
 	golang.org/x/crypto v0.32.0
+	golang.org/x/net v0.34.0
+	golang.org/x/sys v0.29.0
 	google.golang.org/api v0.211.0
 	google.golang.org/genproto v0.0.0-20241118233622-e639e219e697
 	google.golang.org/protobuf v1.35.2
@@ -50,60 +55,36 @@ require (
 )
 
 require (
+	aidanwoods.dev/go-result v0.1.0 // indirect
 	cel.dev/expr v0.16.1 // indirect
 	cloud.google.com/go v0.116.0 // indirect
 	cloud.google.com/go/auth v0.12.1 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.6 // indirect
+	cloud.google.com/go/compute/metadata v0.5.2 // indirect
+	cloud.google.com/go/iam v1.2.2 // indirect
 	cloud.google.com/go/longrunning v0.6.2 // indirect
 	cloud.google.com/go/monitoring v1.21.2 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.24.1 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.48.1 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.1 // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
-	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect
-	github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78 // indirect
-	github.com/envoyproxy/go-control-plane v0.13.0 // indirect
-	github.com/envoyproxy/protoc-gen-validate v1.1.0 // indirect
-	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/go-jose/go-jose/v4 v4.0.1 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
-	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
-	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
-	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 // indirect
-	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
-	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
-	github.com/ryanuber/go-glob v1.0.0 // indirect
-	go.opentelemetry.io/contrib/detectors/gcp v1.29.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.54.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.54.0 // indirect
-	go.opentelemetry.io/otel v1.29.0 // indirect
-	go.opentelemetry.io/otel/metric v1.29.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.29.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.29.0 // indirect
-	go.opentelemetry.io/otel/trace v1.29.0 // indirect
-	google.golang.org/grpc/stats/opentelemetry v0.0.0-20240907200651-3ffb98b2c93a // indirect
-)
-
-require (
-	aidanwoods.dev/go-result v0.1.0 // indirect
-	cloud.google.com/go/compute/metadata v0.5.2 // indirect
-	cloud.google.com/go/iam v1.2.2 // indirect
 	github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2 // indirect
 	github.com/ajg/form v1.5.1 // indirect
 	github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 // indirect
 	github.com/andybalholm/brotli v1.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/envoyproxy/go-control-plane v0.13.0 // indirect
+	github.com/envoyproxy/protoc-gen-validate v1.1.0 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/go-jose/go-jose/v4 v4.0.1 // indirect
+	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-pg/zerochecker v0.2.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
@@ -112,8 +93,15 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
+	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
+	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 // indirect
+	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
+	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/hashicorp/vault/api v1.15.0
 	github.com/imkira/go-interpol v1.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
@@ -123,14 +111,17 @@ require (
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
-	github.com/robfig/cron v1.2.0
+	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sanity-io/litter v1.5.5 // indirect
@@ -155,19 +146,25 @@ require (
 	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
+	go.opentelemetry.io/contrib/detectors/gcp v1.29.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.54.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.54.0 // indirect
+	go.opentelemetry.io/otel v1.29.0 // indirect
+	go.opentelemetry.io/otel/metric v1.29.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.29.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.29.0 // indirect
+	go.opentelemetry.io/otel/trace v1.29.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	go.uber.org/mock v0.5.0
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 // indirect
-	golang.org/x/net v0.34.0
 	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
-	golang.org/x/sys v0.29.0
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.8.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241118233622-e639e219e697 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241206012308-a4fef0638583 // indirect
 	google.golang.org/grpc v1.67.2 // indirect
+	google.golang.org/grpc/stats/opentelemetry v0.0.0-20240907200651-3ffb98b2c93a // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	mellium.im/sasl v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -360,8 +360,6 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
-github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kKGuY=
-github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK4QwQ3WMXF8=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=

--- a/server/cmd/version.go
+++ b/server/cmd/version.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 
 	locale "github.com/elliotcourant/go-lclocale"
-	"github.com/klauspost/cpuid/v2"
 	"github.com/monetr/monetr/server/build"
 	"github.com/monetr/monetr/server/icons"
 	"github.com/monetr/monetr/server/ui"
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/cpu"
 )
 
 type versionCommand struct {
@@ -58,9 +58,9 @@ func newVersionCommand(parent *cobra.Command) {
 			}
 
 			simd := "N/A"
-			if cpuid.CPU.Supports(cpuid.AVX512F) {
+			if cpu.X86.HasAVX512F {
 				simd = "AVX512"
-			} else if cpuid.CPU.Supports(cpuid.AVX) {
+			} else if cpu.X86.HasAVX {
 				simd = "AVX"
 			}
 

--- a/server/internal/calc/euclidean_amd64.go
+++ b/server/internal/calc/euclidean_amd64.go
@@ -2,7 +2,9 @@
 
 package calc
 
-import "github.com/klauspost/cpuid/v2"
+import (
+	"golang.org/x/sys/cpu"
+)
 
 //go:noescape
 func __euclideanDistance64_AVX(a, b []float64) float64
@@ -17,10 +19,10 @@ func __euclideanDistance64_AVX512(a, b []float64) float64
 func __euclideanDistance32_AVX512(a, b []float32) float32
 
 func init() {
-	if cpuid.CPU.Supports(cpuid.AVX512F) {
+	if cpu.X86.HasAVX512F {
 		euclideanImplementation64 = __euclideanDistance64_AVX512
 		euclideanImplementation32 = __euclideanDistance32_AVX512
-	} else if cpuid.CPU.Supports(cpuid.AVX) {
+	} else if cpu.X86.HasAVX {
 		euclideanImplementation64 = __euclideanDistance64_AVX
 		euclideanImplementation32 = __euclideanDistance32_AVX
 	}

--- a/server/internal/calc/euclidean_amd64_test.go
+++ b/server/internal/calc/euclidean_amd64_test.go
@@ -7,12 +7,12 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/klauspost/cpuid/v2"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/cpu"
 )
 
 func BenchmarkEuclideanDistance64_AVX(bench *testing.B) {
-	if !cpuid.CPU.Has(cpuid.AVX) {
+	if !cpu.X86.HasAVX {
 		bench.Skip("host does not support AVX")
 	}
 
@@ -47,7 +47,7 @@ func BenchmarkEuclideanDistance64_AVX(bench *testing.B) {
 }
 
 func BenchmarkEuclideanDistance32_AVX(bench *testing.B) {
-	if !cpuid.CPU.Has(cpuid.AVX) {
+	if !cpu.X86.HasAVX {
 		bench.Skip("host does not support AVX")
 	}
 
@@ -82,7 +82,7 @@ func BenchmarkEuclideanDistance32_AVX(bench *testing.B) {
 }
 
 func BenchmarkEuclideanDistance64_AVX512(bench *testing.B) {
-	if !cpuid.CPU.Has(cpuid.AVX512F) {
+	if !cpu.X86.HasAVX512F {
 		bench.Skip("host does not support AVX512")
 	}
 
@@ -117,7 +117,7 @@ func BenchmarkEuclideanDistance64_AVX512(bench *testing.B) {
 }
 
 func BenchmarkEuclideanDistance32_AVX512(bench *testing.B) {
-	if !cpuid.CPU.Has(cpuid.AVX512F) {
+	if !cpu.X86.HasAVX512F {
 		bench.Skip("host does not support AVX512")
 	}
 
@@ -152,7 +152,7 @@ func BenchmarkEuclideanDistance32_AVX512(bench *testing.B) {
 }
 
 func TestEuclideanDistance64_AVX(t *testing.T) {
-	if !cpuid.CPU.Has(cpuid.AVX) {
+	if !cpu.X86.HasAVX {
 		t.Skip("host does not support AVX")
 	}
 
@@ -170,7 +170,7 @@ func TestEuclideanDistance64_AVX(t *testing.T) {
 }
 
 func TestEuclideanDistance32_AVX(t *testing.T) {
-	if !cpuid.CPU.Has(cpuid.AVX) {
+	if !cpu.X86.HasAVX {
 		t.Skip("host does not support AVX")
 	}
 
@@ -235,7 +235,7 @@ func TestEuclideanDistance32_AVX(t *testing.T) {
 }
 
 func TestEuclideanDistance64_AVX512(t *testing.T) {
-	if !cpuid.CPU.Has(cpuid.AVX512F) {
+	if !cpu.X86.HasAVX512F {
 		t.Skip("host does not support AVX512")
 	}
 
@@ -253,7 +253,7 @@ func TestEuclideanDistance64_AVX512(t *testing.T) {
 }
 
 func TestEuclideanDistance32_AVX512(t *testing.T) {
-	if !cpuid.CPU.Has(cpuid.AVX512F) {
+	if !cpu.X86.HasAVX512F {
 		t.Skip("host does not support AVX")
 	}
 

--- a/server/internal/calc/vector_amd64.go
+++ b/server/internal/calc/vector_amd64.go
@@ -2,7 +2,7 @@
 
 package calc
 
-import "github.com/klauspost/cpuid/v2"
+import "golang.org/x/sys/cpu"
 
 //go:noescape
 func __normalizeVector64_AVX(input []float64)
@@ -17,10 +17,10 @@ func __normalizeVector32_AVX(input []float32)
 func __normalizeVector32_AVX512(input []float32)
 
 func init() {
-	if cpuid.CPU.Supports(cpuid.AVX512F) {
+	if cpu.X86.HasAVX512F {
 		normalizeVectorImplementation64 = __normalizeVector64_AVX512
 		normalizeVectorImplementation32 = __normalizeVector32_AVX512
-	} else if cpuid.CPU.Supports(cpuid.AVX) {
+	} else if cpu.X86.HasAVX {
 		normalizeVectorImplementation64 = __normalizeVector64_AVX
 		normalizeVectorImplementation32 = __normalizeVector32_AVX
 	}

--- a/server/internal/calc/vector_amd64_test.go
+++ b/server/internal/calc/vector_amd64_test.go
@@ -7,12 +7,12 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/klauspost/cpuid/v2"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/cpu"
 )
 
 func TestNormalizeVector64_AVX(t *testing.T) {
-	if !cpuid.CPU.Has(cpuid.AVX) {
+	if !cpu.X86.HasAVX {
 		t.Skip("host does not support AVX")
 	}
 
@@ -84,7 +84,7 @@ func TestNormalizeVector64_AVX(t *testing.T) {
 }
 
 func TestNormalizeVector64_AVX512(t *testing.T) {
-	if !cpuid.CPU.Has(cpuid.AVX512F) {
+	if !cpu.X86.HasAVX512F {
 		t.Skip("host does not support AVX512")
 	}
 
@@ -156,7 +156,7 @@ func TestNormalizeVector64_AVX512(t *testing.T) {
 }
 
 func TestNormalizeVector32_AVX(t *testing.T) {
-	if !cpuid.CPU.Has(cpuid.AVX) {
+	if !cpu.X86.HasAVX {
 		t.Skip("host does not support AVX")
 	}
 
@@ -228,7 +228,7 @@ func TestNormalizeVector32_AVX(t *testing.T) {
 }
 
 func TestNormalizeVector32_AVX512(t *testing.T) {
-	if !cpuid.CPU.Has(cpuid.AVX512F) {
+	if !cpu.X86.HasAVX512F {
 		t.Skip("host does not support AVX512")
 	}
 
@@ -308,7 +308,7 @@ func TestNormalizeVector32_AVX512(t *testing.T) {
 }
 
 func BenchmarkNormalizeVector64_AVX(bench *testing.B) {
-	if !cpuid.CPU.Has(cpuid.AVX) {
+	if !cpu.X86.HasAVX {
 		bench.Skip("host does not support AVX")
 	}
 
@@ -341,7 +341,7 @@ func BenchmarkNormalizeVector64_AVX(bench *testing.B) {
 }
 
 func BenchmarkNormalizeVector64_AVX512(bench *testing.B) {
-	if !cpuid.CPU.Has(cpuid.AVX512F) {
+	if !cpu.X86.HasAVX512F {
 		bench.Skip("host does not support AVX512")
 	}
 
@@ -374,7 +374,7 @@ func BenchmarkNormalizeVector64_AVX512(bench *testing.B) {
 }
 
 func BenchmarkNormalizeVector32_AVX(bench *testing.B) {
-	if !cpuid.CPU.Has(cpuid.AVX) {
+	if !cpu.X86.HasAVX {
 		bench.Skip("host does not support AVX")
 	}
 
@@ -407,7 +407,7 @@ func BenchmarkNormalizeVector32_AVX(bench *testing.B) {
 }
 
 func BenchmarkNormalizeVector32_AVX512(bench *testing.B) {
-	if !cpuid.CPU.Has(cpuid.AVX512F) {
+	if !cpu.X86.HasAVX512F {
 		bench.Skip("host does not support AVX512")
 	}
 


### PR DESCRIPTION
Instead of using the CPUID package, use the x/sys/cpu package provided
by golang's authors. This package was already being used anyway so this
change also removes a dependency and doesn't technically add one.

Resolves #2332
