### PR TITLE
fix(api): Fix not handling long passwords

### DIFF
--- a/interface/src/pages/register.tsx
+++ b/interface/src/pages/register.tsx
@@ -66,6 +66,10 @@ function validator(values: RegisterValues): FormikErrors<RegisterValues> {
     errors['confirmPassword'] = 'Password confirmation must match.';
   }
 
+  if (values?.password.length > 71) {
+    errors['password'] = 'Password is too long, must be less than 72 characters.';
+  }
+
   return errors;
 }
 

--- a/server/controller/authentication.go
+++ b/server/controller/authentication.go
@@ -344,9 +344,12 @@ func (c *Controller) postRegister(ctx echo.Context) error {
 	log := c.getLog(ctx)
 
 	registerRequest.Email = strings.TrimSpace(registerRequest.Email)
-	registerRequest.Password = strings.TrimSpace(registerRequest.Password)
 	registerRequest.FirstName = strings.TrimSpace(registerRequest.FirstName)
 	registerRequest.Locale = strings.TrimSpace(registerRequest.Locale)
+	registerRequest.Password = strings.TrimSpace(registerRequest.Password)
+	if len(registerRequest.Password) > 71 {
+		return c.badRequest(ctx, "Password must be less than 72 characters")
+	}
 	if registerRequest.BetaCode != nil {
 		*registerRequest.BetaCode = strings.TrimSpace(*registerRequest.BetaCode)
 	}


### PR DESCRIPTION
If a password is provided that is longer than 72 bytes then bcrypt wont
be able to handle it. This might be another indicator to start looking
into argon2 instead, but idk what it's limitations are.

In the mean time, return a proper error for this situation as well as
validate the input on the frontend.

Resolves #2367
