### PR TITLE
fix(api): Removed unused balances view

### DIFF
--- a/server/migrations/schema/2025021700_DropBalanceView.tx.up.sql
+++ b/server/migrations/schema/2025021700_DropBalanceView.tx.up.sql
@@ -1,0 +1,1 @@
+DROP VIEW "balances";


### PR DESCRIPTION
This view has been unused since the v1.3.0 release, but to make sure
that API requests didn't fail during the rollout of the release, the
view was not dropped in the same version. This change drops the view for
the new version of monetr.
