### PR TITLE
fix(api): Significantly improve logging

### DIFF
--- a/server/background/calculate_transaction_clusters.go
+++ b/server/background/calculate_transaction_clusters.go
@@ -120,13 +120,18 @@ func (c *CalculateTransactionClustersJob) Run(ctx context.Context) error {
 
 	accountId := c.args.AccountId
 	bankAccountId := c.args.BankAccountId
-
-	repo := repository.NewRepositoryFromSession(c.clock, "user_system", accountId, c.db)
-
 	log := c.log.WithContext(span.Context()).WithFields(logrus.Fields{
 		"accountId":     accountId,
 		"bankAccountId": bankAccountId,
 	})
+
+	repo := repository.NewRepositoryFromSession(
+		c.clock,
+		"user_system",
+		accountId,
+		c.db,
+		log,
+	)
 
 	clustering := recurring.NewSimilarTransactions_TFIDF_DBSCAN(log)
 
@@ -138,7 +143,12 @@ func (c *CalculateTransactionClustersJob) Run(ctx context.Context) error {
 			"offset": offset,
 		})
 		txnLog.Trace("requesting next batch of transactions")
-		transactions, err := repo.GetTransactions(span.Context(), bankAccountId, limit, offset)
+		transactions, err := repo.GetTransactions(
+			span.Context(),
+			bankAccountId,
+			limit,
+			offset,
+		)
 		if err != nil {
 			return errors.Wrap(err, "failed to read transactions for clustering")
 		}

--- a/server/background/deactivate_links.go
+++ b/server/background/deactivate_links.go
@@ -90,8 +90,17 @@ func (d *DeactivateLinksHandler) HandleConsumeJob(
 		span := sentry.StartSpan(ctx, "db.transaction")
 		defer span.Finish()
 
-		log := log.WithContext(span.Context())
-		repo := repository.NewRepositoryFromSession(d.clock, "user_system", args.AccountId, txn)
+		log = log.WithContext(span.Context()).WithFields(logrus.Fields{
+			"accountId": args.AccountId,
+			"linkId":    args.LinkId,
+		})
+		repo := repository.NewRepositoryFromSession(
+			d.clock,
+			"user_system",
+			args.AccountId,
+			txn,
+			log,
+		)
 		secretsRepo := repository.NewSecretsRepository(
 			log,
 			d.clock,

--- a/server/background/notification_trial_expiry.go
+++ b/server/background/notification_trial_expiry.go
@@ -141,11 +141,16 @@ func (h *NotificationTrialExpiryHandler) HandleConsumeJob(
 		span := sentry.StartSpan(ctx, "db.transaction")
 		defer span.Finish()
 
+		log = log.WithContext(span.Context()).WithFields(logrus.Fields{
+			"accountId": args.AccountId,
+		})
+
 		repo := repository.NewRepositoryFromSession(
 			h.clock,
 			"user_system",
 			args.AccountId,
 			txn,
+			log,
 		)
 		job, err := NewNotificationTrialExpiryJob(
 			log,

--- a/server/background/notification_trial_expiry_test.go
+++ b/server/background/notification_trial_expiry_test.go
@@ -225,9 +225,17 @@ func TestNotificationTrialExpiryJob_Run(t *testing.T) {
 		assert.NotNil(t, user.Account.TrialEndsAt, "trial ends at date must be present")
 		assert.Nil(t, user.Account.TrialExpiryNotificationSentAt, "trial notification email should be unsent")
 
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
+
 		job, err := background.NewNotificationTrialExpiryJob(
 			log,
-			repository.NewRepositoryFromSession(clock, user.UserId, user.AccountId, db),
+			repo,
 			db,
 			clock,
 			config,
@@ -281,9 +289,17 @@ func TestNotificationTrialExpiryJob_Run(t *testing.T) {
 		user.Account.TrialExpiryNotificationSentAt = myownsanity.TimeP(clock.Now())
 		testutils.MustDBUpdate(t, user.Account)
 
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
+
 		job, err := background.NewNotificationTrialExpiryJob(
 			log,
-			repository.NewRepositoryFromSession(clock, user.UserId, user.AccountId, db),
+			repo,
 			db,
 			clock,
 			config,

--- a/server/background/process_ofx_upload.go
+++ b/server/background/process_ofx_upload.go
@@ -194,7 +194,13 @@ func (h *ProcessOFXUploadHandler) HandleConsumeJob(
 		defer span.Finish()
 
 		log := log.WithContext(span.Context())
-		repo := repository.NewRepositoryFromSession(h.clock, "user_system", args.AccountId, txn)
+		repo := repository.NewRepositoryFromSession(
+			h.clock,
+			"user_system",
+			args.AccountId,
+			txn,
+			log,
+		)
 
 		job, err := NewProcessOFXUploadJob(
 			log, repo, h.clock, h.files, h.publisher, h.enqueuer, args,

--- a/server/background/reconcile_subscription.go
+++ b/server/background/reconcile_subscription.go
@@ -89,11 +89,16 @@ func (h *ReconcileSubscriptionHandler) HandleConsumeJob(
 
 	crumbs.IncludeUserInScope(ctx, args.AccountId)
 
+	log = log.WithContext(ctx).WithFields(logrus.Fields{
+		"accountId": args.AccountId,
+	})
+
 	repo := repository.NewRepositoryFromSession(
 		h.clock,
 		"user_system",
 		args.AccountId,
 		h.db,
+		log,
 	)
 	job, err := NewReconcileSubscriptionJob(
 		log,

--- a/server/background/remove_file.go
+++ b/server/background/remove_file.go
@@ -83,8 +83,17 @@ func (h *RemoveFileHandler) HandleConsumeJob(
 		span := sentry.StartSpan(ctx, "db.transaction")
 		defer span.Finish()
 
-		log := log.WithContext(span.Context())
-		repo := repository.NewRepositoryFromSession(h.clock, "user_system", args.AccountId, txn)
+		log := log.WithContext(span.Context()).WithFields(logrus.Fields{
+			"accountId": args.AccountId,
+			"fileId":    args.FileId,
+		})
+		repo := repository.NewRepositoryFromSession(
+			h.clock,
+			"user_system",
+			args.AccountId,
+			txn,
+			log,
+		)
 
 		job, err := NewRemoveFileJob(
 			log,

--- a/server/background/sync_plaid.go
+++ b/server/background/sync_plaid.go
@@ -130,6 +130,10 @@ func (s *SyncPlaidHandler) HandleConsumeJob(
 	}
 
 	crumbs.IncludeUserInScope(ctx, args.AccountId)
+	log = log.WithFields(logrus.Fields{
+		"accountId": args.AccountId,
+		"linkId":    args.LinkId,
+	})
 
 	attempts := 0
 	maxAttempts := 3
@@ -144,8 +148,13 @@ RetrySync:
 		defer span.Finish()
 
 		log := log.WithContext(span.Context())
-
-		repo := repository.NewRepositoryFromSession(s.clock, "user_plaid", args.AccountId, txn)
+		repo := repository.NewRepositoryFromSession(
+			s.clock,
+			"user_plaid",
+			args.AccountId,
+			txn,
+			log,
+		)
 		secretsRepo := repository.NewSecretsRepository(
 			log,
 			s.clock,

--- a/server/background/sync_plaid_accounts.go
+++ b/server/background/sync_plaid_accounts.go
@@ -96,9 +96,18 @@ func (s *SyncPlaidAccountsHandler) HandleConsumeJob(
 		span := sentry.StartSpan(ctx, "db.transaction")
 		defer span.Finish()
 
-		log := log.WithContext(span.Context())
+		log := log.WithContext(span.Context()).WithFields(logrus.Fields{
+			"accountId": args.AccountId,
+			"linkId":    args.LinkId,
+		})
 
-		repo := repository.NewRepositoryFromSession(s.clock, "user_plaid", args.AccountId, txn)
+		repo := repository.NewRepositoryFromSession(
+			s.clock,
+			"user_plaid",
+			args.AccountId,
+			txn,
+			log,
+		)
 		secretsRepo := repository.NewSecretsRepository(
 			log,
 			s.clock,

--- a/server/background/sync_plaid_accounts_test.go
+++ b/server/background/sync_plaid_accounts_test.go
@@ -195,7 +195,13 @@ func TestSyncPlaidAccountsJob_Run(t *testing.T) {
 
 		job, err := background.NewSyncPlaidAccountsJob(
 			log,
-			repository.NewRepositoryFromSession(clock, "user_system", user.AccountId, db),
+			repository.NewRepositoryFromSession(
+				clock,
+				"user_system",
+				user.AccountId,
+				db,
+				log,
+			),
 			clock,
 			repository.NewSecretsRepository(log, clock, db, kms, user.AccountId),
 			plaidPlatypus,
@@ -291,7 +297,13 @@ func TestSyncPlaidAccountsJob_Run(t *testing.T) {
 
 		job, err := background.NewSyncPlaidAccountsJob(
 			log,
-			repository.NewRepositoryFromSession(clock, "user_system", user.AccountId, db),
+			repository.NewRepositoryFromSession(
+				clock,
+				"user_system",
+				user.AccountId,
+				db,
+				log,
+			),
 			clock,
 			repository.NewSecretsRepository(log, clock, db, kms, user.AccountId),
 			plaidPlatypus,

--- a/server/cmd/jobs.go
+++ b/server/cmd/jobs.go
@@ -146,7 +146,13 @@ var (
 						return err
 					}
 
-					repo := repository.NewRepositoryFromSession(clock, "user_admin", jobArgs.AccountId, txn)
+					repo := repository.NewRepositoryFromSession(
+						clock,
+						"user_admin",
+						jobArgs.AccountId,
+						txn,
+						log,
+					)
 
 					kms, err := getKMS(log, configuration)
 					if err != nil {

--- a/server/controller/helpers.go
+++ b/server/controller/helpers.go
@@ -194,7 +194,9 @@ func (c *Controller) mustGetUnauthenticatedRepository(ctx echo.Context) reposito
 	return repo
 }
 
-func (c *Controller) getAuthenticatedRepository(ctx echo.Context) (repository.Repository, error) {
+func (c *Controller) getAuthenticatedRepository(
+	ctx echo.Context,
+) (repository.Repository, error) {
 	userId, err := c.getUserId(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "you are not authenticated to an account")
@@ -210,7 +212,13 @@ func (c *Controller) getAuthenticatedRepository(ctx echo.Context) (repository.Re
 		return nil, errors.Errorf("no transaction for request")
 	}
 
-	return repository.NewRepositoryFromSession(c.Clock, userId, accountId, txn), nil
+	return repository.NewRepositoryFromSession(
+		c.Clock,
+		userId,
+		accountId,
+		txn,
+		c.getLog(ctx),
+	), nil
 }
 
 func (c *Controller) mustGetAuthenticatedRepository(ctx echo.Context) repository.Repository {

--- a/server/controller/plaid_webhook.go
+++ b/server/controller/plaid_webhook.go
@@ -204,6 +204,7 @@ func (c *Controller) processWebhook(ctx echo.Context, hook PlaidWebhook) error {
 		link.CreatedBy,
 		link.AccountId,
 		c.mustGetDatabase(ctx),
+		log,
 	)
 
 	if hook.Error != nil {

--- a/server/internal/fixtures/bank_account.go
+++ b/server/internal/fixtures/bank_account.go
@@ -1,7 +1,6 @@
 package fixtures
 
 import (
-	"context"
 	"testing"
 
 	"github.com/benbjohnson/clock"
@@ -12,26 +11,53 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func ReadBankAccounts(t *testing.T, clock clock.Clock, link models.Link) []models.BankAccount {
+func ReadBankAccounts(
+	t *testing.T,
+	clock clock.Clock,
+	link models.Link,
+) []models.BankAccount {
 	require.NotZero(t, link.LinkId, "link id must be included")
 	require.NotZero(t, link.AccountId, "link id must be included")
 
+	log := testutils.GetLog(t)
 	db := testutils.GetPgDatabase(t)
-	repo := repository.NewRepositoryFromSession(clock, link.CreatedBy, link.AccountId, db)
+	repo := repository.NewRepositoryFromSession(
+		clock,
+		link.CreatedBy,
+		link.AccountId,
+		db,
+		log,
+	)
 
-	bankAccounts, err := repo.GetBankAccountsByLinkId(context.Background(), link.LinkId)
+	bankAccounts, err := repo.GetBankAccountsByLinkId(
+		t.Context(),
+		link.LinkId,
+	)
 	require.NoError(t, err, "must be able to read bank accounts")
 
 	return bankAccounts
 }
 
-func GivenIHaveABankAccount(t *testing.T, clock clock.Clock, link *models.Link, accountType models.BankAccountType, subType models.BankAccountSubType) models.BankAccount {
+func GivenIHaveABankAccount(
+	t *testing.T,
+	clock clock.Clock,
+	link *models.Link,
+	accountType models.BankAccountType,
+	subType models.BankAccountSubType,
+) models.BankAccount {
 	require.NotNil(t, link, "link must actually be provided")
 	require.NotZero(t, link.LinkId, "link id must be included")
 	require.NotZero(t, link.AccountId, "link id must be included")
 
+	log := testutils.GetLog(t)
 	db := testutils.GetPgDatabase(t)
-	repo := repository.NewRepositoryFromSession(clock, link.CreatedBy, link.AccountId, db)
+	repo := repository.NewRepositoryFromSession(
+		clock,
+		link.CreatedBy,
+		link.AccountId,
+		db,
+		log,
+	)
 
 	current := int64(gofakeit.Number(2000, 100000))
 	available := current - int64(gofakeit.Number(100, 2000))
@@ -54,7 +80,7 @@ func GivenIHaveABankAccount(t *testing.T, clock clock.Clock, link *models.Link, 
 		},
 	}
 
-	err := repo.CreateBankAccounts(context.Background(), banks...)
+	err := repo.CreateBankAccounts(t.Context(), banks...)
 	require.NoError(t, err, "must seed bank account")
 	require.NotZero(t, banks[0].BankAccountId, "bank account Id must have been set")
 
@@ -73,8 +99,15 @@ func GivenIHaveAPlaidBankAccount(
 	require.NotZero(t, link.AccountId, "link id must be included")
 	require.NotZero(t, link.PlaidLinkId, "link plaid link id must be included")
 
+	log := testutils.GetLog(t)
 	db := testutils.GetPgDatabase(t)
-	repo := repository.NewRepositoryFromSession(clock, link.CreatedBy, link.AccountId, db)
+	repo := repository.NewRepositoryFromSession(
+		clock,
+		link.CreatedBy,
+		link.AccountId,
+		db,
+		log,
+	)
 
 	current := int64(gofakeit.Number(2000, 100000))
 	available := current - int64(gofakeit.Number(100, 2000))
@@ -91,7 +124,7 @@ func GivenIHaveAPlaidBankAccount(
 	}
 	require.NoError(
 		t,
-		repo.CreatePlaidBankAccount(context.Background(), &plaidBankAccount),
+		repo.CreatePlaidBankAccount(t.Context(), &plaidBankAccount),
 		"must be able to create the plaid bank account record",
 	)
 
@@ -114,7 +147,7 @@ func GivenIHaveAPlaidBankAccount(
 
 	require.NoError(
 		t,
-		repo.CreateBankAccounts(context.Background(), &bankAccount),
+		repo.CreateBankAccounts(t.Context(), &bankAccount),
 		"must seed bank account",
 	)
 	require.NotZero(t, bankAccount.BankAccountId, "bank account Id must have been set")

--- a/server/internal/fixtures/funding_schedules.go
+++ b/server/internal/fixtures/funding_schedules.go
@@ -1,7 +1,6 @@
 package fixtures
 
 import (
-	"context"
 	"testing"
 
 	"github.com/benbjohnson/clock"
@@ -13,7 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func GivenIHaveAFundingSchedule(t *testing.T, clock clock.Clock, bankAccount *models.BankAccount, ruleString string, excludeWeekends bool) *models.FundingSchedule {
+func GivenIHaveAFundingSchedule(
+	t *testing.T,
+	clock clock.Clock,
+	bankAccount *models.BankAccount,
+	ruleString string,
+	excludeWeekends bool,
+) *models.FundingSchedule {
 	require.NotNil(t, bankAccount, "must provide a valid bank account")
 	require.NotZero(t, bankAccount.BankAccountId, "bank account must have a valid Id")
 	require.NotZero(t, bankAccount.AccountId, "bank account must have a valid account Id")
@@ -23,8 +28,15 @@ func GivenIHaveAFundingSchedule(t *testing.T, clock clock.Clock, bankAccount *mo
 		panic("sorry I haven't implemented this yet")
 	}
 
+	log := testutils.GetLog(t)
 	db := testutils.GetPgDatabase(t)
-	repo := repository.NewRepositoryFromSession(clock, bankAccount.Link.CreatedBy, bankAccount.AccountId, db)
+	repo := repository.NewRepositoryFromSession(
+		clock,
+		bankAccount.Link.CreatedBy,
+		bankAccount.AccountId,
+		db,
+		log,
+	)
 
 	timezone := testutils.MustEz(t, bankAccount.Account.GetTimezone)
 	rule := testutils.RuleToSet(t, timezone, ruleString, clock.Now())
@@ -44,7 +56,10 @@ func GivenIHaveAFundingSchedule(t *testing.T, clock clock.Clock, bankAccount *mo
 		NextRecurrenceOriginal: nextOccurrence,
 	}
 
-	require.NoError(t, repo.CreateFundingSchedule(context.Background(), &fundingSchedule), "must be able to create funding schedule")
+	require.NoError(t, repo.CreateFundingSchedule(
+		t.Context(),
+		&fundingSchedule,
+	), "must be able to create funding schedule")
 
 	return &fundingSchedule
 }

--- a/server/internal/fixtures/link.go
+++ b/server/internal/fixtures/link.go
@@ -1,7 +1,6 @@
 package fixtures
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -26,7 +25,13 @@ func GivenIHaveAPlaidLink(t *testing.T, clock clock.Clock, user User) Link {
 	log := testutils.GetLog(t)
 	db := testutils.GetPgDatabase(t)
 
-	repo := repository.NewRepositoryFromSession(clock, user.UserId, user.AccountId, db)
+	repo := repository.NewRepositoryFromSession(
+		clock,
+		user.UserId,
+		user.AccountId,
+		db,
+		log,
+	)
 	secretsRepo := repository.NewSecretsRepository(
 		log,
 		clock,
@@ -39,7 +44,7 @@ func GivenIHaveAPlaidLink(t *testing.T, clock clock.Clock, user User) Link {
 		Kind:  PlaidSecretKind,
 		Value: gofakeit.UUID(),
 	}
-	err := secretsRepo.Store(context.Background(), &secret)
+	err := secretsRepo.Store(t.Context(), &secret)
 	require.NoError(t, err, "must be able to see plaid token secret")
 
 	plaidLink := PlaidLink{
@@ -61,7 +66,7 @@ func GivenIHaveAPlaidLink(t *testing.T, clock clock.Clock, user User) Link {
 		CreatedAt:            clock.Now().UTC(),
 		CreatedBy:            user.UserId,
 	}
-	err = repo.CreatePlaidLink(context.Background(), &plaidLink)
+	err = repo.CreatePlaidLink(t.Context(), &plaidLink)
 	require.NoError(t, err, "must be able to seed plaid link")
 
 	link := Link{
@@ -77,16 +82,22 @@ func GivenIHaveAPlaidLink(t *testing.T, clock clock.Clock, user User) Link {
 		UpdatedAt:       clock.Now(),
 	}
 
-	err = repo.CreateLink(context.Background(), &link)
+	err = repo.CreateLink(t.Context(), &link)
 	require.NoError(t, err, "must be able to seed link")
 
 	return link
 }
 
 func GivenIHaveAManualLink(t *testing.T, clock clock.Clock, user User) Link {
+	log := testutils.GetLog(t)
 	db := testutils.GetPgDatabase(t)
-
-	repo := repository.NewRepositoryFromSession(clock, user.UserId, user.AccountId, db)
+	repo := repository.NewRepositoryFromSession(
+		clock,
+		user.UserId,
+		user.AccountId,
+		db,
+		log,
+	)
 
 	link := Link{
 		AccountId:       user.AccountId,
@@ -99,7 +110,7 @@ func GivenIHaveAManualLink(t *testing.T, clock clock.Clock, user User) Link {
 		UpdatedAt:       clock.Now(),
 	}
 
-	err := repo.CreateLink(context.Background(), &link)
+	err := repo.CreateLink(t.Context(), &link)
 	require.NoError(t, err, "must be able to seed link")
 
 	return link

--- a/server/internal/fixtures/transactions.go
+++ b/server/internal/fixtures/transactions.go
@@ -1,7 +1,6 @@
 package fixtures
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -48,8 +47,15 @@ func GivenIHaveNTransactions(t *testing.T, clock clock.Clock, bankAccount BankAc
 	require.NotZero(t, bankAccount.AccountId, "bank account Id must be included")
 	require.NotNil(t, bankAccount.Account, "bank account must include account object")
 
+	log := testutils.GetLog(t)
 	db := testutils.GetPgDatabase(t)
-	repo := repository.NewRepositoryFromSession(clock, bankAccount.Link.CreatedBy, bankAccount.AccountId, db)
+	repo := repository.NewRepositoryFromSession(
+		clock,
+		bankAccount.Link.CreatedBy,
+		bankAccount.AccountId,
+		db,
+		log,
+	)
 
 	timezone, err := bankAccount.Account.GetTimezone()
 	require.NoError(t, err, "must be able to get the timezone from the account")
@@ -84,7 +90,7 @@ func GivenIHaveNTransactions(t *testing.T, clock clock.Clock, bankAccount BankAc
 
 			require.NoError(
 				t,
-				repo.CreatePlaidTransaction(context.Background(), plaidTransaction),
+				repo.CreatePlaidTransaction(t.Context(), plaidTransaction),
 				"must be able to seed transaction",
 			)
 		}
@@ -114,7 +120,7 @@ func GivenIHaveNTransactions(t *testing.T, clock clock.Clock, bankAccount BankAc
 			transaction.PlaidTransaction = plaidTransaction
 		}
 
-		err = repo.CreateTransaction(context.Background(), bankAccount.BankAccountId, &transaction)
+		err = repo.CreateTransaction(t.Context(), bankAccount.BankAccountId, &transaction)
 		require.NoError(t, err, "must be able to seed transaction")
 
 		transactions[i] = transaction

--- a/server/models/transaction.go
+++ b/server/models/transaction.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"time"
 
-	"github.com/getsentry/sentry-go"
 	"github.com/go-pg/pg/v10"
 	"github.com/monetr/monetr/server/crumbs"
 	"github.com/monetr/monetr/server/internal/myownsanity"
-	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type TransactionSource string
@@ -81,8 +80,13 @@ func (t Transaction) IsAddition() bool {
 // AddSpendingToTransaction will take the provided spending object and deduct as
 // much as possible from this transaction from that spending object. It does not
 // change the spendingId on the transaction, it simply performs the deductions.
-func (t *Transaction) AddSpendingToTransaction(ctx context.Context, spending *Spending, account *Account) error {
-	span := sentry.StartSpan(ctx, "AddSpendingToTransaction")
+func (t *Transaction) AddSpendingToTransaction(
+	ctx context.Context,
+	spending *Spending,
+	timezone *time.Location,
+	log *logrus.Entry,
+) error {
+	span := crumbs.StartFnTrace(ctx)
 	defer span.Finish()
 
 	var allocationAmount int64
@@ -117,14 +121,13 @@ func (t *Transaction) AddSpendingToTransaction(ctx context.Context, spending *Sp
 
 	// Now that we have deducted the amount we need from the spending we need to
 	// recalculate it's next contribution.
-	if err := spending.CalculateNextContribution(
+	spending.CalculateNextContribution(
 		span.Context(),
-		account.Timezone,
+		timezone,
 		spending.FundingSchedule,
 		time.Now(),
-	); err != nil {
-		return errors.Wrap(err, "failed to calculate next contribution for new transaction expense")
-	}
+		log,
+	)
 
 	return nil
 }
@@ -135,6 +138,7 @@ func AddSpendingToTransaction(
 	spending Spending,
 	timezone *time.Location,
 	now time.Time,
+	log *logrus.Entry,
 ) (amount int64, result Spending) {
 	span := crumbs.StartFnTrace(ctx)
 	defer span.Finish()
@@ -166,6 +170,15 @@ func AddSpendingToTransaction(
 	}
 
 	// Keep track of how much we took from the spending in case things change later.
+
+	spending.CalculateNextContribution(
+		span.Context(),
+		timezone,
+		spending.FundingSchedule,
+		now,
+		log,
+	)
+
 	return allocationAmount, CalculateNextContribution(
 		span.Context(),
 		spending,
@@ -181,6 +194,7 @@ func ProcessSpentFrom(
 	inputSpend, currentSpend *Spending,
 	now time.Time,
 	timezone *time.Location,
+	log *logrus.Entry,
 ) (updatedTransaction Transaction, updatedSpending []Spending) {
 	span := crumbs.StartFnTrace(ctx)
 	defer span.Finish()
@@ -252,15 +266,19 @@ func ProcessSpentFrom(
 			"current spend is missing the embedded funding schedule data",
 		)
 
-		// Now that we have added that money back to the expense we need to
-		// calculate the expense's next contribution.
-		updatedSpending = append(updatedSpending, CalculateNextContribution(
-			span.Context(),
-			*currentSpend,
-			*currentSpend.FundingSchedule,
-			timezone,
-			now,
-		))
+		{ // Clone the expense object so we don't modify things upstream
+			current := *currentSpend
+			// Calculate the next contribution
+			current.CalculateNextContribution(
+				span.Context(),
+				timezone,
+				current.FundingSchedule,
+				now,
+				log,
+			)
+			// Then add it to our list
+			updatedSpending = append(updatedSpending, current)
+		}
 
 		// If we are only removing the expense then we are done with this part.
 		if expensePlan == RemoveExpense {
@@ -271,13 +289,13 @@ func ProcessSpentFrom(
 		// handle the processing of the new expense.
 		fallthrough
 	case AddExpense:
-
 		amountSpent, updatedNewSpend := AddSpendingToTransaction(
 			span.Context(),
 			input,
 			*inputSpend,
 			timezone,
 			now,
+			log,
 		)
 
 		// Then take all the fields that have changed and throw them in our list of

--- a/server/models/transaction.go
+++ b/server/models/transaction.go
@@ -179,13 +179,7 @@ func AddSpendingToTransaction(
 		log,
 	)
 
-	return allocationAmount, CalculateNextContribution(
-		span.Context(),
-		spending,
-		*spending.FundingSchedule,
-		timezone,
-		now,
-	)
+	return allocationAmount, spending
 }
 
 func ProcessSpentFrom(

--- a/server/repository/accounts_test.go
+++ b/server/repository/accounts_test.go
@@ -15,9 +15,16 @@ import (
 func TestRepositoryBase_GetAccount(t *testing.T) {
 	t.Run("account does not exist", func(t *testing.T) {
 		clock := clock.NewMock()
+		log := testutils.GetLog(t)
 		db := testutils.GetPgDatabase(t, testutils.IsolatedDatabase)
 
-		repo := repository.NewRepositoryFromSession(clock, "user_bogus", "acct_bogus", db)
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			"user_bogus",
+			"acct_bogus",
+			db,
+			log,
+		)
 		account, err := repo.GetAccount(context.Background())
 		assert.EqualError(t, err, "failed to retrieve account: pg: no rows in result set")
 		assert.Nil(t, account, "should not return an account")
@@ -25,11 +32,18 @@ func TestRepositoryBase_GetAccount(t *testing.T) {
 
 	t.Run("account exists", func(t *testing.T) {
 		clock := clock.NewMock()
+		log := testutils.GetLog(t)
 		db := testutils.GetPgDatabase(t, testutils.IsolatedDatabase)
 
 		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
 
-		repo := repository.NewRepositoryFromSession(clock, user.UserId, user.AccountId, db)
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
 		account, err := repo.GetAccount(context.Background())
 		assert.NoError(t, err, "must not return an error if the account exists")
 		assert.NotNil(t, account, "should return a valid account")
@@ -38,11 +52,18 @@ func TestRepositoryBase_GetAccount(t *testing.T) {
 
 	t.Run("will cache the account", func(t *testing.T) {
 		clock := clock.NewMock()
+		log := testutils.GetLog(t)
 		db := testutils.GetPgDatabase(t, testutils.IsolatedDatabase)
 
 		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
 
-		repo := repository.NewRepositoryFromSession(clock, user.UserId, user.AccountId, db)
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
 		account, err := repo.GetAccount(context.Background())
 		assert.NoError(t, err, "must not return an error if the account exists")
 		assert.NotNil(t, account, "should return a valid account")

--- a/server/repository/balances_test.go
+++ b/server/repository/balances_test.go
@@ -15,12 +15,19 @@ import (
 func TestRepositoryBase_GetBalances(t *testing.T) {
 	t.Run("will read balances", func(t *testing.T) {
 		clock := clock.NewMock()
+		log := testutils.GetLog(t)
 		db := testutils.GetPgDatabase(t)
 		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
 		link := fixtures.GivenIHaveAManualLink(t, clock, user)
 		bank := fixtures.GivenIHaveABankAccount(t, clock, &link, models.DepositoryBankAccountType, models.CheckingBankAccountSubType)
 
-		repo := repository.NewRepositoryFromSession(clock, user.UserId, user.AccountId, db)
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
 
 		balances, err := repo.GetBalances(t.Context(), bank.BankAccountId)
 		assert.NoError(t, err, "must not return an error when reading balances")
@@ -33,12 +40,19 @@ func TestRepositoryBase_GetBalances(t *testing.T) {
 
 	t.Run("with spending objects", func(t *testing.T) {
 		clock := clock.NewMock()
+		log := testutils.GetLog(t)
 		db := testutils.GetPgDatabase(t)
 		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
 		link := fixtures.GivenIHaveAManualLink(t, clock, user)
 		bank := fixtures.GivenIHaveABankAccount(t, clock, &link, models.DepositoryBankAccountType, models.CheckingBankAccountSubType)
 
-		repo := repository.NewRepositoryFromSession(clock, user.UserId, user.AccountId, db)
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
 
 		{ // Before we create an expense, double check balances
 			balances, err := repo.GetBalances(t.Context(), bank.BankAccountId)

--- a/server/repository/funding_schedules_test.go
+++ b/server/repository/funding_schedules_test.go
@@ -15,12 +15,19 @@ import (
 func TestRepositoryBase_UpdateFundingSchedule(t *testing.T) {
 	t.Run("simple", func(t *testing.T) {
 		clock := clock.NewMock()
+		log := testutils.GetLog(t)
 		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
 		link := fixtures.GivenIHaveAManualLink(t, clock, user)
 		bankAccount := fixtures.GivenIHaveABankAccount(t, clock, &link, models.DepositoryBankAccountType, models.CheckingBankAccountSubType)
 		fundingSchedule := fixtures.GivenIHaveAFundingSchedule(t, clock, &bankAccount, "FREQ=DAILY", false)
 
-		repo := repository.NewRepositoryFromSession(clock, user.UserId, user.AccountId, testutils.GetPgDatabase(t))
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			testutils.GetPgDatabase(t),
+			log,
+		)
 
 		fundingSchedule.Name = "Updated name"
 

--- a/server/repository/main_test.go
+++ b/server/repository/main_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func GetTestAuthenticatedRepository(t *testing.T, clock clock.Clock) repository.Repository {
+	log := testutils.GetLog(t)
 	db := testutils.GetPgDatabase(t)
 
 	user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
@@ -23,5 +24,11 @@ func GetTestAuthenticatedRepository(t *testing.T, clock clock.Clock) repository.
 		assert.NoError(t, txn.Commit(), "should commit")
 	})
 
-	return repository.NewRepositoryFromSession(clock, user.UserId, user.AccountId, txn)
+	return repository.NewRepositoryFromSession(
+		clock,
+		user.UserId,
+		user.AccountId,
+		txn,
+		log,
+	)
 }

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-pg/pg/v10"
 	"github.com/monetr/monetr/server/crumbs"
 	. "github.com/monetr/monetr/server/models"
+	"github.com/sirupsen/logrus"
 )
 
 type BaseRepository interface {
@@ -153,16 +154,26 @@ type UnauthenticatedRepository interface {
 	ValidateBetaCode(ctx context.Context, betaCode string) (*Beta, error)
 }
 
-func NewRepositoryFromSession(clock clock.Clock, userId ID[User], accountId ID[Account], database pg.DBI) Repository {
+func NewRepositoryFromSession(
+	clock clock.Clock,
+	userId ID[User],
+	accountId ID[Account],
+	database pg.DBI,
+	log *logrus.Entry,
+) Repository {
 	return &repositoryBase{
 		userId:    userId,
 		accountId: accountId,
 		txn:       database,
 		clock:     clock,
+		log:       log,
 	}
 }
 
-func NewUnauthenticatedRepository(clock clock.Clock, txn pg.DBI) UnauthenticatedRepository {
+func NewUnauthenticatedRepository(
+	clock clock.Clock,
+	txn pg.DBI,
+) UnauthenticatedRepository {
 	return &unauthenticatedRepo{
 		txn:   txn,
 		clock: clock,

--- a/server/repository/repository_default.go
+++ b/server/repository/repository_default.go
@@ -5,6 +5,7 @@ import (
 	"github.com/go-pg/pg/v10"
 	. "github.com/monetr/monetr/server/models"
 	"github.com/monetr/monetr/server/secrets"
+	"github.com/sirupsen/logrus"
 )
 
 type repositoryBase struct {
@@ -14,4 +15,5 @@ type repositoryBase struct {
 	account   *Account
 	kms       secrets.KeyManagement
 	clock     clock.Clock
+	log       *logrus.Entry
 }

--- a/server/repository/sync_test.go
+++ b/server/repository/sync_test.go
@@ -17,6 +17,7 @@ import (
 func TestRepositoryBaseGetLastPlaidSync(t *testing.T) {
 	t.Run("no previous syncs", func(t *testing.T) {
 		clock := clock.NewMock()
+		log := testutils.GetLog(t)
 
 		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
 		link := fixtures.GivenIHaveAPlaidLink(t, clock, user)
@@ -24,7 +25,13 @@ func TestRepositoryBaseGetLastPlaidSync(t *testing.T) {
 		assert.NotZero(t, plaidLink.PlaidLinkId, "plaid link ID must not be zero, must have a valid record!")
 
 		db := testutils.GetPgDatabase(t)
-		repo := repository.NewRepositoryFromSession(clock, user.UserId, user.AccountId, db)
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
 		result, err := repo.GetLastPlaidSync(context.Background(), plaidLink.PlaidLinkId)
 		assert.NoError(t, err, "should not receive an error when there is no previous plaid sync")
 		assert.Nil(t, result, "should receive nil, because there has not been a plaid sync before this")
@@ -32,6 +39,7 @@ func TestRepositoryBaseGetLastPlaidSync(t *testing.T) {
 
 	t.Run("one previous sync", func(t *testing.T) {
 		clock := clock.NewMock()
+		log := testutils.GetLog(t)
 		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
 		link := fixtures.GivenIHaveAPlaidLink(t, clock, user)
 		plaidLink := *link.PlaidLink
@@ -51,8 +59,14 @@ func TestRepositoryBaseGetLastPlaidSync(t *testing.T) {
 		assert.NotZero(t, plaidSync.PlaidSyncId, "plaid sync ID must not be zero, must have created a valid record!")
 
 		db := testutils.GetPgDatabase(t)
-		repo := repository.NewRepositoryFromSession(clock, user.UserId, user.AccountId, db)
-		result, err := repo.GetLastPlaidSync(context.Background(), plaidLink.PlaidLinkId)
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
+		result, err := repo.GetLastPlaidSync(t.Context(), plaidLink.PlaidLinkId)
 		assert.NoError(t, err, "should not receive an error when there is no previous plaid sync")
 		assert.NotNil(t, result, "resulting plaid sync should be returned")
 		assert.Equal(t, plaidSync.PlaidSyncId, result.PlaidSyncId, "should have received the last inserted plaid sync")
@@ -60,6 +74,7 @@ func TestRepositoryBaseGetLastPlaidSync(t *testing.T) {
 
 	t.Run("multiple previous syncs", func(t *testing.T) {
 		clock := clock.NewMock()
+		log := testutils.GetLog(t)
 		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
 		link := fixtures.GivenIHaveAPlaidLink(t, clock, user)
 		plaidLink := *link.PlaidLink
@@ -100,7 +115,13 @@ func TestRepositoryBaseGetLastPlaidSync(t *testing.T) {
 		clock.Add(1 * 24 * time.Hour)
 
 		db := testutils.GetPgDatabase(t)
-		repo := repository.NewRepositoryFromSession(clock, user.UserId, user.AccountId, db)
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
 		result, err := repo.GetLastPlaidSync(context.Background(), plaidLink.PlaidLinkId)
 		assert.NoError(t, err, "should not receive an error when there is no previous plaid sync")
 		assert.Equal(t, plaidSync.PlaidSyncId, result.PlaidSyncId, "should have received the last inserted plaid sync")

--- a/server/repository/transaction_test.go
+++ b/server/repository/transaction_test.go
@@ -17,6 +17,7 @@ import (
 func TestRepositoryBase_GetTransactionsByPlaidTransactionId(t *testing.T) {
 	t.Run("non-pending", func(t *testing.T) {
 		clock := clock.NewMock()
+		log := testutils.GetLog(t)
 		db := testutils.GetPgDatabase(t)
 		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
 		link := fixtures.GivenIHaveAPlaidLink(t, clock, user)
@@ -28,7 +29,13 @@ func TestRepositoryBase_GetTransactionsByPlaidTransactionId(t *testing.T) {
 			models.CheckingBankAccountSubType,
 		)
 
-		repo := repository.NewRepositoryFromSession(clock, user.UserId, user.AccountId, db)
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
 
 		plaidTransaction := models.PlaidTransaction{
 			AccountId:          repo.AccountId(),
@@ -83,6 +90,7 @@ func TestRepositoryBase_GetTransactionsByPlaidTransactionId(t *testing.T) {
 
 	t.Run("with pending", func(t *testing.T) {
 		clock := clock.NewMock()
+		log := testutils.GetLog(t)
 		db := testutils.GetPgDatabase(t)
 		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
 		link := fixtures.GivenIHaveAPlaidLink(t, clock, user)
@@ -94,7 +102,13 @@ func TestRepositoryBase_GetTransactionsByPlaidTransactionId(t *testing.T) {
 			models.CheckingBankAccountSubType,
 		)
 
-		repo := repository.NewRepositoryFromSession(clock, user.UserId, user.AccountId, db)
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
 
 		pendingPlaidTransaction := models.PlaidTransaction{
 			AccountId:          repo.AccountId(),

--- a/server/repository/user_test.go
+++ b/server/repository/user_test.go
@@ -16,11 +16,18 @@ import (
 
 func TestRepositoryBase_GetMe(t *testing.T) {
 	clock := clock.NewMock()
+	log := testutils.GetLog(t)
 	db := testutils.GetPgDatabase(t)
 
 	user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
 
-	repo := repository.NewRepositoryFromSession(clock, user.UserId, user.AccountId, db)
+	repo := repository.NewRepositoryFromSession(
+		clock,
+		user.UserId,
+		user.AccountId,
+		db,
+		log,
+	)
 
 	me, err := repo.GetMe(context.Background())
 	assert.NoError(t, err, "should not return an error for retrieving me")
@@ -32,6 +39,7 @@ func TestRepositoryBase_GetMe(t *testing.T) {
 func TestRepositoryBase_GetAccountOwner(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		clock := clock.NewMock()
+		log := testutils.GetLog(t)
 		db := testutils.GetPgDatabase(t)
 		unauthenticatedRepo := GetTestUnauthenticatedRepository(t, clock)
 
@@ -79,7 +87,13 @@ func TestRepositoryBase_GetAccountOwner(t *testing.T) {
 		}
 
 		{ // When we are authenticated as the owner
-			ownerRepo := repository.NewRepositoryFromSession(clock, ownerUser.UserId, ownerUser.AccountId, db)
+			ownerRepo := repository.NewRepositoryFromSession(
+				clock,
+				ownerUser.UserId,
+				ownerUser.AccountId,
+				db,
+				log,
+			)
 			owner, err := ownerRepo.GetAccountOwner(context.Background())
 			assert.NoError(t, err, "must be able to retrieve the owner")
 			assert.NotNil(t, owner.Account, "account sub object should be included")
@@ -88,7 +102,13 @@ func TestRepositoryBase_GetAccountOwner(t *testing.T) {
 		}
 
 		{ // When we are authenticated as a member
-			memberRepo := repository.NewRepositoryFromSession(clock, memberUser.UserId, memberUser.AccountId, db)
+			memberRepo := repository.NewRepositoryFromSession(
+				clock,
+				memberUser.UserId,
+				memberUser.AccountId,
+				db,
+				log,
+			)
 			// Even if we are the member, we should still retrieve the owner who is
 			// not us. Makes sure the current user ID doesn't change the query.
 			owner, err := memberRepo.GetAccountOwner(context.Background())
@@ -101,6 +121,7 @@ func TestRepositoryBase_GetAccountOwner(t *testing.T) {
 
 	t.Run("missing owner", func(t *testing.T) {
 		clock := clock.NewMock()
+		log := testutils.GetLog(t)
 		db := testutils.GetPgDatabase(t)
 		unauthenticatedRepo := GetTestUnauthenticatedRepository(t, clock)
 
@@ -134,7 +155,13 @@ func TestRepositoryBase_GetAccountOwner(t *testing.T) {
 		}
 
 		{ // When there is no owner, we should get an error
-			memberRepo := repository.NewRepositoryFromSession(clock, memberUser.UserId, memberUser.AccountId, db)
+			memberRepo := repository.NewRepositoryFromSession(
+				clock,
+				memberUser.UserId,
+				memberUser.AccountId,
+				db,
+				log,
+			)
 			owner, err := memberRepo.GetAccountOwner(context.Background())
 			assert.Error(t, err, "must return an error when there is no owner")
 			assert.Nil(t, owner, "owner object should be nil when there is no owner")


### PR DESCRIPTION
This adds a shitload of logging to a ton of different areas, including
logging changes to budgets as they are calculated to help better
diagnose issues in the future. The logs produce enough information that
if a bug is reported in the calculations I should be able to compose a
test to reproduce the bug with the informataion.

This also changes several call signatures of the code internally in
order to more easily pass data through, like passing actual timezone
objects instead of just the timezone string.
