### PR TITLE
feat(locale): Migrating to CLDR as a locale datasource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ server/ui/static/*
 !server/ui/static/NOTICE
 server/icons/sources/*
 !server/icons/sources/README.md
+server/locale/sources/*
+!server/locale/sources/README.md
 server/internal/source/embed/*
 !server/internal/source/embed/README.md
 tmp

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -109,6 +109,7 @@ add_custom_command(
     build.interface
     build.email
     sourcemaps.golang
+    download.cldr-json
 )
 
 if(BUILD_SIMPLE_ICONS)

--- a/server/locale/CMakeLists.txt
+++ b/server/locale/CMakeLists.txt
@@ -1,0 +1,24 @@
+include(GolangTestUtils)
+
+provision_golang_tests(${CMAKE_CURRENT_SOURCE_DIR})
+
+include(ExternalProject)
+ExternalProject_Add(cldr-json
+  GIT_REPOSITORY https://github.com/unicode-org/cldr-json.git
+  GIT_TAG 46.1.0
+  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/sources/cldr-json"
+  BINARY_DIR ""
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+  TEST_COMMAND ""
+)
+
+add_custom_target(
+  download.cldr-json
+  # By having the byproducts here, cmake will automatically clean up this directory when the clean target is run.
+  BYPRODUCTS ${CMAKE_CURRENT_SOURCE_DIR}/sources/cldr-json
+  # Essentially a no-op
+  COMMAND ${CMAKE_COMMAND} -E true
+  DEPENDS cldr-json
+)

--- a/server/locale/sources/README.md
+++ b/server/locale/sources/README.md
@@ -1,0 +1,1 @@
+# CLDR Dataset


### PR DESCRIPTION
Right now monetr uses glibc's `locales.h` as a datasource for numeric
currency data and locale information. This dataset is not really as up
to date as I had hoped and does not contain as much information as I've
found I need.

CLDR however is much more extensive and is used by a lot of other locale
packages. So it should be more suitable.
