### PR TITLE
refactor(ui): Make sidebar styles less convoluted

### DIFF
--- a/interface/src/components/Layout/BankSidebar.module.scss
+++ b/interface/src/components/Layout/BankSidebar.module.scss
@@ -28,10 +28,11 @@
 
 .bankSidebarWrapperRoot {
   z-index: 41;
-  position: fixed;
+  position: sticky;
   left: 0;
   top: 0;
   bottom: 0;
+  height: 100dvh;
 
   border-right: 1px solid var(--border);
   flex-direction: column;

--- a/interface/src/components/Layout/BudgetLayout.module.scss
+++ b/interface/src/components/Layout/BudgetLayout.module.scss
@@ -2,6 +2,5 @@
 
 .budgetLayoutRoot {
   min-width: 0px; 
-  padding-left: calc(var(--bank-sidebar-width) + var(--budget-sidebar-width));
   width: 100%;
 }

--- a/interface/src/components/Layout/BudgetSidebar.module.scss
+++ b/interface/src/components/Layout/BudgetSidebar.module.scss
@@ -37,13 +37,12 @@
 
 .budgetSidebarRoot {
   z-index: 40;
-  position: fixed;
+  position: sticky;
   top: 0;
   bottom: 0;
   left: 0;
-  padding-left: var(--bank-sidebar-width-static);
   
-  min-height: 100vh;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
   border-right: 1px solid var(--border);

--- a/interface/src/styles/index.scss
+++ b/interface/src/styles/index.scss
@@ -92,12 +92,12 @@ svg.lucide {
   --semibold: 600;
   --bold: 700;
 
-  --bank-sidebar-width-static: #{16 * variables.$size};
+  --bank-sidebar-width-static: #{20 * variables.$size};
   --bank-sidebar-width: 0px;
   --budget-sidebar-width: 0px;
 
   @media (min-width: variables.$largeScreen) {
-    --bank-sidebar-width: #{16 * variables.$size};
+    --bank-sidebar-width: #{20 * variables.$size};
     --budget-sidebar-width: #{72 * variables.$size};
   }
 


### PR DESCRIPTION
This makes it so that instead of needing to calculate the width of the
sidebar, instead we just make it sticky so that we can easily stack
layers on the sidebar as needed and we don't need to worry about
calculation. Instead it just pushes content over as needed.
