### PR TITLE
fix(ui): Use account timezone if available instead of browser timezone

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -259,6 +259,7 @@
                 "^@tanstack",
                 "^@testing-library",
                 "^axios",
+                "^@date-fns",
                 "^date-fns",
                 "^formik",
                 "^history",

--- a/interface/package.json
+++ b/interface/package.json
@@ -22,6 +22,7 @@
     ]
   },
   "dependencies": {
+    "@date-fns/tz": "1.2.0",
     "@ebay/nice-modal-react": "1.2.13",
     "@fontsource-variable/inter": "5.2.5",
     "@mui/icons-material": "5.11.0",

--- a/interface/src/components/MDatePicker.tsx
+++ b/interface/src/components/MDatePicker.tsx
@@ -11,7 +11,10 @@ import { ReactElement } from './types';
 import { Button } from '@monetr/interface/components/Button';
 import { Calendar } from '@monetr/interface/components/Calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '@monetr/interface/components/Popover';
+import useTimezone from '@monetr/interface/hooks/useTimezone';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
+
+import { tz } from '@date-fns/tz';
 
 export interface MDatePickerProps extends
   Omit<React.HTMLAttributes<HTMLButtonElement>, 'value' | 'defaultValue'>
@@ -32,7 +35,10 @@ export interface MDatePickerProps extends
 }
 
 export default function MDatePicker(props: MDatePickerProps): JSX.Element {
-  const today = startOfToday();
+  const { data: timezone } = useTimezone();
+  const today = startOfToday({
+    in: tz(timezone),
+  });
   const formikContext = useFormikContext();
 
   const getFormikError = () => {
@@ -78,7 +84,9 @@ export default function MDatePicker(props: MDatePickerProps): JSX.Element {
     ? formatSelectedDates(selectedValue, undefined, enUS)
     : placeholder;
 
-  const defaultMonth = startOfMonth(selectedValue ?? maxDate ?? today);
+  const defaultMonth = startOfMonth(selectedValue ?? maxDate ?? today, {
+    in: tz(timezone),
+  });
   const isClearEnabled = enableClear && !disabled;
 
   const handleClick = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {

--- a/interface/src/components/MDatePicker.tsx
+++ b/interface/src/components/MDatePicker.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable max-len */
 
 import React, { useCallback, useMemo, useState } from 'react';
+import { tz } from '@date-fns/tz';
 import { isEqual, Locale, startOfMonth, startOfToday } from 'date-fns';
 import { enUS } from 'date-fns/locale/en-US';
 import { useFormikContext } from 'formik';
@@ -13,8 +14,6 @@ import { Calendar } from '@monetr/interface/components/Calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '@monetr/interface/components/Popover';
 import useTimezone from '@monetr/interface/hooks/useTimezone';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
-
-import { tz } from '@date-fns/tz';
 
 export interface MDatePickerProps extends
   Omit<React.HTMLAttributes<HTMLButtonElement>, 'value' | 'defaultValue'>

--- a/interface/src/components/MSelectFrequency.tsx
+++ b/interface/src/components/MSelectFrequency.tsx
@@ -3,6 +3,7 @@ import { ActionMeta, OnChangeValue } from 'react-select';
 import { useFormikContext } from 'formik';
 
 import MSelect, { MSelectProps } from './MSelect';
+import useTimezone from '@monetr/interface/hooks/useTimezone';
 
 import getRecurrencesForDate from './Recurrence/getRecurrencesForDate';
 import Recurrence from './Recurrence/Recurrence';
@@ -14,12 +15,13 @@ export interface MSelectFrequencyProps extends MSelectProps<Recurrence> {
 }
 
 export default function MSelectFrequency(props: MSelectFrequencyProps): JSX.Element {
+  const { data: timezone } = useTimezone();
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const formikContext = useFormikContext();
 
   const date = formikContext.values[props.dateFrom];
 
-  const rules = getRecurrencesForDate(date);
+  const rules = getRecurrencesForDate(date, timezone);
 
   // Every time the date input changes we need to rebuild the list of recurrences. When this happens we should also try
   // to find a recurrence that matches our current rule. This happens when we have a rule like the 15,-1 and the current

--- a/interface/src/components/Recurrence/getRecurrencesForDate.ts
+++ b/interface/src/components/Recurrence/getRecurrencesForDate.ts
@@ -4,17 +4,24 @@ import { endOfMonth, format, getDate, getMonth, isEqual, startOfDay, startOfMont
 import Recurrence from '@monetr/interface/components/Recurrence/Recurrence';
 import parseDate from '@monetr/interface/util/parseDate';
 
+import { tz } from '@date-fns/tz';
 import { RRule, Weekday } from 'rrule';
 
-export default function getRecurrencesForDate(inputDate: Date | string | null): Array<Recurrence> {
+export default function getRecurrencesForDate(inputDate: Date | string | null, timezone: string): Array<Recurrence> {
   const date = parseDate(inputDate);
   if (!date) {
     return [];
   }
 
-  const input = startOfDay(date);
-  const endOfMonthDate = startOfDay(endOfMonth(input));
-  const startOfMonthDate = startOfDay(startOfMonth(input));
+  const input = startOfDay(date, {
+    in: tz(timezone),
+  });
+  const endOfMonthDate = startOfDay(endOfMonth(input), {
+    in: tz(timezone),
+  });
+  const startOfMonthDate = startOfDay(startOfMonth(input), {
+    in: tz(timezone),
+  });
   const isStartOfMonth = isEqual(input, startOfMonthDate);
   const isEndOfMonth = isEqual(input, endOfMonthDate);
 

--- a/interface/src/components/Recurrence/getRecurrencesForDate.ts
+++ b/interface/src/components/Recurrence/getRecurrencesForDate.ts
@@ -1,10 +1,10 @@
 /* eslint-disable id-length */
+import { tz } from '@date-fns/tz';
 import { endOfMonth, format, getDate, getMonth, isEqual, startOfDay, startOfMonth } from 'date-fns';
 
 import Recurrence from '@monetr/interface/components/Recurrence/Recurrence';
 import parseDate from '@monetr/interface/util/parseDate';
 
-import { tz } from '@date-fns/tz';
 import { RRule, Weekday } from 'rrule';
 
 export default function getRecurrencesForDate(inputDate: Date | string | null, timezone: string): Array<Recurrence> {

--- a/interface/src/components/setup/manual/ManualLinkSetupIncome.tsx
+++ b/interface/src/components/setup/manual/ManualLinkSetupIncome.tsx
@@ -15,8 +15,11 @@ import { useCreateBankAccount } from '@monetr/interface/hooks/bankAccounts';
 import { useCreateFundingSchedule } from '@monetr/interface/hooks/fundingSchedules';
 import { useCreateLink } from '@monetr/interface/hooks/links';
 import useLocaleCurrency from '@monetr/interface/hooks/useLocaleCurrency';
+import useTimezone from '@monetr/interface/hooks/useTimezone';
 import { BankAccountSubType, BankAccountType } from '@monetr/interface/models/BankAccount';
 import FundingSchedule from '@monetr/interface/models/FundingSchedule';
+
+import { tz } from '@date-fns/tz';
 
 interface Values {
   nextPayday: Date;
@@ -25,6 +28,7 @@ interface Values {
 }
 
 export default function ManualLinkSetupIncome(): JSX.Element {
+  const { data: timezone } = useTimezone();
   const { data: locale } = useLocaleCurrency();
   const createLink = useCreateLink();
   const createBankAccount = useCreateBankAccount();
@@ -32,7 +36,9 @@ export default function ManualLinkSetupIncome(): JSX.Element {
   const navigate = useNavigate();
   const viewContext = useViewContext<ManualLinkSetupSteps, {}>();
   const initialValues: Values = {
-    nextPayday: startOfTomorrow(),
+    nextPayday: startOfTomorrow({
+      in: tz(timezone),
+    }),
     ruleset: '',
     paydayAmount: 0.00,
     ...viewContext.formData,
@@ -60,7 +66,9 @@ export default function ManualLinkSetupIncome(): JSX.Element {
       .then(bankAccount => createFundingSchedule(new FundingSchedule({
         bankAccountId: bankAccount.bankAccountId,
         name: 'Payday',
-        nextRecurrence: startOfDay(values.nextPayday),
+        nextRecurrence: startOfDay(values.nextPayday, {
+          in: tz(timezone),
+        }),
         ruleset: values.ruleset,
         estimatedDeposit: locale.friendlyToAmount(values.paydayAmount),
         excludeWeekends: false,
@@ -88,7 +96,9 @@ export default function ManualLinkSetupIncome(): JSX.Element {
             label='When do you get paid next?'
             className='w-full'
             required
-            min={ startOfTomorrow() }
+            min={ startOfTomorrow({
+              in: tz(timezone),
+            }) }
             autoFocus
           />
           <MSelectFrequency

--- a/interface/src/components/setup/manual/ManualLinkSetupIncome.tsx
+++ b/interface/src/components/setup/manual/ManualLinkSetupIncome.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { tz } from '@date-fns/tz';
 import { startOfDay, startOfTomorrow } from 'date-fns';
 import { FormikHelpers } from 'formik';
 
@@ -18,8 +19,6 @@ import useLocaleCurrency from '@monetr/interface/hooks/useLocaleCurrency';
 import useTimezone from '@monetr/interface/hooks/useTimezone';
 import { BankAccountSubType, BankAccountType } from '@monetr/interface/models/BankAccount';
 import FundingSchedule from '@monetr/interface/models/FundingSchedule';
-
-import { tz } from '@date-fns/tz';
 
 interface Values {
   nextPayday: Date;

--- a/interface/src/hooks/useTimezone.ts
+++ b/interface/src/hooks/useTimezone.ts
@@ -1,0 +1,23 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+
+import { AuthenticationWrapper } from '@monetr/interface/hooks/useAuthentication';
+import { getTimezone } from '@monetr/interface/util/locale';
+
+/**
+ * useTimezone is the same or similar to the useAuthentication hook, however it will always return a timezone string no
+ * matter what. It will always have initial data. If the user's timezone is not accessible via the API then it will be
+ * derived from the browser's current timezone.
+ */
+export default function useTimezone(): UseQueryResult<string, never> {
+  return useQuery<Partial<AuthenticationWrapper>, never, string>(['/users/me'], {
+    initialData: () => ({
+      user: {
+        account: {
+          timezone: getTimezone(),
+        },
+      },
+    }) as Partial<AuthenticationWrapper>,
+    initialDataUpdatedAt: undefined,
+    select: data => data?.user?.account?.timezone ?? getTimezone(),
+  });
+}

--- a/interface/src/modals/NewExpenseModal.tsx
+++ b/interface/src/modals/NewExpenseModal.tsx
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react';
 import NiceModal, { useModal } from '@ebay/nice-modal-react';
 import { AxiosError } from 'axios';
+import { tz } from '@date-fns/tz';
 import { startOfDay, startOfTomorrow } from 'date-fns';
 import { FormikHelpers } from 'formik';
 import { useSnackbar } from 'notistack';
@@ -20,8 +21,6 @@ import useLocaleCurrency from '@monetr/interface/hooks/useLocaleCurrency';
 import useTimezone from '@monetr/interface/hooks/useTimezone';
 import Spending, { SpendingType } from '@monetr/interface/models/Spending';
 import { ExtractProps } from '@monetr/interface/util/typescriptEvils';
-
-import { tz } from '@date-fns/tz';
 
 interface NewExpenseValues {
   name: string;

--- a/interface/src/pages/transaction/details.tsx
+++ b/interface/src/pages/transaction/details.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { AxiosError } from 'axios';
+import { tz } from '@date-fns/tz';
 import { startOfDay } from 'date-fns';
 import { FormikHelpers } from 'formik';
 import { HeartCrack, Save, ShoppingCart } from 'lucide-react';
@@ -24,8 +25,6 @@ import useLocaleCurrency from '@monetr/interface/hooks/useLocaleCurrency';
 import useTimezone from '@monetr/interface/hooks/useTimezone';
 import Transaction from '@monetr/interface/models/Transaction';
 import { APIError } from '@monetr/interface/util/request';
-
-import { tz } from '@date-fns/tz';
 
 interface TransactionValues {
   name: string;

--- a/interface/src/pages/transaction/details.tsx
+++ b/interface/src/pages/transaction/details.tsx
@@ -21,8 +21,11 @@ import SimilarTransactions from '@monetr/interface/components/transactions/Simil
 import { useCurrentLink } from '@monetr/interface/hooks/links';
 import { useTransaction, useUpdateTransaction } from '@monetr/interface/hooks/transactions';
 import useLocaleCurrency from '@monetr/interface/hooks/useLocaleCurrency';
+import useTimezone from '@monetr/interface/hooks/useTimezone';
 import Transaction from '@monetr/interface/models/Transaction';
 import { APIError } from '@monetr/interface/util/request';
+
+import { tz } from '@date-fns/tz';
 
 interface TransactionValues {
   name: string;
@@ -34,6 +37,7 @@ interface TransactionValues {
 }
 
 export default function TransactionDetails(): JSX.Element {
+  const { data: timezone } = useTimezone();
   const { data: locale } = useLocaleCurrency();
   const { data: link } = useCurrentLink();
   const { enqueueSnackbar } = useSnackbar();
@@ -47,7 +51,9 @@ export default function TransactionDetails(): JSX.Element {
       name: values.name,
       spendingId: values.spendingId,
       amount: locale.friendlyToAmount(values.amount),
-      date: startOfDay(values.date),
+      date: startOfDay(values.date, {
+        in: tz(timezone),
+      }),
       isPending: values.isPending,
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
 
   interface:
     dependencies:
+      '@date-fns/tz':
+        specifier: 1.2.0
+        version: 1.2.0
       '@ebay/nice-modal-react':
         specifier: 1.2.13
         version: 1.2.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1494,6 +1497,9 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@date-fns/tz@1.2.0':
+    resolution: {integrity: sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==}
 
   '@ebay/nice-modal-react@1.2.13':
     resolution: {integrity: sha512-jx8xIWe/Up4tpNuM02M+rbnLoxdngTGk3Y8LjJsLGXXcSoKd/+eZStZcAlIO/jwxyz/bhPZnpqPJZWAmhOofuA==}
@@ -13516,6 +13522,8 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
     optional: true
+
+  '@date-fns/tz@1.2.0': {}
 
   '@ebay/nice-modal-react@1.2.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
If a user has their timezone configured as X and their browser timezone
is Y. This can cause some of the dates sent to the server to be
malformed and can cause some odd behaviors. For lack of a better
solution for now (like not having times at all and instead only using
dates?); this adds timezone to components that need it. Forcing the time
to be shown and calculated in the user's timezone instead of only the
browsers timezone.

Resolves #2386
