### PR TITLE
fix(plaid): Fix Plaid pagination error handling

### DIFF
--- a/server/internal/mock_http_helper/responder.go
+++ b/server/internal/mock_http_helper/responder.go
@@ -3,7 +3,7 @@ package mock_http_helper
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -31,7 +31,7 @@ func NewHttpMockJsonResponder(
 			Proto:         "HTTP/1.0",
 			ProtoMajor:    1,
 			ProtoMinor:    0,
-			Body:          ioutil.NopCloser(body),
+			Body:          io.NopCloser(body),
 			ContentLength: int64(body.Len()),
 			Request:       request,
 			Header: map[string][]string{

--- a/server/internal/mock_plaid/sync.go
+++ b/server/internal/mock_plaid/sync.go
@@ -1,0 +1,71 @@
+package mock_plaid
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/monetr/monetr/server/internal/mock_http_helper"
+	"github.com/monetr/monetr/server/internal/myownsanity"
+	"github.com/plaid/plaid-go/v30/plaid"
+	"github.com/stretchr/testify/require"
+)
+
+func MockSync(t *testing.T, transactions []plaid.Transaction) {
+	mock_http_helper.NewHttpMockJsonResponder(
+		t,
+		"POST", Path(t, "/transactions/sync"),
+		func(t *testing.T, request *http.Request) (interface{}, int) {
+			ValidatePlaidAuthentication(t, request, RequireAccessToken)
+			var syncTransactionsRequest struct {
+				Cursor string `json:"cursor"`
+				Count  int    `json:"count"`
+			}
+			require.NoError(t, json.NewDecoder(request.Body).Decode(&syncTransactionsRequest), "must decode request")
+			count := syncTransactionsRequest.Count
+
+			filteredTransactions := make([]plaid.Transaction, 0, len(transactions))
+			for _, transaction := range transactions {
+				filteredTransactions = append(filteredTransactions, transaction)
+			}
+
+			endingOffset := myownsanity.Min(len(filteredTransactions), count)
+			data := filteredTransactions[0:endingOffset]
+
+			return plaid.TransactionsSyncResponse{
+				Accounts:             nil, // Add some basic reporting here too
+				Added:                data,
+				HasMore:              false,
+				RequestId:            gofakeit.UUID(),
+				AdditionalProperties: nil,
+			}, http.StatusOK
+		},
+		PlaidHeaders,
+	)
+}
+
+func MockSyncError(t *testing.T, error plaid.PlaidError) {
+	mock_http_helper.NewHttpMockJsonResponder(
+		t,
+		"POST", Path(t, "/transactions/sync"),
+		func(t *testing.T, request *http.Request) (interface{}, int) {
+			ValidatePlaidAuthentication(t, request, RequireAccessToken)
+			var syncTransactionsRequest struct {
+				Cursor string `json:"cursor"`
+				Count  int    `json:"count"`
+			}
+			require.NoError(t, json.NewDecoder(request.Body).Decode(&syncTransactionsRequest), "must decode request")
+
+			var status int
+			if s := error.Status.Get(); s != nil {
+				status = int(*s)
+			} else {
+				status = http.StatusInternalServerError
+			}
+
+			return error, status
+		},
+		PlaidHeaders,
+	)
+}

--- a/server/platypus/error.go
+++ b/server/platypus/error.go
@@ -1,0 +1,22 @@
+package platypus
+
+import (
+	"fmt"
+
+	"github.com/plaid/plaid-go/v30/plaid"
+)
+
+var (
+	_ error = &PlatypusError{}
+)
+
+type PlatypusError struct {
+	plaid.PlaidError
+}
+
+func (p *PlatypusError) Error() string {
+	return fmt.Sprintf(
+		"plaid API call failed with [%s - %s]%s",
+		p.ErrorType, p.ErrorCode, p.ErrorMessage,
+	)
+}

--- a/server/platypus/platypus.go
+++ b/server/platypus/platypus.go
@@ -108,16 +108,10 @@ func after(span *sentry.Span, response *http.Response, err error, message, error
 			return errors.Wrap(err, errorMessage)
 		}
 
-		// Only include the plaid error message if it is provided.
-		plaidMessage := ""
-		if plaidError.ErrorMessage != "" {
-			plaidMessage += " " + plaidError.ErrorMessage
-		}
-
-		return errors.Wrap(errors.Errorf(
-			"plaid API call failed with [%s - %s]%s",
-			plaidError.ErrorType, plaidError.ErrorCode, plaidMessage,
-		), errorMessage)
+		return errors.Wrapf(
+			&PlatypusError{plaidError},
+			errorMessage,
+		)
 	default:
 		span.Status = sentry.SpanStatusInternalError
 		return errors.Wrap(err, errorMessage)

--- a/server/platypus/sync_test.go
+++ b/server/platypus/sync_test.go
@@ -1,0 +1,132 @@
+package platypus
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/jarcoal/httpmock"
+	"github.com/monetr/monetr/server/config"
+	"github.com/monetr/monetr/server/internal/fixtures"
+	"github.com/monetr/monetr/server/internal/mock_plaid"
+	"github.com/monetr/monetr/server/internal/testutils"
+	"github.com/monetr/monetr/server/models"
+	"github.com/monetr/monetr/server/repository"
+	"github.com/monetr/monetr/server/secrets"
+	"github.com/pkg/errors"
+	"github.com/plaid/plaid-go/v30/plaid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlaidSync(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		clock := clock.New()
+
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		log := testutils.GetLog(t)
+		kms := secrets.NewPlaintextKMS()
+		db := testutils.GetPgDatabase(t)
+		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
+		plaidLink := fixtures.GivenIHaveAPlaidLink(t, clock, user)
+		secret, err := repository.NewSecretsRepository(
+			log,
+			clock,
+			db,
+			kms,
+			plaidLink.AccountId,
+		).Read(context.Background(), plaidLink.PlaidLink.SecretId)
+		assert.NoError(t, err, "must be able to read the secret")
+
+		end := clock.Now().UTC().Truncate(time.Hour)
+		start := clock.Now().UTC().Add(-30 * 24 * time.Hour).Truncate(time.Hour)
+		bankAccounts := []string{
+			"1234",
+		}
+		transactions := mock_plaid.GenerateTransactions(t, start, end, 10, bankAccounts)
+
+		mock_plaid.MockSync(t, transactions)
+
+		platypus := NewPlaid(log, clock, kms, db, config.Plaid{
+			ClientID:     gofakeit.UUID(),
+			ClientSecret: gofakeit.UUID(),
+			Environment:  plaid.Sandbox,
+			OAuthDomain:  "localhost",
+		})
+
+		link := &models.Link{
+			LinkId:    "link_foo",
+			AccountId: user.AccountId,
+		}
+
+		client, err := platypus.NewClient(
+			context.Background(),
+			link,
+			secret.Value,
+			gofakeit.UUID(),
+		)
+		assert.NoError(t, err, "should create platypus")
+		assert.NotNil(t, platypus, "should not be nil")
+
+		result, err := client.Sync(t.Context(), nil)
+		assert.NoError(t, err)
+		assert.Len(t, result.New, len(transactions))
+	})
+
+	t.Run("pagination error", func(t *testing.T) {
+		clock := clock.New()
+
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		log := testutils.GetLog(t)
+		kms := secrets.NewPlaintextKMS()
+		db := testutils.GetPgDatabase(t)
+		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
+		plaidLink := fixtures.GivenIHaveAPlaidLink(t, clock, user)
+		secret, err := repository.NewSecretsRepository(
+			log,
+			clock,
+			db,
+			kms,
+			plaidLink.AccountId,
+		).Read(context.Background(), plaidLink.PlaidLink.SecretId)
+		assert.NoError(t, err, "must be able to read the secret")
+
+		mock_plaid.MockSyncError(t, plaid.PlaidError{
+			ErrorType:    "TRANSACTIONS_ERROR",
+			ErrorCode:    "TRANSACTIONS_SYNC_MUTATION_DURING_PAGINATION",
+			ErrorMessage: "Underlying transaction data changed since last page was fetched. Please restart pagination from last update.",
+		})
+
+		platypus := NewPlaid(log, clock, kms, db, config.Plaid{
+			ClientID:     gofakeit.UUID(),
+			ClientSecret: gofakeit.UUID(),
+			Environment:  plaid.Sandbox,
+			OAuthDomain:  "localhost",
+		})
+
+		link := &models.Link{
+			LinkId:    "link_foo",
+			AccountId: user.AccountId,
+		}
+
+		client, err := platypus.NewClient(
+			context.Background(),
+			link,
+			secret.Value,
+			gofakeit.UUID(),
+		)
+		assert.NoError(t, err, "should create platypus")
+		assert.NotNil(t, platypus, "should not be nil")
+
+		result, err := client.Sync(t.Context(), nil)
+		assert.EqualError(t, err, "failed to sync data with Plaid: plaid API call failed with [TRANSACTIONS_ERROR - TRANSACTIONS_SYNC_MUTATION_DURING_PAGINATION]Underlying transaction data changed since last page was fetched. Please restart pagination from last update.")
+		assert.Nil(t, result)
+		assert.IsType(t, errors.Cause(err), new(PlatypusError), "Should be a platypus error")
+		assert.Equal(t, "TRANSACTIONS_SYNC_MUTATION_DURING_PAGINATION", (errors.Cause(err).(*PlatypusError)).ErrorCode, "Must be able to extract error code")
+	})
+}


### PR DESCRIPTION
When we get an error from Plaid indicating that the sync must be retried
from scratch we now throw an error causing the transaction to be rolled
back. We then retry the job from scratch up to a few attempts to correct
the issue. If we get any other error then we still return it normally.

Resolves #2453
