### PR TITLE
fix(ui): Fix font loading flash

### DIFF
--- a/interface/rsbuild.config.ts
+++ b/interface/rsbuild.config.ts
@@ -81,6 +81,12 @@ export default defineConfig({
       minify: !isDevelopment,
     },
   },
+  performance: {
+    preload: {
+      type: 'all-assets',
+      include: [/\.woff2$/],
+    },
+  },
   output: {
     target: 'web',
     distPath: {

--- a/interface/src/index.tsx
+++ b/interface/src/index.tsx
@@ -1,5 +1,3 @@
-import '@fontsource-variable/inter';
-
 import React from 'react';
 import { init, reactRouterV6BrowserTracingIntegration, showReportDialog } from '@sentry/react';
 import { createRoutesFromChildren, matchRoutes, useLocation, useNavigationType } from 'react-router-dom';

--- a/interface/src/styles/index.scss
+++ b/interface/src/styles/index.scss
@@ -1,10 +1,21 @@
 @use '@monetr/interface/variables';
 
+/* inter-latin-wght-normal */
+@font-face {
+  font-family: 'Inter Variable';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 900;
+  src: url(@fontsource-variable/inter/files/inter-latin-wght-normal.woff2) format('woff2-variations');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
 html {
   background-color: var(--background);
 }
 
 body {
+  font-family: 'Inter Variable', sans-serif;
   background-color: var(--background);
   margin: 0;
   color: var(--content-emphasis);


### PR DESCRIPTION
Sometimes when the page is initially loading the font can flash briefly
due to the page loading before the font has. This changes it so the font
is preloaded by the browser which should improve that flash.
