### PR TITLE
fix(api): Fix stripe webhook reading unbounded request body

### DIFF
--- a/server/controller/stripe.go
+++ b/server/controller/stripe.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"io"
+	"math"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -26,7 +27,12 @@ func (c *Controller) handleStripeWebhook(ctx echo.Context) error {
 	}
 	defer body.Close()
 
-	requestBody, err := io.ReadAll(body)
+	// Not using [http.MaxBytesReader] since it leverages the response writer as
+	// well. I don't want to interfere with echo's response handling or any other
+	// middleware I have setup so I'm using [io.LimitReader] instead to achieve
+	// the same thing. Max of 65kb based on:
+	// https://github.com/stripe/stripe-go/blob/395614cfd3891376de57411afe8e02ab1f614cf3/webhook/client_handler_test.go#L14-L17
+	requestBody, err := io.ReadAll(io.LimitReader(body, int64(math.MaxUint16)))
 	if err != nil {
 		c.reportError(ctx, err)
 		return c.wrapAndReturnError(ctx, err, http.StatusBadRequest, "failed to read request body")

--- a/server/controller/stripe_test.go
+++ b/server/controller/stripe_test.go
@@ -1,0 +1,122 @@
+package controller_test
+
+import (
+	"math"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stripe/stripe-go/v81/webhook"
+)
+
+func TestHandleStripeWebhook(t *testing.T) {
+	t.Run("not found when stripe is not enabled", func(t *testing.T) {
+		config := NewTestApplicationConfig(t)
+		config.Stripe.Enabled = false
+		config.Stripe.WebhooksEnabled = true
+		_, e := NewTestApplicationWithConfig(t, config)
+
+		response := e.POST(`/api/stripe/webhook`).
+			WithHeader("Stripe-Signature", "t=0,v1=00").
+			WithBytes([]byte(`{}`)).
+			Expect()
+
+		response.Status(http.StatusNotFound)
+		response.JSON().Path("$.error").String().IsEqual("stripe webhooks not enabled on this server")
+	})
+
+	t.Run("not found when stripe webhooks are not enabled", func(t *testing.T) {
+		config := NewTestApplicationConfig(t)
+		config.Stripe.Enabled = true
+		config.Stripe.APIKey = gofakeit.UUID()
+		config.Stripe.WebhooksEnabled = false
+		_, e := NewTestApplicationWithConfig(t, config)
+
+		response := e.POST(`/api/stripe/webhook`).
+			WithHeader("Stripe-Signature", "t=0,v1=00").
+			WithBytes([]byte(`{}`)).
+			Expect()
+
+		response.Status(http.StatusNotFound)
+		response.JSON().Path("$.error").String().IsEqual("stripe webhooks not enabled on this server")
+	})
+
+	t.Run("bad request when stripe signature is missing", func(t *testing.T) {
+		config := NewTestApplicationConfig(t)
+		config.Stripe.Enabled = true
+		config.Stripe.APIKey = gofakeit.UUID()
+		config.Stripe.WebhooksEnabled = true
+		config.Stripe.WebhookSecret = "whsec_" + gofakeit.UUID()
+		_, e := NewTestApplicationWithConfig(t, config)
+
+		response := e.POST(`/api/stripe/webhook`).
+			WithBytes([]byte(`{}`)).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.error").String().IsEqual("stripe signature is missing")
+	})
+
+	t.Run("successful webhook with a small body", func(t *testing.T) {
+		webhookSecret := "whsec_" + gofakeit.UUID()
+
+		config := NewTestApplicationConfig(t)
+		config.Stripe.Enabled = true
+		config.Stripe.APIKey = gofakeit.UUID()
+		config.Stripe.WebhooksEnabled = true
+		config.Stripe.WebhookSecret = webhookSecret
+		_, e := NewTestApplicationWithConfig(t, config)
+
+		// Use an event type that the billing webhook does not handle so that we can
+		// exercise the controller without standing up additional billing fixtures.
+		body := []byte(`{"id":"evt_test","type":"unknown.event"}`)
+		signed := webhook.GenerateTestSignedPayload(&webhook.UnsignedPayload{
+			Payload: body,
+			Secret:  webhookSecret,
+		})
+
+		response := e.POST(`/api/stripe/webhook`).
+			WithHeader("Stripe-Signature", signed.Header).
+			WithBytes(body).
+			Expect()
+
+		response.Status(http.StatusOK)
+	})
+
+	t.Run("rejects body larger than the read limit", func(t *testing.T) {
+		webhookSecret := "whsec_" + gofakeit.UUID()
+
+		config := NewTestApplicationConfig(t)
+		config.Stripe.Enabled = true
+		config.Stripe.APIKey = gofakeit.UUID()
+		config.Stripe.WebhooksEnabled = true
+		config.Stripe.WebhookSecret = webhookSecret
+		_, e := NewTestApplicationWithConfig(t, config)
+
+		// Build a payload that exceeds the 65535 byte limit on the stripe webhook
+		// handler. We sign the entire body so the signature is valid against the
+		// unbounded payload, but the controller now caps the read at math.MaxUint16
+		// bytes which means the bytes the server actually reads cannot match the
+		// signature we generated. The controller must reject the request rather
+		// than allowing an unbounded body to be read into memory. Combined with the
+		// "successful webhook with a small body" subtest above, this proves the
+		// limit is in effect: a payload that would otherwise have a valid signature
+		// is rejected solely because the read was truncated.
+		padding := strings.Repeat(" ", math.MaxUint16+1)
+		body := []byte(`{"id":"evt_test","type":"unknown.event","description":"` + padding + `"}`)
+
+		signed := webhook.GenerateTestSignedPayload(&webhook.UnsignedPayload{
+			Payload: body,
+			Secret:  webhookSecret,
+		})
+
+		response := e.POST(`/api/stripe/webhook`).
+			WithHeader("Stripe-Signature", signed.Header).
+			WithBytes(body).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.error").String().IsEqual("failed to validate stripe event")
+	})
+}


### PR DESCRIPTION
The Stripe webhook controller would read the entire request body in an
unbounded way, this means that even if the request body is not valid
JSON it would still be entirely read into memory without any limits.

This change limits it to 65k per request.

Resolves https://github.com/monetr/monetr/security/advisories/GHSA-v7xq-3wx6-fqc2
