### PR TITLE
fix(api): Fix handling of old timezone names

### DIFF
--- a/server/commands/serve.go
+++ b/server/commands/serve.go
@@ -35,6 +35,7 @@ import (
 	"github.com/monetr/monetr/server/storage"
 	"github.com/monetr/monetr/server/stripe_helper"
 	"github.com/monetr/monetr/server/ui"
+	"github.com/monetr/monetr/server/zoneinfo"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -58,6 +59,9 @@ func ServeCommand(parent *cobra.Command) {
 			if configFileName := configuration.GetConfigFileName(); configFileName != "" {
 				log.WithField("config", configFileName).Info("config file loaded")
 			}
+
+			// Load any timezone aliases from the host operating system.
+			zoneinfo.LoadAliasesFromHost(cmd.Context(), log)
 
 			log.WithFields(logrus.Fields{
 				"privateKeyPath":       configuration.Security.PrivateKey,

--- a/server/controller/authentication.go
+++ b/server/controller/authentication.go
@@ -17,6 +17,7 @@ import (
 	"github.com/monetr/monetr/server/models"
 	"github.com/monetr/monetr/server/repository"
 	"github.com/monetr/monetr/server/security"
+	"github.com/monetr/monetr/server/zoneinfo"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -372,7 +373,7 @@ func (c *Controller) postRegister(ctx echo.Context) error {
 		return err // validateRegistration also returns a valid http error that can just be passed through.
 	}
 
-	timezone, err := time.LoadLocation(registerRequest.Timezone)
+	timezone, err := zoneinfo.Timezone(registerRequest.Timezone)
 	if err != nil {
 		return c.wrapAndReturnError(ctx, err, http.StatusBadRequest, "failed to parse timezone")
 	}

--- a/server/models/account.go
+++ b/server/models/account.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-pg/pg/v10"
 	"github.com/monetr/monetr/server/internal/myownsanity"
+	"github.com/monetr/monetr/server/zoneinfo"
 	"github.com/pkg/errors"
 	"github.com/stripe/stripe-go/v81"
 )
@@ -49,7 +50,7 @@ func (o *Account) BeforeInsert(ctx context.Context) (context.Context, error) {
 }
 
 func (a *Account) GetTimezone() (*time.Location, error) {
-	location, err := time.LoadLocation(a.Timezone)
+	location, err := zoneinfo.Timezone(a.Timezone)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse account timezone as location")
 	}

--- a/server/zoneinfo/CMakeLists.txt
+++ b/server/zoneinfo/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(GolangTestUtils)
+
+provision_golang_tests(${CMAKE_CURRENT_SOURCE_DIR})

--- a/server/zoneinfo/aliases_other.go
+++ b/server/zoneinfo/aliases_other.go
@@ -1,0 +1,13 @@
+//go:build !unix
+
+package zoneinfo
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+)
+
+func LoadAliasesFromHost(ctx context.Context, log *logrus.Entry) {
+	// no-op
+}

--- a/server/zoneinfo/aliases_unix.go
+++ b/server/zoneinfo/aliases_unix.go
@@ -1,0 +1,91 @@
+//go:build unix
+
+package zoneinfo
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	zoneInfoLocations = []string{
+		// Not sure where they are on other OSes. This is accurate for Debian though
+		// which is what monetr runs in inside a container anyway.
+		"/usr/share/zoneinfo/tzdata.zi",
+	}
+	loadAliasesOnce = sync.Once{}
+)
+
+func LoadAliasesFromHost(ctx context.Context, logEntry *logrus.Entry) {
+	loadAliasesOnce.Do(func() {
+		log := logEntry.WithContext(ctx)
+		for _, zoneInfoLocation := range zoneInfoLocations {
+			if err := ParseAliasesFromFile(zoneInfoLocation, aliases); err != nil {
+				log.WithField("filename", zoneInfoLocation).
+					WithError(err).
+					Warn("failed to parse zone info from file")
+			}
+		}
+	})
+}
+
+// ParseAliasesFromFile parses a file in the zic file format but is looking
+// specifically for Link data inside the file. All other information is ignored.
+// See https://man7.org/linux/man-pages/man8/zic.8.html for more information.
+func ParseAliasesFromFile(path string, aliasMap map[string]string) error {
+	reader, err := os.Open(path)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer reader.Close()
+
+	buffer := bufio.NewReader(reader)
+	var currentLine []byte
+	for {
+		line, isPrefix, err := buffer.ReadLine()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return errors.Wrap(err, "failed to parse aliases from tzdata file")
+		}
+
+		currentLine = append(currentLine, line...)
+		if isPrefix {
+			continue
+		}
+
+		// If the current tzdata line is not a link then we should clear our current
+		// line and move on. We are looking for only the link lines
+		if currentLine[0] != 'L' {
+			currentLine = nil
+			continue
+		}
+
+		parts := bytes.SplitAfterN(currentLine, []byte(" "), 3)
+
+		var oldName, newName []byte
+		for i, part := range parts {
+			switch i {
+			case 0: // Link part of the link, no-op
+			case 1: // New name
+				newName = bytes.TrimSpace(part)
+			case 2: // Old name
+				oldName = bytes.TrimSpace(part)
+			}
+		}
+
+		aliasMap[string(oldName)] = string(newName)
+
+		currentLine = nil
+	}
+
+	return nil
+}

--- a/server/zoneinfo/aliases_unix_test.go
+++ b/server/zoneinfo/aliases_unix_test.go
@@ -1,0 +1,28 @@
+//go:build unix
+
+package zoneinfo_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/monetr/monetr/server/zoneinfo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseAliasesFromFile(t *testing.T) {
+	t.Run("will parse a host file", func(t *testing.T) {
+		path := "/usr/share/zoneinfo/tzdata.zi"
+		_, err := os.Stat("/usr/share/zoneinfo/tzdata.zi")
+		if os.IsNotExist(err) {
+			t.Skip("tzdata file does not exist at the expected path, skipping!")
+			return
+		}
+
+		target := map[string]string{}
+		err = zoneinfo.ParseAliasesFromFile(path, target)
+		assert.NoError(t, err, "should not have an error parsing the file")
+		assert.Contains(t, target, "Asia/Calcutta", "should have a known timezone that changed names")
+		assert.Equal(t, "Asia/Kolkata", target["Asia/Calcutta"], "should have the expected new timezone name")
+	})
+}

--- a/server/zoneinfo/doc.go
+++ b/server/zoneinfo/doc.go
@@ -1,0 +1,6 @@
+// zoneinfo is a package that is meant to wrap the time.LoadLocation API.
+// Instead zoneinfo.Timezone should be used instead as it takes into account
+// timezone names that have changed over time. This behavior is not always
+// present however and is dependent on the host operating system having timezone
+// data files available that contain this information.
+package zoneinfo

--- a/server/zoneinfo/zoneinfo.go
+++ b/server/zoneinfo/zoneinfo.go
@@ -1,0 +1,19 @@
+package zoneinfo
+
+import "time"
+
+var (
+	aliases = map[string]string{}
+)
+
+// Timezone will return a time location but will handle aliases or updated time
+// zone names. If a timezone name specified has been changed to instead be a new
+// name, this will automatically use the new name instead.
+func Timezone(timezone string) (*time.Location, error) {
+	newName, ok := aliases[timezone]
+	if !ok {
+		return time.LoadLocation(timezone)
+	}
+
+	return time.LoadLocation(newName)
+}


### PR DESCRIPTION
This adds support for timezones that have changed their name, allowing
the old timezone name to continue to be supported by parsing the
timezone data files on the host OS (if they are available).

Resolves #2741
