### PR TITLE
fix(api): Fixed transaction clusters not having a name

### DIFF
--- a/server/background/calculate_transaction_clusters.go
+++ b/server/background/calculate_transaction_clusters.go
@@ -128,7 +128,7 @@ func (c *CalculateTransactionClustersJob) Run(ctx context.Context) error {
 		"bankAccountId": bankAccountId,
 	})
 
-	clustering := recurring.NewSimilarTransactions_TFIDF_DBSCAN()
+	clustering := recurring.NewSimilarTransactions_TFIDF_DBSCAN(log)
 
 	limit := 500
 	offset := 0

--- a/server/recurring/recurring_test.go
+++ b/server/recurring/recurring_test.go
@@ -52,8 +52,7 @@ func TestRecurringDetection(t *testing.T) {
 		// First build out several transaction clusters
 		data := GetFixtures(t, "monetr_sample_data_1.json")
 		log := testutils.GetLog(t)
-
-		detector := NewSimilarTransactions_TFIDF_DBSCAN()
+		detector := NewSimilarTransactions_TFIDF_DBSCAN(log)
 
 		for i := range data {
 			detector.AddTransaction(&data[i])

--- a/server/recurring/similar_test.go
+++ b/server/recurring/similar_test.go
@@ -6,14 +6,15 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/monetr/monetr/server/internal/testutils"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSimilarTransactions_TFIDF_DBSCAN(t *testing.T) {
 	t.Run("monetr mercury dataset", func(t *testing.T) {
 		data := GetFixtures(t, "monetr_sample_data_1.json")
-
-		detector := NewSimilarTransactions_TFIDF_DBSCAN()
+		log := testutils.GetLog(t)
+		detector := NewSimilarTransactions_TFIDF_DBSCAN(log)
 
 		for i := range data {
 			detector.AddTransaction(&data[i])
@@ -33,8 +34,8 @@ func TestSimilarTransactions_TFIDF_DBSCAN(t *testing.T) {
 
 	t.Run("amazon dataset", func(t *testing.T) {
 		data := GetFixtures(t, "amazon_sample_data_1.json")
-
-		detector := NewSimilarTransactions_TFIDF_DBSCAN()
+		log := testutils.GetLog(t)
+		detector := NewSimilarTransactions_TFIDF_DBSCAN(log)
 
 		for i := range data {
 			detector.AddTransaction(&data[i])


### PR DESCRIPTION
It was possible for transaction clusters to be calculated without a
name, this should be considered a bug but until I've had more time to
investigate it I'm just going to omit clusters without a name from being
persisted to the database.

What is likely happening is this "no name" cluster is a bunch of
transactions that are so close to the 0 point, or consisting of such low
value words in their description that there aren't any non-zero words to
use for a name.

Resolves #2475
