### PR TITLE
feat(api): Improving transaction similarity API experience

### DIFF
--- a/server/migrations/schema/2025020900_ClusterConsistency.tx.up.sql
+++ b/server/migrations/schema/2025020900_ClusterConsistency.tx.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "transaction_clusters" ADD COLUMN "signature" TEXT;

--- a/server/models/transaction_cluster.go
+++ b/server/models/transaction_cluster.go
@@ -15,6 +15,7 @@ type TransactionCluster struct {
 	Account              *Account               `json:"-" pg:"rel:has-one"`
 	BankAccountId        ID[BankAccount]        `json:"bankAccountId" pg:"bank_account_id,notnull"`
 	BankAccount          *BankAccount           `json:"-" pg:"rel:has-one"`
+	Signature            string                 `json:"signature" pg:"signature"`
 	Name                 string                 `json:"name" pg:"name,notnull"`
 	Members              []ID[Transaction]      `json:"members" pg:"members,notnull,type:'varchar(32)[]'"`
 	CreatedAt            time.Time              `json:"createdAt" pg:"created_at,notnull,default:now()"`

--- a/server/recurring/dbscan_test.go
+++ b/server/recurring/dbscan_test.go
@@ -82,7 +82,7 @@ func TestPreProcessor(t *testing.T) {
 			item := dbscan.dataset[index]
 			output[i] = append(output[i], Presentation{
 				ID:        item.ID,
-				Sanitized: strings.Join(item.Parts, " "),
+				Sanitized: strings.Join(item.UpperParts, " "),
 				Original:  strings.TrimSpace(item.Transaction.OriginalName + " " + item.Transaction.OriginalMerchantName),
 			})
 		}

--- a/server/recurring/recurring_test.go
+++ b/server/recurring/recurring_test.go
@@ -4,17 +4,24 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/benbjohnson/clock"
+	"github.com/monetr/monetr/server/internal/testutils"
+	"github.com/monetr/monetr/server/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRecurringDetection(t *testing.T) {
 	t.Run("amazon sample data", func(t *testing.T) {
+		clock := clock.NewMock()
+		clock.Set(time.Date(2023, 12, 1, 9, 0, 0, 0, time.UTC))
 		data := GetFixtures(t, "amazon_sample_data_1.json")
 
-		result, err := DetectRecurringTransactions(context.Background(), data)
+		result, err := DetectRecurringTransactions(context.Background(), clock, data)
 		assert.NoError(t, err)
 
 		j, err := json.MarshalIndent(result, "", "    ")
@@ -24,9 +31,11 @@ func TestRecurringDetection(t *testing.T) {
 	})
 
 	t.Run("freshbooks sample data", func(t *testing.T) {
+		clock := clock.NewMock()
+		clock.Set(time.Date(2022, 3, 1, 9, 0, 0, 0, time.UTC))
 		data := GetFixtures(t, "monetr_freshbooks_data_1.json")
 
-		result, err := DetectRecurringTransactions(context.Background(), data)
+		result, err := DetectRecurringTransactions(context.Background(), clock, data)
 		assert.NoError(t, err)
 
 		j, err := json.MarshalIndent(result, "", "    ")
@@ -35,5 +44,68 @@ func TestRecurringDetection(t *testing.T) {
 		fmt.Println(string(j))
 
 		assert.EqualValues(t, 30, result.Best.Frequency, "should recurr every 30 days")
+	})
+
+	t.Run("larger sample data", func(t *testing.T) {
+		clock := clock.NewMock()
+		clock.Set(time.Date(2023, 12, 1, 9, 0, 0, 0, time.UTC))
+		// First build out several transaction clusters
+		data := GetFixtures(t, "monetr_sample_data_1.json")
+		log := testutils.GetLog(t)
+
+		detector := NewSimilarTransactions_TFIDF_DBSCAN()
+
+		for i := range data {
+			detector.AddTransaction(&data[i])
+		}
+
+		groups := detector.DetectSimilarTransactions(context.Background())
+		assert.NotEmpty(t, groups, "must return an array of groups of similar transactions")
+		for _, group := range groups {
+			if len(group.Members) < 3 {
+				continue
+			}
+
+			assert.NotEmpty(t, group.Members, "a groups matches should not be empty!")
+			assert.NotEmpty(t, group.Name, "a groups name should not be empty!")
+			assert.NotEmpty(t, group.Signature, "a groups signature should not be empty!")
+
+			transactions := make([]models.Transaction, 0, len(group.Members))
+		MemberLoop:
+			for _, memberId := range group.Members {
+				for i := range data {
+					transaction := data[i]
+					if transaction.TransactionId == memberId {
+						transactions = append(transactions, transaction)
+						continue MemberLoop
+					}
+				}
+			}
+
+			recurringResult, err := DetectRecurringTransactions(context.Background(), clock, transactions)
+			assert.NoError(t, err)
+
+			if recurringResult.Best == nil || recurringResult.Best.StartDate.IsZero() {
+				log.Infof("cluster: \"%s\" does not recur", group.Name)
+				continue
+			}
+
+			log.Infof("cluster: \"%s\" does recur roughly every %d days", group.Name, recurringResult.Best.Frequency)
+
+			switch strings.ToLower(group.Name) {
+			case "freshbooks":
+				// Should recur monthly
+				assert.Contains(t, []int{30, 31}, recurringResult.Best.Frequency)
+			case "github inc":
+				// Should recur monthly
+				assert.Contains(t, []int{30, 31}, recurringResult.Best.Frequency)
+			case "sentry":
+				// Should recur monthly
+				assert.Contains(t, []int{30, 31}, recurringResult.Best.Frequency)
+			case "treasury courant elliot":
+				// Should recur twice a month
+				assert.Contains(t, []int{15, 16}, recurringResult.Best.Frequency)
+			}
+		}
 	})
 }

--- a/server/recurring/similar.go
+++ b/server/recurring/similar.go
@@ -119,8 +119,8 @@ func (s *SimilarTransactions_TFIDF_DBSCAN) DetectSimilarTransactions(
 		})
 
 		consistentId := sha512.New()
-		slug := make([]string, 0, 5)
-		for _, valuableWord := range mostValuableIndicies[0:5] {
+		slug := make([]string, 0, 3)
+		for _, valuableWord := range mostValuableIndicies[0:cap(slug)] {
 			if valuableWord.Value == 0 {
 				continue
 			}

--- a/server/recurring/similar_test.go
+++ b/server/recurring/similar_test.go
@@ -2,6 +2,8 @@ package recurring
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,8 +24,11 @@ func TestSimilarTransactions_TFIDF_DBSCAN(t *testing.T) {
 		for _, group := range groups {
 			assert.NotEmpty(t, group.Members, "a groups matches should not be empty!")
 			assert.NotEmpty(t, group.Name, "a groups name should not be empty!")
+			assert.NotEmpty(t, group.Signature, "a groups signature should not be empty!")
 		}
 		// TODO, add specific assertions here about what the groups are.
+		j, _ := json.MarshalIndent(groups, "", "  ")
+		fmt.Println(string(j))
 	})
 
 	t.Run("amazon dataset", func(t *testing.T) {


### PR DESCRIPTION
This work definitly hurts the efficiency of the transaction cluster
calculation, I think I can improve some of that later on. But in the
mean time this should provide a really good starting point for providing
consistent identifiers for transaction clusters. Specifically, the
cluster calculation now generates a signature based on the top 5 most
valuable words in the cluster that have a value greater than 0. This way
words that push the clusters closer together will end up making up the
signature. The most valuable words of those should be consistent. I
might need to reduce the number of words to consider down to something
like 2 though.
