### PR TITLE
fix(api): Fixed issue with transaction mutation during pagination

### DIFF
--- a/interface/src/components/Calendar.tsx
+++ b/interface/src/components/Calendar.tsx
@@ -7,6 +7,7 @@ import Typography from '@monetr/interface/components/Typography';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 
 import styles from './Calendar.module.scss';
+
 import { Fragment } from 'react/jsx-runtime';
 
 export type CalendarProps = PropsBase &

--- a/interface/src/hooks/useMountEffect.ts
+++ b/interface/src/hooks/useMountEffect.ts
@@ -1,5 +1,5 @@
 import { type EffectCallback, useEffect } from 'react';
 
 export default function useMountEffect(callback: EffectCallback) {
-  useEffect(callback, []);
+  useEffect(callback, [callback]);
 }

--- a/interface/src/pages/transactions.tsx
+++ b/interface/src/pages/transactions.tsx
@@ -152,7 +152,7 @@ export default function Transactions(): JSX.Element {
 function AddTransactionButton(): JSX.Element {
   const { data: link } = useCurrentLink();
 
-  if (!link || !link.getIsManual()) {
+  if (!link?.getIsManual()) {
     return null;
   }
 

--- a/server/datasources/plaid/plaid_jobs/sync_plaid.go
+++ b/server/datasources/plaid/plaid_jobs/sync_plaid.go
@@ -27,6 +27,16 @@ const (
 	DeleteSyncAction SyncAction = "delete"
 )
 
+const (
+	// maxNullCursorRestarts bounds how many times a single SyncPlaid invocation
+	// will discard its cursor and restart pagination from null in response to
+	// Plaid's TRANSACTIONS_SYNC_MUTATION_DURING_PAGINATION error. One attempt is
+	// enough to clear out a stale mid-pagination cursor; if Plaid raises the same
+	// error on the subsequent null-cursor call then something is broken upstream
+	// and we defer to the queue's normal retry semantics.
+	maxNullCursorRestarts = 1
+)
+
 type SyncChange struct {
 	Field string `json:"field"`
 	Old   any    `json:"old"`
@@ -735,9 +745,54 @@ func SyncPlaid(ctx queue.Context, args SyncPlaidArguments) error {
 			cursor = &lastSync.NextCursor
 		}
 
+		// Tracks how many times we have had to throw away a stored cursor and
+		// restart pagination from null in response to Plaid reporting that the
+		// underlying transaction data mutated while we were paginating.
+		nullCursorRestarts := 0
+		// Set to true when an iteration reports has_more=true; cleared when we
+		// break out via has_more=false. If it is still true after the loop ends
+		// that means we exited because of the iter cap, not because Plaid ran
+		// out of pages, which is a silent failure we need to surface.
+		exitedMidPagination := false
+
 		for iter := 0; iter < 10; iter++ {
 			syncData, err := plaidClient.Sync(ctx, cursor)
 			if err != nil {
+				// Plaid returns TRANSACTIONS_SYNC_MUTATION_DURING_PAGINATION when the
+				// underlying transaction data mutated while we were paginating with the
+				// stored cursor. Per Plaid's documentation the remediation is to
+				// restart pagination with a null cursor. The existing
+				// syncPlaidTransaction / hydrateTransactions pipeline dedupes by plaid
+				// transaction id, so any items already written on a prior iteration
+				// will be updated in place rather than duplicated.
+				//
+				// Note: a null-cursor /transactions/sync does not emit removed items,
+				// so any deletions Plaid captured between the prior successful sync and
+				// this recovery window will be missed. The `deletesMayBeMissed`
+				// breadcrumb tag below lets us audit how often this actually happens in
+				// production.
+				if nullCursorRestarts < maxNullCursorRestarts &&
+					platypus.IsPlaidErrorCode(err, platypus.ErrorCodeTransactionsSyncMutationDuringPagination) {
+					nullCursorRestarts++
+					s.log.WarnContext(ctx,
+						"plaid reported TRANSACTIONS_SYNC_MUTATION_DURING_PAGINATION; discarding cursor and restarting pagination from null",
+						"iter", iter,
+						"previousCursor", cursor,
+					)
+					crumbs.Warn(ctx,
+						"Plaid mutation-during-pagination; restarting sync with null cursor",
+						"plaid",
+						map[string]any{
+							"iter":               iter,
+							"nullCursorRestart":  nullCursorRestarts,
+							"plaidLinkId":        link.PlaidLink.PlaidLinkId,
+							"itemId":             link.PlaidLink.PlaidId,
+							"deletesMayBeMissed": true,
+						},
+					)
+					cursor = nil
+					continue
+				}
 				return errors.Wrap(err, "failed to sync with plaid")
 			}
 
@@ -919,10 +974,33 @@ func SyncPlaid(ctx queue.Context, args SyncPlaidArguments) error {
 			}
 
 			if !syncData.HasMore {
+				exitedMidPagination = false
 				break
 			}
 
+			exitedMidPagination = true
 			s.log.InfoContext(ctx, "there is more data to sync from plaid, continuing", "iter", iter)
+		}
+
+		// If the pagination loop ran out of iterations while Plaid still had more
+		// pages available, the cursor we just recorded points to the middle of a
+		// sync stream. A follow-up job run will resume from it, but if Plaid's
+		// underlying data mutates before that happens we will see
+		// TRANSACTIONS_SYNC_MUTATION_DURING_PAGINATION and auto-recover via the
+		// null-cursor restart above. Surfacing this as a warning + breadcrumb turns
+		// a previously silent failure into something we can see in logs and Sentry.
+		if exitedMidPagination {
+			s.log.WarnContext(ctx,
+				"plaid sync exited at iteration cap while more pages remain; follow-up sync will continue from last recorded cursor",
+			)
+			crumbs.Warn(ctx,
+				"Plaid sync hit iteration cap",
+				"plaid",
+				map[string]any{
+					"plaidLinkId": link.PlaidLink.PlaidLinkId,
+					"itemId":      link.PlaidLink.PlaidId,
+				},
+			)
 		}
 
 		// Then enqueue all of the bank accounts we touched to have their similar

--- a/server/datasources/plaid/plaid_jobs/sync_plaid_test.go
+++ b/server/datasources/plaid/plaid_jobs/sync_plaid_test.go
@@ -14,9 +14,13 @@ import (
 	"github.com/monetr/monetr/server/models"
 	"github.com/monetr/monetr/server/platypus"
 	"github.com/monetr/monetr/server/pubsub"
+	"github.com/monetr/monetr/server/repository"
 	"github.com/monetr/monetr/server/secrets"
 	"github.com/monetr/monetr/server/similar/similar_jobs"
+	"github.com/pkg/errors"
+	"github.com/plaid/plaid-go/v41/plaid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -235,6 +239,612 @@ func TestSyncPlaidJob_Run(t *testing.T) {
 		// There should be only one transaction since we handle merging.
 		count = fixtures.CountAllTransactions(t, user.AccountId)
 		assert.EqualValues(t, 1, count, "should have a total of two transactions including the deleted one")
+	})
+
+	t.Run("recovers from mutation-during-pagination", func(t *testing.T) {
+		clock := clock.NewMock()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		log := testutils.GetLog(t)
+		db := testutils.GetPgDatabase(t)
+		publisher := pubsub.NewPostgresPubSub(log, db)
+		kms := secrets.NewPlaintextKMS()
+
+		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
+		plaidLink := fixtures.GivenIHaveAPlaidLink(t, clock, user)
+
+		plaidBankAccount := fixtures.GivenIHaveAPlaidBankAccount(
+			t,
+			clock,
+			&plaidLink,
+			models.DepositoryBankAccountType,
+			models.CheckingBankAccountSubType,
+		)
+
+		// Pre-seed a PlaidSync row so that SyncPlaid believes a prior sync already
+		// stored a cursor. This is the exact condition the user hit: a stored
+		// cursor from a successful first sync that Plaid now considers
+		// mid-pagination because its data mutated in the meantime.
+		storedCursor := "stored-cursor-from-previous-sync"
+		{
+			repo := repository.NewRepositoryFromSession(
+				clock,
+				user.UserId,
+				user.AccountId,
+				db,
+				log,
+			)
+			require.NoError(
+				t,
+				repo.RecordPlaidSync(
+					t.Context(),
+					*plaidLink.PlaidLinkId,
+					storedCursor,
+					"webhook",
+					0, 0, 0,
+				),
+				"must be able to seed prior plaid sync",
+			)
+		}
+
+		// Advance the mock clock so the pre-seeded PlaidSync row has an earlier
+		// timestamp than the row the recovery path will write. GetLastPlaidSync
+		// orders by timestamp DESC with Limit(1), so the test would be
+		// non-deterministic if both rows shared the same mock timestamp.
+		clock.Add(time.Second)
+
+		plaidPlatypus := mockgen.NewMockPlatypus(ctrl)
+		plaidClient := mockgen.NewMockClient(ctrl)
+		enqueuer := mockgen.NewMockProcessor(ctrl)
+
+		plaidPlatypus.EXPECT().
+			NewClient(
+				gomock.Any(),
+				gomock.AssignableToTypeOf(new(models.Link)),
+				gomock.Any(),
+				gomock.Eq(plaidLink.PlaidLink.PlaidId),
+			).
+			Return(plaidClient, nil).
+			AnyTimes()
+
+		// First call uses the stored cursor. Plaid responds with the
+		// mutation-during-pagination error, exactly as produced by
+		// platypus/sync.go's after() wrapper.
+		mutationErr := errors.Wrap(
+			&platypus.PlatypusError{PlaidError: plaid.PlaidError{
+				ErrorType:    "TRANSACTIONS_ERROR",
+				ErrorCode:    platypus.ErrorCodeTransactionsSyncMutationDuringPagination,
+				ErrorMessage: "Underlying transaction data changed since last page was fetched. Please restart pagination from last update.",
+			}},
+			"failed to sync data with Plaid",
+		)
+		firstSyncCall := plaidClient.EXPECT().
+			Sync(
+				gomock.Any(),
+				testutils.NewGenericMatcher(func(cursor *string) bool {
+					return assert.NotNil(t, cursor, "first call must use the stored cursor, not nil") &&
+						assert.EqualValues(t, storedCursor, *cursor, "first call must use the stored cursor")
+				}),
+			).
+			Return(nil, mutationErr).
+			Times(1)
+
+		// Second call is the restart. SyncPlaid must detect the mutation error and
+		// reset the cursor to nil; this mock expectation is the assertion that the
+		// reset happened.
+		freshCursor := gofakeit.UUID()
+		freshTxnId := gofakeit.UUID()
+		plaidClient.EXPECT().
+			Sync(
+				gomock.Any(),
+				gomock.Nil(),
+			).
+			After(firstSyncCall).
+			Return(&platypus.SyncResult{
+				NextCursor: freshCursor,
+				HasMore:    false,
+				New: []platypus.Transaction{
+					platypus.PlaidTransaction{
+						Amount:                 1250,
+						BankAccountId:          plaidBankAccount.PlaidBankAccount.PlaidId,
+						Category:               []string{},
+						Date:                   time.Date(2023, 01, 01, 0, 0, 0, 0, time.Local),
+						ISOCurrencyCode:        "USD",
+						UnofficialCurrencyCode: "USD",
+						IsPending:              false,
+						MerchantName:           "Acme Corp",
+						Name:                   "Acme Corp",
+						OriginalDescription:    "ACME CORP",
+						PendingTransactionId:   nil,
+						TransactionId:          freshTxnId,
+					},
+				},
+				Updated: []platypus.Transaction{},
+				Deleted: []string{},
+				Accounts: []platypus.BankAccount{
+					platypus.PlaidBankAccount{
+						AccountId: plaidBankAccount.PlaidBankAccount.PlaidId,
+						Balances: platypus.PlaidBankAccountBalances{
+							Available: 100,
+							Current:   100,
+						},
+						Mask:         *plaidBankAccount.Mask,
+						Name:         plaidBankAccount.Name,
+						OfficialName: plaidBankAccount.PlaidBankAccount.OfficialName,
+						Type:         "depository",
+						SubType:      "checking",
+					},
+				},
+			}, nil).
+			Times(1)
+
+		enqueuer.EXPECT().
+			EnqueueAt(
+				gomock.Any(),
+				mockqueue.EqQueue(similar_jobs.CalculateTransactionClusters),
+				gomock.Any(),
+				gomock.Eq(similar_jobs.CalculateTransactionClustersArguments{
+					AccountId:     plaidBankAccount.AccountId,
+					BankAccountId: plaidBankAccount.BankAccountId,
+				}),
+			).
+			Return(nil).
+			Times(1)
+
+		// Before we start the database should be clean.
+		fixtures.AssertThatIHaveZeroTransactions(t, user.AccountId)
+
+		context := mockgen.NewMockContext(ctrl)
+		context.EXPECT().Clock().Return(clock).MinTimes(1)
+		context.EXPECT().DB().Return(db).MinTimes(1)
+		context.EXPECT().Enqueuer().Return(enqueuer).MinTimes(1)
+		context.EXPECT().KMS().Return(kms).MinTimes(1)
+		context.EXPECT().Log().Return(log).MinTimes(1)
+		context.EXPECT().Platypus().Return(plaidPlatypus).MinTimes(1)
+		context.EXPECT().Publisher().Return(publisher).AnyTimes()
+		context.EXPECT().RunInTransaction(gomock.Any(), gomock.Any()).Times(1)
+
+		err := plaid_jobs.SyncPlaid(
+			mockqueue.NewMockContext(context),
+			plaid_jobs.SyncPlaidArguments{
+				AccountId: user.AccountId,
+				LinkId:    plaidLink.LinkId,
+				Trigger:   "webhook",
+			},
+		)
+		assert.NoError(t, err, "must recover from mutation-during-pagination and finish without error")
+
+		// The transaction from the second (restart) call must have been persisted;
+		// this proves the recovery path actually produced real data.
+		count := fixtures.CountNonDeletedTransactions(t, user.AccountId)
+		assert.EqualValues(t, 1, count, "must persist the transaction returned by the null-cursor restart")
+
+		// The latest PlaidSync row must hold the fresh cursor, not the stale
+		// pre-seeded one. GetLastPlaidSync orders by timestamp DESC, so writing the
+		// fresh cursor naturally supersedes the pre-seeded stale row.
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
+		latestSync, err := repo.GetLastPlaidSync(t.Context(), *plaidLink.PlaidLinkId)
+		require.NoError(t, err, "must be able to read the latest plaid sync")
+		require.NotNil(t, latestSync, "must have a plaid sync row after recovery")
+		assert.Equal(
+			t,
+			freshCursor,
+			latestSync.NextCursor,
+			"the latest plaid sync row must hold the cursor from the null-cursor restart, not the stale one",
+		)
+	})
+
+	t.Run("gives up after repeated mutation-during-pagination errors", func(t *testing.T) {
+		clock := clock.NewMock()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		log := testutils.GetLog(t)
+		db := testutils.GetPgDatabase(t)
+		publisher := pubsub.NewPostgresPubSub(log, db)
+		kms := secrets.NewPlaintextKMS()
+
+		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
+		plaidLink := fixtures.GivenIHaveAPlaidLink(t, clock, user)
+
+		fixtures.GivenIHaveAPlaidBankAccount(
+			t,
+			clock,
+			&plaidLink,
+			models.DepositoryBankAccountType,
+			models.CheckingBankAccountSubType,
+		)
+
+		storedCursor := "stored-cursor-from-previous-sync"
+		{
+			repo := repository.NewRepositoryFromSession(
+				clock,
+				user.UserId,
+				user.AccountId,
+				db,
+				log,
+			)
+			require.NoError(
+				t,
+				repo.RecordPlaidSync(
+					t.Context(),
+					*plaidLink.PlaidLinkId,
+					storedCursor,
+					"webhook",
+					0, 0, 0,
+				),
+				"must be able to seed prior plaid sync",
+			)
+		}
+
+		plaidPlatypus := mockgen.NewMockPlatypus(ctrl)
+		plaidClient := mockgen.NewMockClient(ctrl)
+		enqueuer := mockgen.NewMockProcessor(ctrl)
+
+		plaidPlatypus.EXPECT().
+			NewClient(
+				gomock.Any(),
+				gomock.AssignableToTypeOf(new(models.Link)),
+				gomock.Any(),
+				gomock.Eq(plaidLink.PlaidLink.PlaidId),
+			).
+			Return(plaidClient, nil).
+			AnyTimes()
+
+		mutationErr := errors.Wrap(
+			&platypus.PlatypusError{PlaidError: plaid.PlaidError{
+				ErrorType:    "TRANSACTIONS_ERROR",
+				ErrorCode:    platypus.ErrorCodeTransactionsSyncMutationDuringPagination,
+				ErrorMessage: "Underlying transaction data changed since last page was fetched. Please restart pagination from last update.",
+			}},
+			"failed to sync data with Plaid",
+		)
+		// Both calls return the same error. The job should call Sync exactly twice;
+		// once with the stored cursor, once with the null restart; then bail out
+		// rather than looping forever.
+		plaidClient.EXPECT().
+			Sync(gomock.Any(), gomock.Any()).
+			Return(nil, mutationErr).
+			Times(2)
+
+		// No transactions get written so no similarity recalc gets enqueued.
+		enqueuer.EXPECT().EnqueueAt(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+		context := mockgen.NewMockContext(ctrl)
+		context.EXPECT().Clock().Return(clock).MinTimes(1)
+		context.EXPECT().DB().Return(db).MinTimes(1)
+		context.EXPECT().Enqueuer().Return(enqueuer).AnyTimes()
+		context.EXPECT().KMS().Return(kms).MinTimes(1)
+		context.EXPECT().Log().Return(log).MinTimes(1)
+		context.EXPECT().Platypus().Return(plaidPlatypus).MinTimes(1)
+		context.EXPECT().Publisher().Return(publisher).AnyTimes()
+		context.EXPECT().RunInTransaction(gomock.Any(), gomock.Any()).Times(1)
+
+		err := plaid_jobs.SyncPlaid(
+			mockqueue.NewMockContext(context),
+			plaid_jobs.SyncPlaidArguments{
+				AccountId: user.AccountId,
+				LinkId:    plaidLink.LinkId,
+				Trigger:   "webhook",
+			},
+		)
+		assert.Error(t, err, "must surface the error once the restart budget is exhausted")
+		assert.True(
+			t,
+			platypus.IsPlaidErrorCode(err, platypus.ErrorCodeTransactionsSyncMutationDuringPagination),
+			"returned error must still carry the underlying plaid error code",
+		)
+	})
+
+	t.Run("recovery preserves transactions from prior successful sync", func(t *testing.T) {
+		// End-to-end reproduction of the user-reported scenario:
+		//   1. An initial sync runs successfully, persists transactions, and stores
+		//      a cursor in plaid_syncs.
+		//   2. Days later, a webhook-triggered sync uses that stored cursor and
+		//      receives TRANSACTIONS_SYNC_MUTATION_DURING_PAGINATION because Plaid
+		//      mutated the data in the meantime.
+		//   3. The job auto-recovers by restarting pagination with a null cursor.
+		//      Plaid replays every current transaction as "added".
+		//
+		// This test proves the recovery does not clobber the previously- synced
+		// data: existing monetr Transaction rows keep their original TransactionId
+		// values (they are updated in place via plaid_id lookup, not recreated), no
+		// rows are marked deleted, and no duplicates are inserted.
+		clock := clock.NewMock()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		log := testutils.GetLog(t)
+		db := testutils.GetPgDatabase(t)
+		publisher := pubsub.NewPostgresPubSub(log, db)
+		kms := secrets.NewPlaintextKMS()
+
+		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
+		plaidLink := fixtures.GivenIHaveAPlaidLink(t, clock, user)
+
+		plaidBankAccount := fixtures.GivenIHaveAPlaidBankAccount(
+			t,
+			clock,
+			&plaidLink,
+			models.DepositoryBankAccountType,
+			models.CheckingBankAccountSubType,
+		)
+
+		plaidPlatypus := mockgen.NewMockPlatypus(ctrl)
+		plaidClient := mockgen.NewMockClient(ctrl)
+		enqueuer := mockgen.NewMockProcessor(ctrl)
+
+		plaidPlatypus.EXPECT().
+			NewClient(
+				gomock.Any(),
+				gomock.AssignableToTypeOf(new(models.Link)),
+				gomock.Any(),
+				gomock.Eq(plaidLink.PlaidLink.PlaidId),
+			).
+			Return(plaidClient, nil).
+			AnyTimes()
+
+		// Two transactions that will exist across both sync runs; these are what we
+		// are proving the recovery path does not clobber.
+		txn1PlaidId := gofakeit.UUID()
+		txn2PlaidId := gofakeit.UUID()
+		initialCursor := gofakeit.UUID()
+
+		buildPlaidTxn := func(plaidId string, amount int64, date time.Time) platypus.PlaidTransaction {
+			return platypus.PlaidTransaction{
+				Amount:                 amount,
+				BankAccountId:          plaidBankAccount.PlaidBankAccount.PlaidId,
+				Category:               []string{},
+				Date:                   date,
+				ISOCurrencyCode:        "USD",
+				UnofficialCurrencyCode: "USD",
+				IsPending:              false,
+				MerchantName:           "Acme Corp",
+				Name:                   "Acme Corp",
+				OriginalDescription:    "ACME CORP",
+				PendingTransactionId:   nil,
+				TransactionId:          plaidId,
+			}
+		}
+
+		plaidAccounts := []platypus.BankAccount{
+			platypus.PlaidBankAccount{
+				AccountId: plaidBankAccount.PlaidBankAccount.PlaidId,
+				Balances: platypus.PlaidBankAccountBalances{
+					Available: 100,
+					Current:   100,
+				},
+				Mask:         *plaidBankAccount.Mask,
+				Name:         plaidBankAccount.Name,
+				OfficialName: plaidBankAccount.PlaidBankAccount.OfficialName,
+				Type:         "depository",
+				SubType:      "checking",
+			},
+		}
+
+		// Step 1: first sync; starts from nil cursor, returns two transactions and
+		// finishes cleanly with the initial cursor.
+		firstSyncCall := plaidClient.EXPECT().
+			Sync(
+				gomock.Any(),
+				gomock.Nil(),
+			).
+			Return(&platypus.SyncResult{
+				NextCursor: initialCursor,
+				HasMore:    false,
+				New: []platypus.Transaction{
+					buildPlaidTxn(txn1PlaidId, 1250, time.Date(2023, 01, 01, 0, 0, 0, 0, time.Local)),
+					buildPlaidTxn(txn2PlaidId, 4599, time.Date(2023, 01, 02, 0, 0, 0, 0, time.Local)),
+				},
+				Updated:  []platypus.Transaction{},
+				Deleted:  []string{},
+				Accounts: plaidAccounts,
+			}, nil).
+			Times(1)
+
+		firstCalculateCall := enqueuer.EXPECT().
+			EnqueueAt(
+				gomock.Any(),
+				mockqueue.EqQueue(similar_jobs.CalculateTransactionClusters),
+				gomock.Any(),
+				gomock.Eq(similar_jobs.CalculateTransactionClustersArguments{
+					AccountId:     plaidBankAccount.AccountId,
+					BankAccountId: plaidBankAccount.BankAccountId,
+				}),
+			).
+			Return(nil).
+			Times(1)
+
+		{ // Run the initial sync.
+			fixtures.AssertThatIHaveZeroTransactions(t, user.AccountId)
+
+			context := mockgen.NewMockContext(ctrl)
+			context.EXPECT().Clock().Return(clock).MinTimes(1)
+			context.EXPECT().DB().Return(db).MinTimes(1)
+			context.EXPECT().Enqueuer().Return(enqueuer).MinTimes(1)
+			context.EXPECT().KMS().Return(kms).MinTimes(1)
+			context.EXPECT().Log().Return(log).MinTimes(1)
+			context.EXPECT().Platypus().Return(plaidPlatypus).MinTimes(1)
+			context.EXPECT().Publisher().Return(publisher).AnyTimes()
+			context.EXPECT().RunInTransaction(gomock.Any(), gomock.Any()).Times(1)
+
+			err := plaid_jobs.SyncPlaid(
+				mockqueue.NewMockContext(context),
+				plaid_jobs.SyncPlaidArguments{
+					AccountId: user.AccountId,
+					LinkId:    plaidLink.LinkId,
+					Trigger:   "webhook",
+				},
+			)
+			require.NoError(t, err, "initial sync must succeed")
+		}
+
+		// Capture the monetr TransactionIds assigned during the initial sync; the
+		// no-clobber assertion below compares these against what is in the database
+		// after recovery.
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
+		initialTxns, err := repo.GetTransactionsByPlaidId(
+			t.Context(),
+			plaidLink.LinkId,
+			[]string{txn1PlaidId, txn2PlaidId},
+		)
+		require.NoError(t, err, "must be able to read transactions after initial sync")
+		require.Len(t, initialTxns, 2, "initial sync must have persisted both transactions")
+		originalTxn1Id := initialTxns[txn1PlaidId].TransactionId
+		originalTxn2Id := initialTxns[txn2PlaidId].TransactionId
+
+		// Step 2: simulate the gap between the webhook-triggered syncs. Three days
+		// is enough time for Plaid's upstream data to mutate and invalidate the
+		// stored cursor.
+		clock.Add(72 * time.Hour)
+
+		// Step 3a: second sync's first call; uses the stored cursor and Plaid
+		// returns TRANSACTIONS_SYNC_MUTATION_DURING_PAGINATION.
+		mutationErr := errors.Wrap(
+			&platypus.PlatypusError{PlaidError: plaid.PlaidError{
+				ErrorType:    "TRANSACTIONS_ERROR",
+				ErrorCode:    platypus.ErrorCodeTransactionsSyncMutationDuringPagination,
+				ErrorMessage: "Underlying transaction data changed since last page was fetched. Please restart pagination from last update.",
+			}},
+			"failed to sync data with Plaid",
+		)
+		mutationErrorCall := plaidClient.EXPECT().
+			Sync(
+				gomock.Any(),
+				testutils.NewGenericMatcher(func(cursor *string) bool {
+					return assert.NotNil(t, cursor, "second sync must start from the stored cursor, not nil") &&
+						assert.EqualValues(t, initialCursor, *cursor, "second sync must start from the cursor recorded by the initial sync")
+				}),
+			).
+			After(firstSyncCall).
+			Return(nil, mutationErr).
+			Times(1)
+
+		// Step 3b: recovery call; SyncPlaid must detect the mutation error
+		// and retry with a nil cursor. Plaid replays both existing
+		// transactions plus one new one.
+		txn3PlaidId := gofakeit.UUID()
+		recoveryCursor := gofakeit.UUID()
+		plaidClient.EXPECT().
+			Sync(
+				gomock.Any(),
+				gomock.Nil(),
+			).
+			After(mutationErrorCall).
+			Return(&platypus.SyncResult{
+				NextCursor: recoveryCursor,
+				HasMore:    false,
+				New: []platypus.Transaction{
+					buildPlaidTxn(txn1PlaidId, 1250, time.Date(2023, 01, 01, 0, 0, 0, 0, time.Local)),
+					buildPlaidTxn(txn2PlaidId, 4599, time.Date(2023, 01, 02, 0, 0, 0, 0, time.Local)),
+					buildPlaidTxn(txn3PlaidId, 750, time.Date(2023, 01, 03, 0, 0, 0, 0, time.Local)),
+				},
+				Updated:  []platypus.Transaction{},
+				Deleted:  []string{},
+				Accounts: plaidAccounts,
+			}, nil).
+			Times(1)
+
+		enqueuer.EXPECT().
+			EnqueueAt(
+				gomock.Any(),
+				mockqueue.EqQueue(similar_jobs.CalculateTransactionClusters),
+				gomock.Any(),
+				gomock.Eq(similar_jobs.CalculateTransactionClustersArguments{
+					AccountId:     plaidBankAccount.AccountId,
+					BankAccountId: plaidBankAccount.BankAccountId,
+				}),
+			).
+			After(firstCalculateCall).
+			Return(nil).
+			MinTimes(1)
+
+		{ // Run the second sync, which triggers the mutation-error recovery.
+			context := mockgen.NewMockContext(ctrl)
+			context.EXPECT().Clock().Return(clock).MinTimes(1)
+			context.EXPECT().DB().Return(db).MinTimes(1)
+			context.EXPECT().Enqueuer().Return(enqueuer).MinTimes(1)
+			context.EXPECT().KMS().Return(kms).MinTimes(1)
+			context.EXPECT().Log().Return(log).MinTimes(1)
+			context.EXPECT().Platypus().Return(plaidPlatypus).MinTimes(1)
+			context.EXPECT().Publisher().Return(publisher).AnyTimes()
+			context.EXPECT().RunInTransaction(gomock.Any(), gomock.Any()).Times(1)
+
+			err := plaid_jobs.SyncPlaid(
+				mockqueue.NewMockContext(context),
+				plaid_jobs.SyncPlaidArguments{
+					AccountId: user.AccountId,
+					LinkId:    plaidLink.LinkId,
+					Trigger:   "webhook",
+				},
+			)
+			require.NoError(t, err, "recovery sync must succeed without clobbering data")
+		}
+
+		// No-clobber assertions:
+		//
+		// Three transactions total (the two from the initial sync plus the one the
+		// recovery call added). No duplicates, no soft-deletes.
+		assert.EqualValues(
+			t,
+			3,
+			fixtures.CountNonDeletedTransactions(t, user.AccountId),
+			"recovery must produce exactly three live transactions (original two + one new)",
+		)
+		assert.EqualValues(
+			t,
+			3,
+			fixtures.CountAllTransactions(t, user.AccountId),
+			"recovery must not soft-delete any of the original transactions",
+		)
+
+		// Same plaid transaction ids must still resolve to the same monetr
+		// TransactionId values; proving recovery updates in place rather than
+		// re-creating the rows.
+		postRecoveryTxns, err := repo.GetTransactionsByPlaidId(
+			t.Context(),
+			plaidLink.LinkId,
+			[]string{txn1PlaidId, txn2PlaidId, txn3PlaidId},
+		)
+		require.NoError(t, err, "must be able to read transactions after recovery")
+		require.Len(t, postRecoveryTxns, 3, "all three plaid ids must resolve to monetr transactions")
+		assert.Equal(
+			t,
+			originalTxn1Id,
+			postRecoveryTxns[txn1PlaidId].TransactionId,
+			"txn1's monetr TransactionId must survive the recovery unchanged",
+		)
+		assert.Equal(
+			t,
+			originalTxn2Id,
+			postRecoveryTxns[txn2PlaidId].TransactionId,
+			"txn2's monetr TransactionId must survive the recovery unchanged",
+		)
+
+		// The latest plaid_syncs row must hold the cursor returned by the recovery
+		// call, not the stale initialCursor.
+		latestSync, err := repo.GetLastPlaidSync(t.Context(), *plaidLink.PlaidLinkId)
+		require.NoError(t, err, "must be able to read latest plaid sync")
+		require.NotNil(t, latestSync, "must have a plaid sync row after recovery")
+		assert.Equal(
+			t,
+			recoveryCursor,
+			latestSync.NextCursor,
+			"latest plaid sync row must hold the recovery cursor, not the stale initial one",
+		)
 	})
 
 	t.Run("initial setup", func(t *testing.T) {

--- a/server/platypus/error.go
+++ b/server/platypus/error.go
@@ -3,7 +3,16 @@ package platypus
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/plaid/plaid-go/v41/plaid"
+)
+
+const (
+	// ErrorCodeTransactionsSyncMutationDuringPagination is returned by Plaid's
+	// /transactions/sync endpoint when the underlying transaction data mutated
+	// while we were paginating through it with a stored cursor. Per Plaid's
+	// documentation the remediation is to restart pagination from a null cursor.
+	ErrorCodeTransactionsSyncMutationDuringPagination = "TRANSACTIONS_SYNC_MUTATION_DURING_PAGINATION"
 )
 
 var (
@@ -19,4 +28,17 @@ func (p *PlatypusError) Error() string {
 		"plaid API call failed with [%s - %s]%s",
 		p.ErrorType, p.ErrorCode, p.ErrorMessage,
 	)
+}
+
+// IsPlaidErrorCode reports whether err, once unwrapped, is a *PlatypusError
+// whose ErrorCode matches the provided code.
+func IsPlaidErrorCode(err error, code string) bool {
+	if err == nil {
+		return false
+	}
+	plaidErr, ok := errors.Cause(err).(*PlatypusError)
+	if !ok {
+		return false
+	}
+	return plaidErr.ErrorCode == code
 }

--- a/server/platypus/error_test.go
+++ b/server/platypus/error_test.go
@@ -1,0 +1,60 @@
+package platypus
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/plaid/plaid-go/v41/plaid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPlaidErrorCode(t *testing.T) {
+	t.Run("matches wrapped PlatypusError", func(t *testing.T) {
+		err := errors.Wrap(
+			&PlatypusError{PlaidError: plaid.PlaidError{
+				ErrorType:    "TRANSACTIONS_ERROR",
+				ErrorCode:    ErrorCodeTransactionsSyncMutationDuringPagination,
+				ErrorMessage: "Underlying transaction data changed since last page was fetched. Please restart pagination from last update.",
+			}},
+			"failed to sync data with Plaid",
+		)
+		assert.True(
+			t,
+			IsPlaidErrorCode(err, ErrorCodeTransactionsSyncMutationDuringPagination),
+			"must extract plaid error code through errors.Wrap",
+		)
+	})
+
+	t.Run("does not match non-plaid error", func(t *testing.T) {
+		err := errors.Wrap(errors.New("boom"), "something went wrong")
+		assert.False(
+			t,
+			IsPlaidErrorCode(err, ErrorCodeTransactionsSyncMutationDuringPagination),
+			"non-plaid errors must not match",
+		)
+	})
+
+	t.Run("does not match different code", func(t *testing.T) {
+		err := errors.Wrap(
+			&PlatypusError{PlaidError: plaid.PlaidError{
+				ErrorType:    "ITEM_ERROR",
+				ErrorCode:    "ITEM_LOGIN_REQUIRED",
+				ErrorMessage: "the user needs to re-auth",
+			}},
+			"failed to sync data with Plaid",
+		)
+		assert.False(
+			t,
+			IsPlaidErrorCode(err, ErrorCodeTransactionsSyncMutationDuringPagination),
+			"different plaid error codes must not match",
+		)
+	})
+
+	t.Run("nil error returns false", func(t *testing.T) {
+		assert.False(
+			t,
+			IsPlaidErrorCode(nil, ErrorCodeTransactionsSyncMutationDuringPagination),
+			"nil error must not match",
+		)
+	})
+}


### PR DESCRIPTION
monetr is running into an issue in the hosted version where some links
are getting the transaction mutation during pagination error AFTER
having stored the cursor. Plaid support recommended reverting to the
null cursor to aleviate this.

This introduces a way to handle that as well as tests to prove the path
works. But it does not do a reconcile against transactions that need to
be deleted because they are no longer in the plaid dataset.
