### PR TITLE
feat(ui): Adding UX to remove transactions for manual links

### DIFF
--- a/cmake/NodeModules.cmake
+++ b/cmake/NodeModules.cmake
@@ -25,7 +25,7 @@ set(SITEMAP_EXECUTABLE ${NODE_MODULES_BIN}/next-sitemap${JS_EXECUTABLE_SUFFIX})
 set(SPELLCHECKER_EXECUTABLE ${NODE_MODULES_BIN}/spellchecker${JS_EXECUTABLE_SUFFIX})
 set(STORYBOOK_EXECUTABLE ${NODE_MODULES_BIN}/storybook${JS_EXECUTABLE_SUFFIX})
 
-set(PNPM_ARGUMENTS "--frozen-lockfile")
+set(PNPM_ARGUMENTS "--frozen-lockfile" "--ignore-scripts")
 
 add_custom_command(
   OUTPUT ${NODE_MODULES}

--- a/interface/src/components/Layout/BalanceFreeToUseAmount.tsx
+++ b/interface/src/components/Layout/BalanceFreeToUseAmount.tsx
@@ -22,11 +22,12 @@ export default function BalanceFreeToUseAmount(): JSX.Element {
       });
 
       return (
-        <div className='flex w-full justify-between'>
+        <div className='flex w-full justify-between flex-shrink min-w-fit'>
           <MSpan size='lg' weight='semibold' className='dark:text-dark-monetr-content-emphasis'>
             <AccountBalanceWalletOutlined />
             Free-To-Use:
           </MSpan>
+          &nbsp;
           <MSpan size='lg' weight='semibold' className={ valueClassName }>
             { locale.formatAmount(balance?.free, AmountType.Stored) }
           </MSpan>

--- a/interface/src/components/Layout/BankSidebar.tsx
+++ b/interface/src/components/Layout/BankSidebar.tsx
@@ -1,13 +1,15 @@
 /* eslint-disable max-len */
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { ErrorOutline, Logout, PlusOne, Settings } from '@mui/icons-material';
+import { ErrorOutline } from '@mui/icons-material';
+import { LogOut, Settings } from 'lucide-react';
 
 import BankSidebarSubscriptionItem from './BankSidebarSubscriptionItem';
 import Logo from '@monetr/interface/assets/Logo';
 import BankSidebarItem from '@monetr/interface/components/Layout/BankSidebarItem';
 import MDivider from '@monetr/interface/components/MDivider';
 import MSidebarToggle from '@monetr/interface/components/MSidebarToggle';
+import MSpan from '@monetr/interface/components/MSpan';
 import { ReactElement } from '@monetr/interface/components/types';
 import { useLinks } from '@monetr/interface/hooks/links';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
@@ -64,7 +66,9 @@ export default function BankSidebar(props: BankSidebarProps): JSX.Element {
           to='/link/create'
           className='cursor-pointer absolute rounded-full w-10 h-10 dark:bg-dark-monetr-background-subtle dark:hover:bg-dark-monetr-background-emphasis drop-shadow-md flex justify-center items-center'
         >
-          <PlusOne className='text-3xl' />
+          <MSpan weight='bold' size='xl' color='emphasis'>
+            +1
+          </MSpan>
         </Link>
       </div>
     </SidebarWrapper>
@@ -125,7 +129,7 @@ function LogoutButton(): JSX.Element {
   // easier to prevent the current user's data from leaking into another session.
   return (
     <Link to='/logout' data-testid='bank-sidebar-logout'>
-      <Logout className='dark:hover:text-dark-monetr-content-emphasis dark:text-dark-monetr-content-subtle cursor-pointer' />
+      <LogOut className='dark:hover:text-dark-monetr-content-emphasis dark:text-dark-monetr-content-subtle cursor-pointer' />
     </Link>
   );
 }

--- a/interface/src/components/Layout/BudgetingSidebar.tsx
+++ b/interface/src/components/Layout/BudgetingSidebar.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable max-len */
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { PriceCheckOutlined, SavingsOutlined, ShoppingCartOutlined, TodayOutlined } from '@mui/icons-material';
-import { Infinity } from 'lucide-react';
+import { CalendarSync, Infinity, PiggyBank, Receipt, ShoppingCart } from 'lucide-react';
 
 import BudgetingSidebarTitle from './BudgetingSidebarTitle';
 import BalanceAvailableAmount from '@monetr/interface/components/Layout/BalanceAvailableAmount';
@@ -77,13 +76,13 @@ export default function BudgetingSidebar(props: BudgetingSidebarProps): JSX.Elem
 
         <div className='flex h-full w-full flex-col gap-2 pb-4'>
           <NavigationItem to={ `/bank/${bankAccount?.bankAccountId}/transactions` }>
-            <ShoppingCartOutlined />
+            <ShoppingCart />
             <MSpan ellipsis color='inherit'>
               Transactions
             </MSpan>
           </NavigationItem>
           <NavigationItem to={ `/bank/${bankAccount?.bankAccountId}/expenses` }>
-            <PriceCheckOutlined />
+            <Receipt />
             <MSpan ellipsis color='inherit'>
               Expenses
             </MSpan>
@@ -92,7 +91,7 @@ export default function BudgetingSidebar(props: BudgetingSidebarProps): JSX.Elem
             </MBadge>
           </NavigationItem>
           <NavigationItem to={ `/bank/${bankAccount?.bankAccountId}/goals` }>
-            <SavingsOutlined />
+            <PiggyBank />
             <MSpan ellipsis color='inherit'>
               Goals
             </MSpan>
@@ -101,7 +100,7 @@ export default function BudgetingSidebar(props: BudgetingSidebarProps): JSX.Elem
             </MBadge>
           </NavigationItem>
           <NavigationItem to={ `/bank/${bankAccount?.bankAccountId}/funding` }>
-            <TodayOutlined />
+            <CalendarSync />
             <MSpan ellipsis color='inherit'>
               Funding Schedules
             </MSpan>

--- a/interface/src/components/Layout/BudgetingSidebar.tsx
+++ b/interface/src/components/Layout/BudgetingSidebar.tsx
@@ -5,6 +5,9 @@ import { PriceCheckOutlined, SavingsOutlined, ShoppingCartOutlined, TodayOutline
 import { Infinity } from 'lucide-react';
 
 import BudgetingSidebarTitle from './BudgetingSidebarTitle';
+import BalanceAvailableAmount from '@monetr/interface/components/Layout/BalanceAvailableAmount';
+import BalanceCurrentAmount from '@monetr/interface/components/Layout/BalanceCurrentAmount';
+import BalanceFreeToUseAmount from '@monetr/interface/components/Layout/BalanceFreeToUseAmount';
 import PlaidBankStatusCard from '@monetr/interface/components/Layout/PlaidBankStatusCard';
 import PlaidLastUpdatedCard from '@monetr/interface/components/Layout/PlaidLastUpdatedCard';
 import SelectBankAccount from '@monetr/interface/components/Layout/SelectBankAccount';
@@ -18,9 +21,6 @@ import { useNextFundingDate } from '@monetr/interface/hooks/fundingSchedules';
 import useLocaleCurrency from '@monetr/interface/hooks/useLocaleCurrency';
 import { AmountType } from '@monetr/interface/util/amounts';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
-import BalanceFreeToUseAmount from '@monetr/interface/components/Layout/BalanceFreeToUseAmount';
-import BalanceAvailableAmount from '@monetr/interface/components/Layout/BalanceAvailableAmount';
-import BalanceCurrentAmount from '@monetr/interface/components/Layout/BalanceCurrentAmount';
 
 export interface BudgetingSidebarProps {
   className?: string;

--- a/interface/src/components/MTopNavigation.tsx
+++ b/interface/src/components/MTopNavigation.tsx
@@ -74,11 +74,31 @@ export default function MTopNavigation(props: MTopNavigationProps): JSX.Element 
           <BreadcrumbMaybe />
         </span>
       </div>
-      { props.children && (
-        <div className='flex gap-x-2 md:p-0'>
-          { props.children }
-        </div>
-      )}
+      <ActionArea children={ props.children } />
+    </div>
+  );
+}
+
+interface ActionAreaProps {
+  children?: React.ReactNode;
+}
+
+function ActionArea(props: ActionAreaProps): JSX.Element {
+  if (!props.children) return null;
+
+  const styles = mergeTailwind([
+    'flex justify-end gap-x-4 md:gap-x-2',
+    'md:relative fixed -bottom-1 md:bottom-auto left-0 md:left-auto',
+    // Hacky width and padding to make sure scrollbar renders properly
+    'p-4 pr-[calc(1rem-16px)] md:p-0',
+    'w-[calc(100vw-16px)] md:w-auto',
+    'z-20',
+    'backdrop-blur-sm bg-dark-monetr-background/90',
+  ]);
+
+  return (
+    <div className={ styles }>
+      { props.children }
     </div>
   );
 }

--- a/interface/src/components/MTopNavigation.tsx
+++ b/interface/src/components/MTopNavigation.tsx
@@ -66,8 +66,8 @@ export default function MTopNavigation(props: MTopNavigationProps): JSX.Element 
   }
 
   return (
-    <div className='w-full h-auto md:h-12 flex flex-col md:flex-row md:items-center px-4 gap-x-4 justify-between'>
-      <div className='flex gap-2 min-w-0 h-12 items-center flex-grow'>
+    <div className='w-full h-auto md:h-12 flex flex-col md:flex-row md:items-center px-4 gap-x-2 justify-between'>
+      <div className='flex gap-2 min-w-0 h-12 items-center flex-shrink'>
         <MSidebarToggle className='mr-2' backButton={ props.base } />
         <span className='flex gap-2 flex-grow min-w-0'>
           <InitialCrumb />
@@ -88,12 +88,13 @@ function ActionArea(props: ActionAreaProps): JSX.Element {
 
   const styles = mergeTailwind([
     'flex justify-end gap-x-4 md:gap-x-2',
+    'flex-shrink-0',
     'md:relative fixed -bottom-1 md:bottom-auto left-0 md:left-auto',
     // Hacky width and padding to make sure scrollbar renders properly
     'p-4 pr-[calc(1rem-16px)] md:p-0',
     'w-[calc(100vw-16px)] md:w-auto',
     'z-20',
-    'backdrop-blur-sm bg-dark-monetr-background/90',
+    'backdrop-blur-sm bg-dark-monetr-background/50',
   ]);
 
   return (

--- a/interface/src/components/Switch.tsx
+++ b/interface/src/components/Switch.tsx
@@ -18,7 +18,7 @@ const Switch = React.forwardRef<
       'focus-visible:ring-offset-2 focus-visible:ring-offset-background',
       // Disabled
       'disabled:cursor-not-allowed disabled:opacity-50',
-      // Checed
+      // Checked
       'data-[state=checked]:bg-dark-monetr-green data-[state=unchecked]:bg-dark-monetr-background-subtle',
       className
     ) }

--- a/interface/src/components/transactions/RemoveTransactionButton.tsx
+++ b/interface/src/components/transactions/RemoveTransactionButton.tsx
@@ -1,0 +1,40 @@
+import React, { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Trash } from 'lucide-react';
+
+import { Button } from '@monetr/interface/components/Button';
+import { useCurrentLink } from '@monetr/interface/hooks/links';
+import { showRemoveTransactionModal } from '@monetr/interface/modals/RemoveTransactionModal';
+import Transaction from '@monetr/interface/models/Transaction';
+
+interface RemoveTransactionButtonProps {
+  transaction: Transaction;
+}
+
+export default function RemoveTransactionButton(props: RemoveTransactionButtonProps): JSX.Element {
+  const { transaction } = props;
+  const { data: link } = useCurrentLink();
+  const navigate = useNavigate();
+
+  const promptRemoveTransaction = useCallback(async () => {
+    return await showRemoveTransactionModal({
+      transaction,
+    })
+      .then(() => navigate(`/bank/${ transaction.bankAccountId }/transactions`));
+  }, [navigate, transaction]);
+
+  // We only allow removing transactions on manual links.
+  if (!link.getIsManual()) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant='destructive'
+      onClick={ promptRemoveTransaction }
+    >
+      <Trash />
+      Remove
+    </Button>
+  );
+}

--- a/interface/src/components/transactions/SimilarTransactionItem.tsx
+++ b/interface/src/components/transactions/SimilarTransactionItem.tsx
@@ -10,6 +10,10 @@ import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 
 export interface SimilarTransactionItemProps {
   transactionId: string;
+  /**
+   * disableNavigate will remove the arrow link or the click-ability of the similar transaction item.
+   */
+  disableNavigate?: boolean;
 }
 
 export default function SimilarTransactionItem(props: SimilarTransactionItemProps): JSX.Element {
@@ -84,7 +88,9 @@ export default function SimilarTransactionItem(props: SimilarTransactionItemProp
           <span className={ amountClassnames }>
             { locale.formatAmount(Math.abs(transaction.amount), AmountType.Stored, transaction.amount < 0) }
           </span>
-          <ArrowLink redirect={ redirectUrl } />
+          { !props.disableNavigate && (
+            <ArrowLink redirect={ redirectUrl } />
+          ) }
         </div>
       </div>
     </li>

--- a/interface/src/hooks/transactions.ts
+++ b/interface/src/hooks/transactions.ts
@@ -188,3 +188,44 @@ export function useCreateTransaction(): (_: CreateTransactionRequest) => Promise
 
   return mutateAsync;
 }
+
+export interface RemoveTransactionRequest {
+  transaction: Transaction;
+  adjustsBalance: boolean;
+  softDelete: boolean;
+}
+
+interface RemoveTransactionResponse {
+  balance: Partial<Balance>;
+  spending: Partial<Spending> | null;
+}
+
+export function useRemoveTransaction(): (_: RemoveTransactionRequest) => Promise<unknown> {
+  const queryClient = useQueryClient();
+
+  // TODO It would be better to make this a mutator, however; since the response does not include the transaction that
+  // was removed it is tricky to do in place mutations. At the moment this implementation instead just invalidates the
+  // related queries that might be affected by the removal.
+  async function removeTransaction(removal: RemoveTransactionRequest): Promise<unknown> {
+    const { transaction, softDelete, adjustsBalance } = removal;
+    const path = `/bank_accounts/${transaction.bankAccountId}/transactions/${transaction.transactionId}`;
+    const params = new URLSearchParams();
+    { // Build the query parameters for the request.
+      params.set('adjusts_balance', String(adjustsBalance));
+      params.set('soft', String(softDelete));
+    }
+    // Send the delete request to the server and handle any changes returned.
+    return await request()
+      .delete(`${path}?${params.toString()}`)
+      .then(result => result.data)
+      .then(async (_: RemoveTransactionResponse) => await Promise.all([
+        // TODO Instead of just invalidating all of these, it would be more efficient to move them into a mutator so we
+        // can update their data in place.
+        queryClient.invalidateQueries([`/bank_accounts/${ removal.transaction.bankAccountId }/transactions`]),
+        queryClient.invalidateQueries([`/bank_accounts/${ removal.transaction.bankAccountId }/spending`]),
+        queryClient.invalidateQueries([`/bank_accounts/${ removal.transaction.bankAccountId }/balances`]),
+      ]));
+  }
+
+  return removeTransaction;
+}

--- a/interface/src/modals/RemoveTransactionModal.tsx
+++ b/interface/src/modals/RemoveTransactionModal.tsx
@@ -50,13 +50,10 @@ function RemoveTransactionModal(props: RemoveTransactionModalProps): JSX.Element
       softDelete: values.softDelete,
       adjustsBalance: values.adjustsBalance,
     })
-      .then(() => enqueueSnackbar(
-        'Transaction removed successfully',
-        {
-          variant: 'success',
-          disableWindowBlurListener: true,
-        },
-      ))
+      .then(() => void enqueueSnackbar('Transaction removed successfully', {
+        variant: 'success',
+        disableWindowBlurListener: true,
+      }))
       .then(() => modal.resolve())
       .then(() => modal.remove())
       .catch((error: AxiosError<APIError>) => void enqueueSnackbar(error.response.data['error'], {

--- a/interface/src/modals/RemoveTransactionModal.tsx
+++ b/interface/src/modals/RemoveTransactionModal.tsx
@@ -1,0 +1,148 @@
+import React, { Fragment, useCallback, useRef } from 'react';
+import NiceModal, { useModal } from '@ebay/nice-modal-react';
+import { AxiosError } from 'axios';
+import { FormikHelpers } from 'formik';
+import { Trash } from 'lucide-react';
+import { useSnackbar } from 'notistack';
+
+import { Button } from '@monetr/interface/components/Button';
+import FormButton from '@monetr/interface/components/FormButton';
+import MForm from '@monetr/interface/components/MForm';
+import MModal, { MModalRef } from '@monetr/interface/components/MModal';
+import MSpan from '@monetr/interface/components/MSpan';
+import { Switch } from '@monetr/interface/components/Switch';
+import SimilarTransactionItem from '@monetr/interface/components/transactions/SimilarTransactionItem';
+import { useRemoveTransaction } from '@monetr/interface/hooks/transactions';
+import Transaction from '@monetr/interface/models/Transaction';
+import { APIError } from '@monetr/interface/util/request';
+import { ExtractProps } from '@monetr/interface/util/typescriptEvils';
+
+interface RemoveTransactionModalProps {
+  transaction: Transaction;
+}
+
+interface RemoveTransactionModalValues {
+  adjustsBalance: boolean;
+  softDelete: boolean;
+}
+
+const initialValues: RemoveTransactionModalValues = {
+  adjustsBalance: false,
+  softDelete: true,
+};
+
+function RemoveTransactionModal(props: RemoveTransactionModalProps): JSX.Element {
+  const { transaction } = props;
+  const modal = useModal();
+  const ref = useRef<MModalRef>(null);
+  const { enqueueSnackbar } = useSnackbar();
+  const removeTransaction = useRemoveTransaction();
+
+  const submit = useCallback(async (
+    values: RemoveTransactionModalValues,
+    helpers: FormikHelpers<RemoveTransactionModalValues>,
+  ): Promise<void> => {
+    helpers.setSubmitting(true);
+
+    // Send the delete request to the server and handle any changes returned.
+    return await removeTransaction({
+      transaction,
+      softDelete: values.softDelete,
+      adjustsBalance: values.adjustsBalance,
+    })
+      .then(() => enqueueSnackbar(
+        'Transaction removed successfully',
+        {
+          variant: 'success',
+          disableWindowBlurListener: true,
+        },
+      ))
+      .then(() => modal.resolve())
+      .then(() => modal.remove())
+      .catch((error: AxiosError<APIError>) => void enqueueSnackbar(error.response.data['error'], {
+        variant: 'error',
+        disableWindowBlurListener: true,
+      }))
+      .finally(() => helpers.setSubmitting(false));
+  }, [enqueueSnackbar, modal, removeTransaction, transaction]);
+
+  return (
+    <MModal open={ modal.visible } ref={ ref } className='md:max-w-md'>
+      <MForm
+        onSubmit={ submit }
+        initialValues={ initialValues }
+        className='h-full flex flex-col gap-stack p-2 justify-between'
+      >
+        { ({ setFieldValue, values, isSubmitting }) => (
+          <Fragment>
+            <div className='flex flex-col gap-stack'>
+              <MSpan weight='bold' size='xl' className='mb-2'>
+                <Trash />
+                Remove Transaction
+              </MSpan>
+              <div className='flex flex-col gap-stack'>
+                <MSpan>
+                  Are you sure you want to remove this transaction?
+                </MSpan>
+                <ul>
+                  <SimilarTransactionItem
+                    transactionId={ transaction.transactionId }
+                    disableNavigate
+                  />
+                </ul>
+                <MSpan>
+                  You will not be able to undo this action.
+                </MSpan>
+                <div className='flex flex-row items-center justify-between rounded-lg ring-1 p-2 ring-dark-monetr-border-string gap-component'>
+                  <div className='gap-component'>
+                    <label className='text-sm font-medium text-dark-monetr-content-emphasis cursor-pointer'>
+                      Prevent Re-Creation
+                    </label>
+                    <p className='text-sm text-dark-monetr-content'>
+                      Prevent this transaction from be re-created if it is present in future file imports?
+                    </p>
+                  </div>
+                  <Switch
+                    checked={ values['softDelete'] }
+                    onCheckedChange={ () => setFieldValue('softDelete', !values['softDelete']) }
+                  />
+                </div>
+                <div className='flex flex-row items-center justify-between rounded-lg ring-1 p-2 ring-dark-monetr-border-string gap-component'>
+                  <div className='gap-component'>
+                    <label className='text-sm font-medium text-dark-monetr-content-emphasis cursor-pointer'>
+                      Adjust Balance
+                    </label>
+                    <p className='text-sm text-dark-monetr-content'>
+                      Update your account balance as if this transaction was reversed?
+                    </p>
+                  </div>
+                  <Switch
+                    checked={ values['adjustsBalance'] }
+                    onCheckedChange={ () => setFieldValue('adjustsBalance', !values['adjustsBalance']) }
+                  />
+                </div>
+              </div>
+              <div className='flex justify-end gap-stack mt-4'>
+                <Button disabled={ isSubmitting } variant='secondary' onClick={ modal.remove }>
+                  Cancel
+                </Button>
+                <FormButton variant='destructive' type='submit'>
+                  Remove
+                </FormButton>
+              </div>
+            </div>
+          </Fragment>
+        ) }
+      </MForm>
+    </MModal>
+  );
+}
+
+const removeTransactionModal = NiceModal.create<RemoveTransactionModalProps>(RemoveTransactionModal);
+
+export default removeTransactionModal;
+
+export function showRemoveTransactionModal(props: RemoveTransactionModalProps): Promise<void> {
+  return NiceModal.show<void, ExtractProps<typeof removeTransactionModal>, {}>(removeTransactionModal, props);
+}
+

--- a/interface/src/modals/TransferModal.tsx
+++ b/interface/src/modals/TransferModal.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useRef } from 'react';
 import NiceModal, { useModal } from '@ebay/nice-modal-react';
-import { SwapVertOutlined } from '@mui/icons-material';
 import { AxiosError } from 'axios';
 import { FormikErrors, FormikHelpers, useFormikContext } from 'formik';
+import { ArrowUpDown } from 'lucide-react';
 import { useSnackbar } from 'notistack';
 
+import FormButton from '@monetr/interface/components/FormButton';
 import MAmountField from '@monetr/interface/components/MAmountField';
-import MFormButton from '@monetr/interface/components/MButton';
 import MForm from '@monetr/interface/components/MForm';
 import { MLabelDecoratorProps } from '@monetr/interface/components/MLabel';
 import MModal, { MModalRef } from '@monetr/interface/components/MModal';
@@ -141,19 +141,19 @@ function TransferModal(props: TransferModalProps): JSX.Element {
           />
         </div>
         <div className='flex justify-end gap-2'>
-          <MFormButton
-            color='secondary'
+          <FormButton
+            variant='secondary'
             onClick={ modal.remove }
             data-testid='close-new-expense-modal'
           >
             Cancel
-          </MFormButton>
-          <MFormButton
-            color='primary'
+          </FormButton>
+          <FormButton
+            variant='primary'
             type='submit'
           >
             Transfer
-          </MFormButton>
+          </FormButton>
         </div>
       </MForm>
     </MModal>
@@ -184,9 +184,9 @@ function ReverseTargetsButton(): JSX.Element {
 
   return (
     <a className='w-full flex justify-center mb-1'>
-      <SwapVertOutlined
+      <ArrowUpDown
         onClick={ swap }
-        className='cursor-pointer text-4xl dark:text-dark-monetr-content-subtle hover:dark:text-dark-monetr-content'
+        className='h-10 w-10 cursor-pointer text-4xl dark:text-dark-monetr-content-subtle hover:dark:text-dark-monetr-content'
       />
     </a>
   );

--- a/interface/src/pages/expense/details.tsx
+++ b/interface/src/pages/expense/details.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { DeleteOutlined, HeartBroken, PriceCheckOutlined, SaveOutlined, SwapVertOutlined } from '@mui/icons-material';
+import { HeartBroken, PriceCheckOutlined } from '@mui/icons-material';
 import { AxiosError } from 'axios';
 import { startOfDay, startOfToday } from 'date-fns';
 import { FormikHelpers } from 'formik';
+import { ArrowUpDown, Save, Trash } from 'lucide-react';
 import { useSnackbar } from 'notistack';
 
 import ExpenseTimeline from './ExpenseTimeline';
+import { Button } from '@monetr/interface/components/Button';
 import FormButton from '@monetr/interface/components/FormButton';
 import MAmountField from '@monetr/interface/components/MAmountField';
-import { MBaseButton } from '@monetr/interface/components/MButton';
 import MDatePicker from '@monetr/interface/components/MDatePicker';
 import MDivider from '@monetr/interface/components/MDivider';
 import MerchantIcon from '@monetr/interface/components/MerchantIcon';
@@ -169,24 +170,23 @@ export default function ExpenseDetails(): JSX.Element {
         base={ `/bank/${spending.bankAccountId}/expenses` }
         breadcrumb={ spending?.name }
       >
-        <MBaseButton
-          color='secondary'
-          className='gap-1 py-1 px-2'
+        <Button
+          variant='secondary'
           onClick={ () => showTransferModal({ initialToSpendingId: spending?.spendingId }) }
         >
-          <SwapVertOutlined />
-            Transfer
-        </MBaseButton>
-        <MBaseButton color='cancel' className='gap-1 py-1 px-2' onClick={ deleteExpense } >
-          <DeleteOutlined />
+          <ArrowUpDown />
+          Transfer
+        </Button>
+        <Button variant='destructive' onClick={ deleteExpense } >
+          <Trash />
           Remove
-        </MBaseButton>
+        </Button>
         <FormButton variant='primary' type='submit' role='form'>
-          <SaveOutlined />
+          <Save />
           Save
         </FormButton>
       </MTopNavigation>
-      <div className='w-full h-full overflow-y-auto min-w-0 p-4'>
+      <div className='w-full h-full overflow-y-auto min-w-0 p-4 pb-16 md:pb-4'>
         <div className='flex flex-col md:flex-row w-full gap-8 items-center md:items-stretch'>
           <div className='w-full md:w-1/2 flex flex-col items-center'>
 

--- a/interface/src/pages/funding/details.tsx
+++ b/interface/src/pages/funding/details.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import { useMatch, useNavigate } from 'react-router-dom';
-import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
 import HeartBroken from '@mui/icons-material/HeartBroken';
-import SaveOutlined from '@mui/icons-material/SaveOutlined';
 import TodayOutlined from '@mui/icons-material/TodayOutlined';
 import { AxiosError } from 'axios';
 import { format, isEqual, startOfDay } from 'date-fns';
 import { FormikErrors, FormikHelpers } from 'formik';
+import { Save, Trash } from 'lucide-react';
 import { useSnackbar } from 'notistack';
 
+import { Button } from '@monetr/interface/components/Button';
+import FormButton from '@monetr/interface/components/FormButton';
 import FundingTimeline from '@monetr/interface/components/funding/FundingTimeline';
 import MAmountField from '@monetr/interface/components/MAmountField';
-import MFormButton, { MBaseButton } from '@monetr/interface/components/MButton';
 import MCheckbox from '@monetr/interface/components/MCheckbox';
 import MDatePicker from '@monetr/interface/components/MDatePicker';
 import MDivider from '@monetr/interface/components/MDivider';
@@ -155,16 +155,16 @@ export default function FundingDetails(): JSX.Element {
         breadcrumb={ funding.name }
         base={ `/bank/${funding.bankAccountId}/funding` }
       >
-        <MBaseButton color='cancel' className='gap-1 py-1 px-2' onClick={ removeFunding } >
-          <DeleteOutlined />
+        <Button variant='destructive' onClick={ removeFunding } >
+          <Trash />
           Remove
-        </MBaseButton>
-        <MFormButton color='primary' className='gap-1 py-1 px-2' type='submit' role='form'>
-          <SaveOutlined />
+        </Button>
+        <FormButton variant='primary' className='gap-1 py-1 px-2' type='submit' role='form'>
+          <Save />
           Save
-        </MFormButton>
+        </FormButton>
       </MTopNavigation>
-      <div className='w-full h-full overflow-y-auto min-w-0 p-4'>
+      <div className='w-full h-full overflow-y-auto min-w-0 p-4 pb-16 md:pb-4'>
         <div className='flex flex-col md:flex-row w-full gap-8 items-center md:items-stretch'>
           <div className='w-full md:w-1/2 flex flex-col'>
             <MTextField className='w-full' label='Name' name='name' id='funding-name-search' required />

--- a/interface/src/pages/goals.tsx
+++ b/interface/src/pages/goals.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment, useCallback, useEffect, useRef } from 'react';
 import { useNavigationType } from 'react-router-dom';
-import { HeartBroken, SavingsOutlined } from '@mui/icons-material';
-import { Plus } from 'lucide-react';
+import { HeartBroken } from '@mui/icons-material';
+import { PiggyBank, Plus } from 'lucide-react';
 
 import { Button } from '@monetr/interface/components/Button';
 import GoalItem from '@monetr/interface/components/goals/GoalItem';
@@ -83,7 +83,7 @@ export default function Goals(): JSX.Element {
 
   return (
     <Fragment>
-      <MTopNavigation icon={ SavingsOutlined } title='Goals' >
+      <MTopNavigation icon={ PiggyBank } title='Goals' >
         <Button variant='primary' onClick={ showNewGoalModal }>
           <Plus />
           New Goal
@@ -101,7 +101,7 @@ function EmptyState(): JSX.Element {
     <div className='w-full h-full flex justify-center items-center'>
       <div className='flex flex-col gap-2 items-center max-w-md'>
         <div className='w-full flex justify-center space-x-4'>
-          <SavingsOutlined className='h-full text-5xl dark:text-dark-monetr-content-muted' />
+          <PiggyBank className='w-16 h-16 dark:text-dark-monetr-content-muted' />
         </div>
         <MSpan size='xl' color='subtle' className='text-center'>
           You don't have any goals yet...

--- a/interface/src/pages/goals/details.tsx
+++ b/interface/src/pages/goals/details.tsx
@@ -2,12 +2,11 @@ import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
   HeartBroken,
-  SavingsOutlined,
 } from '@mui/icons-material';
 import { AxiosError } from 'axios';
 import { startOfDay, startOfToday } from 'date-fns';
 import { FormikHelpers } from 'formik';
-import { ArrowUpDown, Save, Trash } from 'lucide-react';
+import { ArrowUpDown, PiggyBank, Save, Trash } from 'lucide-react';
 import { useSnackbar } from 'notistack';
 
 import { Button } from '@monetr/interface/components/Button';
@@ -172,7 +171,7 @@ export default function GoalDetails(): JSX.Element {
   return (
     <MForm initialValues={ initialValues } onSubmit={ submit } className='flex w-full h-full flex-col'>
       <MTopNavigation
-        icon={ SavingsOutlined }
+        icon={ PiggyBank }
         title='Goals'
         base={ `/bank/${spending.bankAccountId}/goals` }
         breadcrumb={ spending?.name }

--- a/interface/src/pages/goals/details.tsx
+++ b/interface/src/pages/goals/details.tsx
@@ -1,20 +1,19 @@
 import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
-  DeleteOutlined,
   HeartBroken,
-  SaveOutlined,
   SavingsOutlined,
-  SwapVertOutlined,
 } from '@mui/icons-material';
 import { AxiosError } from 'axios';
 import { startOfDay, startOfToday } from 'date-fns';
 import { FormikHelpers } from 'formik';
+import { ArrowUpDown, Save, Trash } from 'lucide-react';
 import { useSnackbar } from 'notistack';
 
+import { Button } from '@monetr/interface/components/Button';
+import FormButton from '@monetr/interface/components/FormButton';
 import GoalTimeline from '@monetr/interface/components/goals/GoalTimeline';
 import MAmountField from '@monetr/interface/components/MAmountField';
-import MFormButton, { MBaseButton } from '@monetr/interface/components/MButton';
 import MCheckbox from '@monetr/interface/components/MCheckbox';
 import MDatePicker from '@monetr/interface/components/MDatePicker';
 import MDivider from '@monetr/interface/components/MDivider';
@@ -178,24 +177,23 @@ export default function GoalDetails(): JSX.Element {
         base={ `/bank/${spending.bankAccountId}/goals` }
         breadcrumb={ spending?.name }
       >
-        <MBaseButton
-          color='secondary'
-          className='gap-1 py-1 px-2'
+        <Button
+          variant='secondary'
           onClick={ () => showTransferModal({ initialToSpendingId: spending?.spendingId }) }
         >
-          <SwapVertOutlined />
+          <ArrowUpDown />
           Transfer
-        </MBaseButton>
-        <MBaseButton color='cancel' className='gap-1 py-1 px-2' onClick={ deleteGoal } >
-          <DeleteOutlined />
+        </Button>
+        <Button variant='destructive' onClick={ deleteGoal } >
+          <Trash />
           Remove
-        </MBaseButton>
-        <MFormButton color='primary' className='gap-1 py-1 px-2' type='submit' role='form'>
-          <SaveOutlined />
+        </Button>
+        <FormButton variant='primary' type='submit' role='form'>
+          <Save />
           Save
-        </MFormButton>
+        </FormButton>
       </MTopNavigation>
-      <div className='w-full h-full overflow-y-auto min-w-0 p-4'>
+      <div className='w-full h-full overflow-y-auto min-w-0 p-4 pb-16 md:pb-4'>
         <div className='flex flex-col md:flex-row w-full gap-8 items-center md:items-stretch'>
           <div className='w-full md:w-1/2 flex flex-col'>
 

--- a/interface/src/pages/transaction/details.tsx
+++ b/interface/src/pages/transaction/details.tsx
@@ -4,10 +4,11 @@ import { ShoppingCartOutlined } from '@mui/icons-material';
 import { AxiosError } from 'axios';
 import { startOfDay } from 'date-fns';
 import { FormikHelpers } from 'formik';
-import { HeartCrack, Save } from 'lucide-react';
+import { HeartCrack, Save, Trash } from 'lucide-react';
 import { useSnackbar } from 'notistack';
 
 import { Button } from '@monetr/interface/components/Button';
+import FormButton from '@monetr/interface/components/FormButton';
 import MAmountField from '@monetr/interface/components/MAmountField';
 import MCheckbox from '@monetr/interface/components/MCheckbox';
 import MDatePicker from '@monetr/interface/components/MDatePicker';
@@ -129,12 +130,16 @@ export default function TransactionDetails(): JSX.Element {
         base={ `/bank/${transaction.bankAccountId}/transactions` }
         breadcrumb={ transaction?.name }
       >
-        <Button variant='primary' className='gap-1 py-1 px-2' type='submit'>
+        <Button variant='destructive' className='gap-1 py-1 px-2' onClick={ () => {} } >
+          <Trash />
+          Remove
+        </Button>
+        <FormButton variant='primary' className='gap-1 py-1 px-2' type='submit' role='form'>
           <Save />
           Save Changes
-        </Button>
+        </FormButton>
       </MTopNavigation>
-      <div className='w-full h-full overflow-y-auto min-w-0 p-4'>
+      <div className='w-full h-full overflow-y-auto min-w-0 p-4 pb-16 md:pb-4'>
         <div className='flex flex-col md:flex-row w-full gap-8 items-center md:items-stretch'>
           <div className='w-full md:w-1/2 flex flex-col items-center'>
             <div className='w-full flex justify-center mb-2'>

--- a/interface/src/pages/transaction/details.tsx
+++ b/interface/src/pages/transaction/details.tsx
@@ -1,12 +1,11 @@
 import React, { useCallback } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { AxiosError } from 'axios';
 import { startOfDay } from 'date-fns';
 import { FormikHelpers } from 'formik';
-import { HeartCrack, Save, ShoppingCart, Trash } from 'lucide-react';
+import { HeartCrack, Save, ShoppingCart } from 'lucide-react';
 import { useSnackbar } from 'notistack';
 
-import { Button } from '@monetr/interface/components/Button';
 import FormButton from '@monetr/interface/components/FormButton';
 import MAmountField from '@monetr/interface/components/MAmountField';
 import MCheckbox from '@monetr/interface/components/MCheckbox';
@@ -17,11 +16,11 @@ import MSelectSpending from '@monetr/interface/components/MSelectSpending';
 import MSpan from '@monetr/interface/components/MSpan';
 import MTextField from '@monetr/interface/components/MTextField';
 import MTopNavigation from '@monetr/interface/components/MTopNavigation';
+import RemoveTransactionButton from '@monetr/interface/components/transactions/RemoveTransactionButton';
 import SimilarTransactions from '@monetr/interface/components/transactions/SimilarTransactions';
 import { useCurrentLink } from '@monetr/interface/hooks/links';
 import { useTransaction, useUpdateTransaction } from '@monetr/interface/hooks/transactions';
 import useLocaleCurrency from '@monetr/interface/hooks/useLocaleCurrency';
-import { showRemoveTransactionModal } from '@monetr/interface/modals/RemoveTransactionModal';
 import Transaction from '@monetr/interface/models/Transaction';
 import { APIError } from '@monetr/interface/util/request';
 
@@ -37,7 +36,6 @@ interface TransactionValues {
 export default function TransactionDetails(): JSX.Element {
   const { data: locale } = useLocaleCurrency();
   const { data: link } = useCurrentLink();
-  const navigate = useNavigate();
   const { enqueueSnackbar } = useSnackbar();
   const { transactionId: id } = useParams();
   const updateTransaction = useUpdateTransaction();
@@ -109,13 +107,6 @@ export default function TransactionDetails(): JSX.Element {
     );
   }
 
-  async function promptRemoveTransaction() {
-    return await showRemoveTransactionModal({
-      transaction,
-    })
-      .then(() => navigate(`/bank/${ transaction.bankAccountId }/transactions`));
-  }
-
   const initialValues: TransactionValues = {
     name: transaction.name,
     originalName: transaction.originalName,
@@ -138,15 +129,8 @@ export default function TransactionDetails(): JSX.Element {
         base={ `/bank/${transaction.bankAccountId}/transactions` }
         breadcrumb={ transaction?.name }
       >
-        <Button
-          variant='destructive'
-          className='flex-shrink-0'
-          onClick={ promptRemoveTransaction }
-        >
-          <Trash />
-          Remove
-        </Button>
-        <FormButton variant='primary' className='flex-shrink-0' type='submit' role='form'>
+        <RemoveTransactionButton transaction={ transaction } />
+        <FormButton variant='primary' type='submit' role='form'>
           <Save />
           Save Changes
         </FormButton>

--- a/interface/src/pages/transaction/details.tsx
+++ b/interface/src/pages/transaction/details.tsx
@@ -1,10 +1,9 @@
 import React, { useCallback } from 'react';
 import { useParams } from 'react-router-dom';
-import { ShoppingCartOutlined } from '@mui/icons-material';
 import { AxiosError } from 'axios';
 import { startOfDay } from 'date-fns';
 import { FormikHelpers } from 'formik';
-import { HeartCrack, Save, Trash } from 'lucide-react';
+import { HeartCrack, Save, ShoppingCart, Trash } from 'lucide-react';
 import { useSnackbar } from 'notistack';
 
 import { Button } from '@monetr/interface/components/Button';
@@ -125,7 +124,7 @@ export default function TransactionDetails(): JSX.Element {
       className='flex w-full h-full flex-col'
     >
       <MTopNavigation
-        icon={ ShoppingCartOutlined }
+        icon={ ShoppingCart }
         title='Transactions'
         base={ `/bank/${transaction.bankAccountId}/transactions` }
         breadcrumb={ transaction?.name }

--- a/interface/src/pages/transaction/details.tsx
+++ b/interface/src/pages/transaction/details.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { AxiosError } from 'axios';
 import { startOfDay } from 'date-fns';
 import { FormikHelpers } from 'formik';
@@ -21,6 +21,7 @@ import SimilarTransactions from '@monetr/interface/components/transactions/Simil
 import { useCurrentLink } from '@monetr/interface/hooks/links';
 import { useTransaction, useUpdateTransaction } from '@monetr/interface/hooks/transactions';
 import useLocaleCurrency from '@monetr/interface/hooks/useLocaleCurrency';
+import { showRemoveTransactionModal } from '@monetr/interface/modals/RemoveTransactionModal';
 import Transaction from '@monetr/interface/models/Transaction';
 import { APIError } from '@monetr/interface/util/request';
 
@@ -36,6 +37,7 @@ interface TransactionValues {
 export default function TransactionDetails(): JSX.Element {
   const { data: locale } = useLocaleCurrency();
   const { data: link } = useCurrentLink();
+  const navigate = useNavigate();
   const { enqueueSnackbar } = useSnackbar();
   const { transactionId: id } = useParams();
   const updateTransaction = useUpdateTransaction();
@@ -107,6 +109,13 @@ export default function TransactionDetails(): JSX.Element {
     );
   }
 
+  async function promptRemoveTransaction() {
+    return await showRemoveTransactionModal({
+      transaction,
+    })
+      .then(() => navigate(`/bank/${ transaction.bankAccountId }/transactions`));
+  }
+
   const initialValues: TransactionValues = {
     name: transaction.name,
     originalName: transaction.originalName,
@@ -129,11 +138,15 @@ export default function TransactionDetails(): JSX.Element {
         base={ `/bank/${transaction.bankAccountId}/transactions` }
         breadcrumb={ transaction?.name }
       >
-        <Button variant='destructive' className='gap-1 py-1 px-2' onClick={ () => {} } >
+        <Button
+          variant='destructive'
+          className='flex-shrink-0'
+          onClick={ promptRemoveTransaction }
+        >
           <Trash />
           Remove
         </Button>
-        <FormButton variant='primary' className='gap-1 py-1 px-2' type='submit' role='form'>
+        <FormButton variant='primary' className='flex-shrink-0' type='submit' role='form'>
           <Save />
           Save Changes
         </FormButton>

--- a/interface/src/pages/transactions.tsx
+++ b/interface/src/pages/transactions.tsx
@@ -7,6 +7,7 @@ import { Plus, Upload } from 'lucide-react';
 import * as R from 'ramda';
 
 import { Button } from '@monetr/interface/components/Button';
+import BalanceFreeToUseAmount from '@monetr/interface/components/Layout/BalanceFreeToUseAmount';
 import MSpan from '@monetr/interface/components/MSpan';
 import MTopNavigation from '@monetr/interface/components/MTopNavigation';
 import TransactionDateItem from '@monetr/interface/components/transactions/TransactionDateItem';
@@ -156,8 +157,8 @@ export default function Transactions(): JSX.Element {
           title='Transactions'
         >
           <UploadButtonMaybe />
-          <AddTransactionButton />
         </MTopNavigation>
+        <AddTransactionButton />
         <div className='w-full h-full flex justify-center items-center'>
           <div className='flex flex-col gap-2 items-center max-w-md'>
             <div className='w-full flex justify-center space-x-4'>
@@ -182,9 +183,14 @@ export default function Transactions(): JSX.Element {
         icon={ ShoppingCartOutlined }
         title='Transactions'
       >
+        <div className='w-screen md:hidden flex justify-evenly'>
+          <div className='flex flex-grow w-full' /> { /* These force the free to use to be more centered */ }
+          <BalanceFreeToUseAmount />
+          <div className='flex flex-grow w-full' />
+        </div>
         <UploadButtonMaybe />
-        <AddTransactionButton />
       </MTopNavigation>
+      <AddTransactionButton />
       <div className='flex flex-grow min-w-0 min-h-0'>
         <ul className='w-full overflow-y-auto pb-16' ref={ ref }>
           <TransactionItems />
@@ -224,7 +230,7 @@ function AddTransactionButton(): JSX.Element {
 
   return (
     <button 
-      className='fixed bottom-4 right-4 w-14 h-14 rounded-full bg-dark-monetr-brand-subtle backdrop-blur-sm bg-opacity-75 backdrop-brightness-200 z-20 flex items-center justify-center active:backdrop-brightness-50'
+      className='fixed md:bottom-4 bottom-8 right-4 w-14 h-14 rounded-full bg-dark-monetr-brand-subtle backdrop-blur-sm bg-opacity-75 backdrop-brightness-200 z-20 flex items-center justify-center active:backdrop-brightness-50'
       onClick={ showNewTransactionModal }
     >
       <Plus className='h-12 w-12 text-dark-monetr-content' />

--- a/interface/src/pages/transactions.tsx
+++ b/interface/src/pages/transactions.tsx
@@ -1,9 +1,9 @@
 import React, { Fragment, useCallback, useEffect, useRef } from 'react';
 import useInfiniteScroll from 'react-infinite-scroll-hook';
 import { useNavigationType } from 'react-router-dom';
-import { HeartBroken, ShoppingCartOutlined } from '@mui/icons-material';
+import { HeartBroken } from '@mui/icons-material';
 import { format, getUnixTime, parse } from 'date-fns';
-import { Plus, Upload } from 'lucide-react';
+import { Plus, ShoppingCart, Upload } from 'lucide-react';
 import * as R from 'ramda';
 
 import { Button } from '@monetr/interface/components/Button';
@@ -153,7 +153,7 @@ export default function Transactions(): JSX.Element {
     return (
       <Fragment>
         <MTopNavigation
-          icon={ ShoppingCartOutlined }
+          icon={ ShoppingCart }
           title='Transactions'
         >
           <UploadButtonMaybe />
@@ -162,7 +162,7 @@ export default function Transactions(): JSX.Element {
         <div className='w-full h-full flex justify-center items-center'>
           <div className='flex flex-col gap-2 items-center max-w-md'>
             <div className='w-full flex justify-center space-x-4'>
-              <ShoppingCartOutlined className='h-full text-5xl dark:text-dark-monetr-content-muted' />
+              <ShoppingCart className='h-16 w-16 text-5xl dark:text-dark-monetr-content-muted' />
             </div>
             <MSpan size='xl' color='subtle' className='text-center'>
               You don't have any transactions yet...
@@ -180,7 +180,7 @@ export default function Transactions(): JSX.Element {
   return (
     <Fragment>
       <MTopNavigation
-        icon={ ShoppingCartOutlined }
+        icon={ ShoppingCart }
         title='Transactions'
       >
         <div className='w-screen md:hidden flex justify-evenly'>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -99,6 +99,10 @@ const config: Partial<Config> = {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
       },
+      gap: {
+        'component': '0.125rem', // gap-0.5
+        'stack': '0.5rem', // gap-2
+      },
       colors: {
         inherit: 'inherit',
         current: 'currentColor',


### PR DESCRIPTION
If you are working with a manual budget, you will now be able to remove
transactions from that budget. Navigating to the transaction details
page and clicking remove will show a confirmation modal, prompting you
whether or not removing the transaction will affect balances.

Resolves #2542 
