### PR TITLE
fix(ofx): Fixing sometimes inverted OFX amounts

### DIFF
--- a/server/background/process_ofx_upload.go
+++ b/server/background/process_ofx_upload.go
@@ -463,20 +463,19 @@ func (j *ProcessOFXUploadJob) syncTransactions(ctx context.Context) error {
 		})
 
 		// Parse the amount in the specified currency.
-		amount, err := currency.ParseFriendlyToAmount(
-			externalTransaction.TRNAMT,
+		amount, err := ofx.ParseTransactionAmount(
+			externalTransaction,
 			j.currency,
 		)
 		if err != nil {
 			tlog.WithError(err).
-				WithField("trnamt", externalTransaction.TRNAMT).
+				WithFields(logrus.Fields{
+					"trntype": externalTransaction.TRNTYPE,
+					"trnamt":  externalTransaction.TRNAMT,
+				}).
 				Error("failed to parse transaction amount")
 			continue
 		}
-		// monetr uses negative amounts to represent deposits and positive to
-		// represent debits. This is the opposite of the file format, so we need
-		// to invert the amount.
-		amount = amount * -1
 
 		// Still need to figure out something to do with memo, but for now we can
 		// take the name and trim it. Memo seems to behave a bit differently from

--- a/server/formats/ofx/parse.go
+++ b/server/formats/ofx/parse.go
@@ -91,11 +91,13 @@ func ParseDate(input string, timezone *time.Location) (time.Time, error) {
 	return time.Time{}, errors.Errorf("failed to parse OFX timestamp [%s], unknown format", input)
 }
 
-func ParseAmount(
+// ParseTransactionAmount takes an OFX transaction object and a currency code
+// and returns an int64 representing the amount as a whole number, or an error
+// if the value cannot be parsed.
+func ParseTransactionAmount(
 	transaction gofx.StatementTransaction,
 	txnCurrency string,
 ) (int64, error) {
-
 	amount, err := currency.ParseFriendlyToAmount(
 		transaction.TRNAMT,
 		txnCurrency,
@@ -108,6 +110,7 @@ func ParseAmount(
 	case strings.EqualFold(transaction.TRNTYPE, "DEBIT"):
 		return myownsanity.Abs(amount), nil
 	case strings.EqualFold(transaction.TRNTYPE, "CREDIT"):
+		// Credits are represented as negative in monetr.
 		return myownsanity.Abs(amount) * -1, nil
 	default:
 		return amount, nil

--- a/server/internal/myownsanity/numbers.go
+++ b/server/internal/myownsanity/numbers.go
@@ -31,3 +31,8 @@ func Min[T Number](a, b T) T {
 
 	return b
 }
+
+func Abs(input int64) int64 {
+	mask := input >> 63
+	return (input ^ mask) - mask
+}


### PR DESCRIPTION
OFX files should respect the debit/credit for direction when available.

Resolves #2687
