### PR TITLE
feat(api): Improve similarity caluclations

### DIFF
--- a/server/internal/calc/euclidean_amd64.go
+++ b/server/internal/calc/euclidean_amd64.go
@@ -23,6 +23,8 @@ func init() {
 		euclideanImplementation64 = __euclideanDistance64_AVX512
 		euclideanImplementation32 = __euclideanDistance32_AVX512
 	} else if cpu.X86.HasAVX {
+		// TODO Technically these rely on both AVX and FMA instructions so there
+		// might need to be additional checks here?
 		euclideanImplementation64 = __euclideanDistance64_AVX
 		euclideanImplementation32 = __euclideanDistance32_AVX
 	}

--- a/server/internal/calc/euclidean_amd64.s
+++ b/server/internal/calc/euclidean_amd64.s
@@ -2,18 +2,17 @@
 
 // func __euclideanDistance64_AVX(a, b []float64) float64
 TEXT ·__euclideanDistance64_AVX(SB), NOSPLIT, $48-56
-  MOVQ a_len+8(FP),   DX // Load the length of a into the DX register.
+  MOVQ a_len+8(FP),   DX // Load the length of A into the DX register.
   MOVQ a_base+0(FP),  AX // Load the pointer of the first array.
   MOVQ b_base+24(FP), BX // Load the pointer of the second array.
 
   VXORPD Y0, Y0, Y0 // Clear the accumulator register.
 
   LOOP:
-    VMOVUPD (AX), Y1  // Load the current 4 float64s from a into the 256-bit register Y1.
-    VMOVUPD (BX), Y2  // Load the current 4 float64s from b into the 256-bit register Y2.
-    VSUBPD Y1, Y2, Y1 // Subtract the 4 from a from the 4 from b and store the result in Y1.
-    VMULPD Y1, Y1, Y2 // Then square Y1 (the result of the subtraction) and store it in Y2.
-    VADDPD Y2, Y0, Y0 // Then add the result of Y2 into the accumulator register.
+    VMOVUPD     (AX), Y1   // Load the current 4 float64s from AX into the 256-bit register Y1.
+    VMOVUPD     (BX), Y2   // Load the current 4 float64s from BX into the 256-bit register Y2.
+    VSUBPD      Y1, Y2, Y1 // Subtract the 4 from AX from the 4 from BX and store the result in Y1.
+    VFMADD231PD Y1, Y1, Y0 // Square the Y1 register and add the result to the Y0 accumulator register.
 
     ADDQ $32, AX      // Add 32 (4 * 8) to the AX and BX registers. This moves the pointer forward
     ADDQ $32, BX      // in the array by 4 items for the next simd operation to take place.
@@ -40,8 +39,7 @@ TEXT ·__euclideanDistance32_AVX(SB), NOSPLIT, $48-52
     VMOVUPS (AX), Y1  // Load the current 8 float32s from a into the 256-bit register Y1.
     VMOVUPS (BX), Y2  // Load the current 8 float32s from b into the 256-bit register Y2.
     VSUBPS Y1, Y2, Y1 // Subtract the 8 from a from the 8 from b and store the result in Y1.
-    VMULPS Y1, Y1, Y2 // Then square Y1 (the result of the subtraction) and store it in Y2.
-    VADDPS Y2, Y0, Y0 // Then add the result of Y2 into the accumulator register.
+    VFMADD231PS Y1, Y1, Y0 // Square the Y1 register and add the result to the Y0 accumulator register.
 
     ADDQ $32, AX      // Add 32 (4 * 8) to the AX and BX registers. This moves the pointer forward
     ADDQ $32, BX      // in the array by 4 items for the next simd operation to take place.
@@ -70,8 +68,7 @@ TEXT ·__euclideanDistance64_AVX512(SB), NOSPLIT, $48-56
     VMOVUPD (AX), Z1  // Load the current 8 float64s from a into the 512-bit register ZMM1.
     VMOVUPD (BX), Z2  // Load the current 8 float64s from b into the 512-bit register ZMM2.
     VSUBPD Z1, Z2, Z1 // Subtract the 8 from a from the 8 from b and store the result in ZMM1.
-    VMULPD Z1, Z1, Z2 // Then square ZMM1 (the result of the subtraction) and store it in ZMM2.
-    VADDPD Z2, Z0, Z0 // Then add the result of ZMM2 into the accumulator register.
+    VFMADD231PD Z1, Z1, Z0 // Square the ZMM1 register and add it to the ZMM0 accumulator register.
 
     ADDQ $64, AX      // Add 64 (8 * 8) to the AX and BX registers. This moves the pointer forward
     ADDQ $64, BX      // in the array by 8 items for the next simd operation to take place.
@@ -102,8 +99,7 @@ TEXT ·__euclideanDistance32_AVX512(SB), NOSPLIT, $48-52
     VMOVUPS (AX), Z1  // Load the current 16 float64s from a into the 512-bit register ZMM1.
     VMOVUPS (BX), Z2  // Load the current 16 float64s from b into the 512-bit register ZMM2.
     VSUBPS Z1, Z2, Z1 // Subtract the 16 from a from the 16 from b and store the result in ZMM1.
-    VMULPS Z1, Z1, Z2 // Then square ZMM1 (the result of the subtraction) and store it in ZMM2.
-    VADDPS Z2, Z0, Z0 // Then add the result of ZMM2 into the accumulator register.
+    VFMADD231PS Z1, Z1, Z0 // Square the ZMM1 register and add it to the ZMM0 accumulator register.
 
     ADDQ $64, AX      // Add 64 (16 * 4) to the AX and BX registers. This moves the pointer forward
     ADDQ $64, BX      // in the array by 16 items for the next simd operation to take place.

--- a/server/internal/calc/vector_amd64.s
+++ b/server/internal/calc/vector_amd64.s
@@ -10,12 +10,11 @@ TEXT ·__normalizeVector64_AVX(SB), NOSPLIT, $24-0
   VXORPD Y0, Y0, Y0 // Clear the YMM0 register to store the normalization weight.
 
   LOOP:
-    VMOVUPD (AX), Y1   // Load the current 4 float64s from the input vector into the YMM1 register.
-    VMULPD  Y1, Y1, Y1 // Square the current 4 float64s and overwrite the YMM1 register with the result.
-    VADDPD  Y1, Y0, Y0 // Add the values to the normalization weight register.
-    ADDQ    $32, AX    // Add 32 (4 * 8) to the AX register. This moves the pointer forward.
-    SUBQ    $4, CX     // Subtract 4 from the CX length register since we are going 4 at a time.
-    JNZ     LOOP       // If the CX register is not zero then jump to the beginning of the loop again.
+    VMOVUPD     (AX), Y1   // Load the current 4 float64s from the input vector into the YMM1 register.
+    VFMADD231PD Y1, Y1, Y0 // Square the Y1 register and add the result to the Y0 accumulator register.
+    ADDQ        $32, AX    // Add 32 (4 * 8) to the AX register. This moves the pointer forward.
+    SUBQ        $4, CX     // Subtract 4 from the CX length register since we are going 4 at a time.
+    JNZ         LOOP       // If the CX register is not zero then jump to the beginning of the loop again.
 
   // TODO: I think this bit could somehow be improved but I have no idea how.
   VHADDPD     Y0, Y0, Y0     // Do a horizontal sum of the two 128 bit pairs in YMM0.
@@ -44,12 +43,11 @@ TEXT ·__normalizeVector32_AVX(SB), NOSPLIT, $24-0
   VXORPS Y0, Y0, Y0 // Clear the YMM0 register to store the normalization weight.
 
   LOOP:
-    VMOVUPS (AX), Y1   // Load the current 8 float32s from the input vector into the YMM1 register.
-    VMULPS  Y1, Y1, Y1 // Square the current 8 float32s and overwrite the YMM1 register with the result.
-    VADDPS  Y1, Y0, Y0 // Add the values to the normalization weight register.
-    ADDQ    $32, AX    // Add 32 (4 * 8) to the AX register. This moves the pointer forward.
-    SUBQ    $8, CX     // Subtract 8 from the CX length register since we are going 8 at a time.
-    JNZ     LOOP       // If the CX register is not zero then jump to the beginning of the loop again.
+    VMOVUPS     (AX), Y1   // Load the current 8 float32s from the input vector into the YMM1 register.
+    VFMADD231PS Y1, Y1, Y0 // Square the Y1 register and add the result to the Y0 accumulator register.
+    ADDQ        $32, AX    // Add 32 (4 * 8) to the AX register. This moves the pointer forward.
+    SUBQ        $8, CX     // Subtract 8 from the CX length register since we are going 8 at a time.
+    JNZ         LOOP       // If the CX register is not zero then jump to the beginning of the loop again.
 
   VHADDPS     Y0, Y0, Y0     // Do a horizontal sum of the two 128 bit pairs in YMM0.
   VPERM2F128  $1, Y0, Y0, Y1 // Take the high 128 bits of YMM0 and stash them in the low 128 of YMM1.
@@ -78,12 +76,11 @@ TEXT ·__normalizeVector64_AVX512(SB), NOSPLIT, $24-0
   VXORPD Z0, Z0, Z0 // Clear the ZMM0 register to store the normalization weight.
 
   LOOP:
-    VMOVUPD (AX), Z1  // Load the current 8 float64s from the input vector into the ZMM1 register.
-    VMULPD Z1, Z1, Z1 // Square the current 8 float64s and overwrite the ZMM1 register with the result.
-    VADDPD Z1, Z0, Z0 // Add the values to the normalization weight register.
-    ADDQ $64, AX      // Add 64 (8 * 8) to the AX register. This moves the pointer forward.
-    SUBQ $8, CX       // Subtract 8 from the CX length register since we are going 8 at a time.
-    JNZ LOOP          // If the CX register is not zero then jump to the beginning of the loop again.
+    VMOVUPD     (AX), Z1   // Load the current 8 float64s from the input vector into the ZMM1 register.
+    VFMADD231PD Z1, Z1, Z0 // Square the ZMM1 register and add it to the ZMM0 accumulator register.
+    ADDQ        $64, AX    // Add 64 (8 * 8) to the AX register. This moves the pointer forward.
+    SUBQ        $8, CX     // Subtract 8 from the CX length register since we are going 8 at a time.
+    JNZ         LOOP       // If the CX register is not zero then jump to the beginning of the loop again.
 
   VEXTRACTF64X4 $1, Z0, Y1     // Extract the high 256-bits of ZMM0 into YMM1
   VHADDPD       Y0, Y0, Y0     // Do horizontal add on YMM0 (the lower 256-bits of ZMM0)
@@ -116,12 +113,11 @@ TEXT ·__normalizeVector32_AVX512(SB), NOSPLIT, $24-0
   VXORPS Z0, Z0, Z0 // Clear the ZMM0 register to store the normalization weight.
 
   LOOP:
-    VMOVUPS (AX), Z1   // Load the current 16 float32s from the input vector into the ZMM1 register.
-    VMULPS  Z1, Z1, Z1 // Square the current 16 float32s and overwrite the ZMM1 register with the result.
-    VADDPS  Z1, Z0, Z0 // Add the values to the normalization weight register.
-    ADDQ    $64, AX    // Add 64 (4 * 16) to the AX register. This moves the pointer forward.
-    SUBQ    $16, CX    // Subtract 16 from the CX length register since we are going 16 at a time.
-    JNZ     LOOP       // If the CX register is not zero then jump to the beginning of the loop again.
+    VMOVUPS     (AX), Z1   // Load the current 16 float32s from the input vector into the ZMM1 register.
+    VFMADD231PS Z1, Z1, Z0 // Square the ZMM1 register and add it to the ZMM0 accumulator register.
+    ADDQ        $64, AX    // Add 64 (4 * 16) to the AX register. This moves the pointer forward.
+    SUBQ        $16, CX    // Subtract 16 from the CX length register since we are going 16 at a time.
+    JNZ         LOOP       // If the CX register is not zero then jump to the beginning of the loop again.
 
   VEXTRACTF32X8 $1, Z0, Y1     // Extract the high 256-bits of ZMM0 into YMM1
   VHADDPS       Y0, Y1, Y0     // Pairwise add between YMM0 and YMM1


### PR DESCRIPTION
Instead of using two instructions to do a square and then an add to the
accumulator register. I've combined them into a single instrction
VFMADD231PS or VFMADD231PD. I still need to benchmark to make sure these
are faster. But the code is now simpler
