### PR TITLE
feat: Automated expense/funding transactions

### DIFF
--- a/interface/src/components/Calendar.tsx
+++ b/interface/src/components/Calendar.tsx
@@ -7,6 +7,7 @@ import Typography from '@monetr/interface/components/Typography';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 
 import styles from './Calendar.module.scss';
+
 import { Fragment } from 'react/jsx-runtime';
 
 export type CalendarProps = PropsBase &

--- a/interface/src/components/FormCheckbox.tsx
+++ b/interface/src/components/FormCheckbox.tsx
@@ -16,6 +16,7 @@ export interface FormCheckboxProps {
   disabled?: boolean;
   checked?: boolean;
   className?: string;
+  'data-testid'?: string;
 }
 
 export default function FormCheckbox(props: FormCheckboxProps): React.JSX.Element {
@@ -37,6 +38,7 @@ export default function FormCheckbox(props: FormCheckboxProps): React.JSX.Elemen
       <div className={formCheckboxStyles.formCheckboxWrapper}>
         <Checkbox
           checked={props.checked}
+          data-testid={props['data-testid']}
           disabled={props.disabled}
           id={props.id}
           name={props.name}

--- a/interface/src/components/FormCheckbox.tsx
+++ b/interface/src/components/FormCheckbox.tsx
@@ -46,7 +46,7 @@ export default function FormCheckbox(props: FormCheckboxProps): React.JSX.Elemen
       </div>
       <div>
         {props.label && (
-          <label className={labelStyles.labelText} htmlFor={props.id}>
+          <label aria-disabled={props.disabled} className={labelStyles.labelText} htmlFor={props.id}>
             {props.label}
           </label>
         )}

--- a/interface/src/components/setup/manual/ManualLinkSetupIncome.tsx
+++ b/interface/src/components/setup/manual/ManualLinkSetupIncome.tsx
@@ -74,6 +74,7 @@ export default function ManualLinkSetupIncome(): JSX.Element {
           ruleset: values.ruleset,
           estimatedDeposit: locale.friendlyToAmount(values.paydayAmount),
           excludeWeekends: false,
+          autoCreateTransaction: false,
         }),
       )
       .then(fundingSchedule => navigate(`/bank/${fundingSchedule.bankAccountId}/transactions`))

--- a/interface/src/hooks/useCreateFundingSchedule.ts
+++ b/interface/src/hooks/useCreateFundingSchedule.ts
@@ -5,7 +5,14 @@ import request from '@monetr/interface/util/request';
 
 export type CreateFundingScheduleRequest = Pick<
   FundingSchedule,
-  'bankAccountId' | 'name' | 'description' | 'ruleset' | 'nextRecurrence' | 'excludeWeekends' | 'estimatedDeposit'
+  | 'bankAccountId'
+  | 'name'
+  | 'description'
+  | 'ruleset'
+  | 'nextRecurrence'
+  | 'excludeWeekends'
+  | 'estimatedDeposit'
+  | 'autoCreateTransaction'
 >;
 
 export function useCreateFundingSchedule(): (_funding: CreateFundingScheduleRequest) => Promise<FundingSchedule> {

--- a/interface/src/hooks/useMountEffect.ts
+++ b/interface/src/hooks/useMountEffect.ts
@@ -1,5 +1,5 @@
 import { type EffectCallback, useEffect } from 'react';
 
 export default function useMountEffect(callback: EffectCallback) {
-  useEffect(callback, []);
+  useEffect(callback, [callback]);
 }

--- a/interface/src/hooks/usePatchFundingSchedule.ts
+++ b/interface/src/hooks/usePatchFundingSchedule.ts
@@ -8,7 +8,13 @@ export type PatchFundingScheduleRequest = Pick<FundingSchedule, 'fundingSchedule
   Partial<
     Pick<
       FundingSchedule,
-      'name' | 'description' | 'ruleset' | 'nextRecurrence' | 'excludeWeekends' | 'estimatedDeposit'
+      | 'name'
+      | 'description'
+      | 'ruleset'
+      | 'nextRecurrence'
+      | 'excludeWeekends'
+      | 'estimatedDeposit'
+      | 'autoCreateTransaction'
     >
   >;
 

--- a/interface/src/modals/NewExpenseModal.tsx
+++ b/interface/src/modals/NewExpenseModal.tsx
@@ -1,7 +1,7 @@
-import { useRef } from 'react';
+import { useId, useRef } from 'react';
 import NiceModal, { useModal } from '@ebay/nice-modal-react';
 import { startOfDay, startOfTomorrow } from 'date-fns';
-import type { FormikHelpers } from 'formik';
+import { type FormikHelpers, useFormikContext } from 'formik';
 import { useSnackbar } from 'notistack';
 
 import type { ApiError } from '@monetr/interface/api/client';
@@ -14,8 +14,10 @@ import MForm from '@monetr/interface/components/MForm';
 import MModal, { type MModalRef } from '@monetr/interface/components/MModal';
 import MSelectFrequency from '@monetr/interface/components/MSelectFrequency';
 import MSelectFunding from '@monetr/interface/components/MSelectFunding';
+import { Switch } from '@monetr/interface/components/Switch';
 import Typography from '@monetr/interface/components/Typography';
 import { useCreateSpending } from '@monetr/interface/hooks/useCreateSpending';
+import { useCurrentLink } from '@monetr/interface/hooks/useCurrentLink';
 import useLocaleCurrency from '@monetr/interface/hooks/useLocaleCurrency';
 import { useSelectedBankAccount } from '@monetr/interface/hooks/useSelectedBankAccount';
 import useTimezone from '@monetr/interface/hooks/useTimezone';
@@ -29,6 +31,7 @@ interface NewExpenseValues {
   nextOccurrence: Date;
   ruleset: string;
   fundingScheduleId: string;
+  autoCreateTransaction: boolean;
 }
 
 function NewExpenseModal(): JSX.Element {
@@ -39,6 +42,8 @@ function NewExpenseModal(): JSX.Element {
   const modal = useModal();
   const { enqueueSnackbar } = useSnackbar();
   const { data: selectedBankAccount } = useSelectedBankAccount();
+  const { data: link } = useCurrentLink();
+  const isManual = Boolean(link?.getIsManual());
   const createSpending = useCreateSpending();
 
   const ref = useRef<MModalRef>(null);
@@ -59,6 +64,7 @@ function NewExpenseModal(): JSX.Element {
     }),
     ruleset: '',
     fundingScheduleId: '',
+    autoCreateTransaction: false,
   };
 
   async function submit(values: NewExpenseValues, helper: FormikHelpers<NewExpenseValues>): Promise<void> {
@@ -72,6 +78,9 @@ function NewExpenseModal(): JSX.Element {
       fundingScheduleId: values.fundingScheduleId,
       targetAmount: friendlyToAmount(values.amount),
       ruleset: values.ruleset,
+      // Auto create transaction requires a manual link and a non-zero target
+      // amount; force it off otherwise so the API will not reject the create.
+      autoCreateTransaction: isManual && values.amount > 0 && values.autoCreateTransaction,
     });
 
     helper.setSubmitting(true);
@@ -140,6 +149,7 @@ function NewExpenseModal(): JSX.Element {
             placeholder='Select a spending frequency...'
             required
           />
+          {isManual && <AutoCreateTransactionToggle />}
         </div>
         <div className='flex justify-end gap-2'>
           <Button data-testid='close-new-expense-modal' onClick={modal.remove} variant='destructive'>
@@ -151,6 +161,38 @@ function NewExpenseModal(): JSX.Element {
         </div>
       </MForm>
     </MModal>
+  );
+}
+
+function AutoCreateTransactionToggle(): JSX.Element {
+  const autoCreateSwitchId = useId();
+  const { setFieldValue, values } = useFormikContext<NewExpenseValues>();
+  const hasAmount = (values.amount ?? 0) > 0;
+
+  return (
+    <div
+      className='flex flex-row items-center justify-between rounded-lg ring-1 p-2 ring-dark-monetr-border-string mb-4'
+      data-testid='new-expense-auto-create-transaction'
+    >
+      <div className='space-y-0.5'>
+        <label
+          aria-disabled={!hasAmount}
+          className='text-sm font-medium text-dark-monetr-content-emphasis cursor-pointer aria-disabled:cursor-not-allowed aria-disabled:opacity-50'
+          htmlFor={autoCreateSwitchId}
+        >
+          Auto create transaction
+        </label>
+        <p aria-disabled={!hasAmount} className='text-sm text-dark-monetr-content aria-disabled:opacity-50'>
+          Automatically add a transaction for this expense each time it is due, deducting from your balance.
+        </p>
+      </div>
+      <Switch
+        checked={hasAmount && values.autoCreateTransaction}
+        disabled={!hasAmount}
+        id={autoCreateSwitchId}
+        onCheckedChange={() => setFieldValue('autoCreateTransaction', !values.autoCreateTransaction)}
+      />
+    </div>
   );
 }
 

--- a/interface/src/modals/NewFundingModal.tsx
+++ b/interface/src/modals/NewFundingModal.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useCallback, useId, useRef } from 'react';
 import NiceModal, { useModal } from '@ebay/nice-modal-react';
 import { startOfDay, startOfTomorrow } from 'date-fns';
-import type { FormikHelpers } from 'formik';
+import { type FormikHelpers, useFormikContext } from 'formik';
 import { useSnackbar } from 'notistack';
 
 import type { ApiError } from '@monetr/interface/api/client';
@@ -35,7 +35,6 @@ interface NewFundingValues {
 
 function NewFundingModal(): JSX.Element {
   const switchId = useId();
-  const autoCreateSwitchId = useId();
   const { inTimezone } = useTimezone();
   const modal = useModal();
   const ref = useRef<MModalRef>(null);
@@ -152,33 +151,10 @@ function NewFundingModal(): JSX.Element {
                   onCheckedChange={() => setFieldValue('excludeWeekends', !values.excludeWeekends)}
                 />
               </div>
-              {isManual && (values.estimatedDeposit ?? 0) > 0 && (
-                <div
-                  className='flex flex-row items-center justify-between rounded-lg ring-1 p-2 ring-dark-monetr-border-string mb-4'
-                  data-testid='new-funding-auto-create-transaction'
-                >
-                  <div className='space-y-0.5'>
-                    <label
-                      className='text-sm font-medium text-dark-monetr-content-emphasis cursor-pointer'
-                      htmlFor={autoCreateSwitchId}
-                    >
-                      Auto create transaction
-                    </label>
-                    <p className='text-sm text-dark-monetr-content'>
-                      Automatically add a deposit transaction for the estimated deposit each time the funding schedule
-                      would occur.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={values.autoCreateTransaction}
-                    id={autoCreateSwitchId}
-                    onCheckedChange={() => setFieldValue('autoCreateTransaction', !values.autoCreateTransaction)}
-                  />
-                </div>
-              )}
+              {isManual && <AutoCreateTransactionToggle />}
             </div>
             <div className='flex justify-end gap-2'>
-              <Button data-testid='close-new-funding-modal' onClick={modal.remove} variant='destructive'>
+              <Button data-testid='close-new-funding-modal' onClick={modal.remove} variant='secondary'>
                 Cancel
               </Button>
               <FormButton type='submit' variant='primary'>
@@ -189,6 +165,38 @@ function NewFundingModal(): JSX.Element {
         )}
       </MForm>
     </MModal>
+  );
+}
+
+function AutoCreateTransactionToggle(): JSX.Element {
+  const autoCreateSwitchId = useId();
+  const { setFieldValue, values } = useFormikContext<NewFundingValues>();
+  const hasDeposit = (values.estimatedDeposit ?? 0) > 0;
+
+  return (
+    <div
+      className='flex flex-row items-center justify-between rounded-lg ring-1 p-2 ring-dark-monetr-border-string mb-4'
+      data-testid='new-funding-auto-create-transaction'
+    >
+      <div className='space-y-0.5'>
+        <label
+          aria-disabled={!hasDeposit}
+          className='text-sm font-medium text-dark-monetr-content-emphasis cursor-pointer aria-disabled:cursor-not-allowed aria-disabled:opacity-50'
+          htmlFor={autoCreateSwitchId}
+        >
+          Auto create transaction
+        </label>
+        <p aria-disabled={!hasDeposit} className='text-sm text-dark-monetr-content aria-disabled:opacity-50'>
+          Automatically add a deposit transaction for the estimated deposit each time the funding schedule would occur.
+        </p>
+      </div>
+      <Switch
+        checked={hasDeposit && values.autoCreateTransaction}
+        disabled={!hasDeposit}
+        id={autoCreateSwitchId}
+        onCheckedChange={() => setFieldValue('autoCreateTransaction', !values.autoCreateTransaction)}
+      />
+    </div>
   );
 }
 

--- a/interface/src/modals/NewFundingModal.tsx
+++ b/interface/src/modals/NewFundingModal.tsx
@@ -71,9 +71,10 @@ function NewFundingModal(): JSX.Element {
         ruleset: values.ruleset,
         estimatedDeposit: values.estimatedDeposit > 0 ? friendlyToAmount(values.estimatedDeposit) : null,
         excludeWeekends: values.excludeWeekends,
-        // Auto create transaction is only supported on manual links; force it
-        // off otherwise so the API will not reject the create.
-        autoCreateTransaction: isManual && values.autoCreateTransaction,
+        // Auto create transaction requires a manual link and a non-zero
+        // estimated deposit; force it off otherwise so the API will not reject
+        // the create.
+        autoCreateTransaction: isManual && (values.estimatedDeposit ?? 0) > 0 && values.autoCreateTransaction,
       })
         .then(created => modal.resolve(created))
         .then(() => modal.remove())
@@ -151,8 +152,11 @@ function NewFundingModal(): JSX.Element {
                   onCheckedChange={() => setFieldValue('excludeWeekends', !values.excludeWeekends)}
                 />
               </div>
-              {isManual && (
-                <div className='flex flex-row items-center justify-between rounded-lg ring-1 p-2 ring-dark-monetr-border-string mb-4'>
+              {isManual && (values.estimatedDeposit ?? 0) > 0 && (
+                <div
+                  className='flex flex-row items-center justify-between rounded-lg ring-1 p-2 ring-dark-monetr-border-string mb-4'
+                  data-testid='new-funding-auto-create-transaction'
+                >
                   <div className='space-y-0.5'>
                     <label
                       className='text-sm font-medium text-dark-monetr-content-emphasis cursor-pointer'
@@ -162,7 +166,7 @@ function NewFundingModal(): JSX.Element {
                     </label>
                     <p className='text-sm text-dark-monetr-content'>
                       Automatically add a deposit transaction for the estimated deposit each time the funding schedule
-                      fires.
+                      would occur.
                     </p>
                   </div>
                   <Switch

--- a/interface/src/modals/NewFundingModal.tsx
+++ b/interface/src/modals/NewFundingModal.tsx
@@ -16,6 +16,7 @@ import MSelectFrequency from '@monetr/interface/components/MSelectFrequency';
 import { Switch } from '@monetr/interface/components/Switch';
 import Typography from '@monetr/interface/components/Typography';
 import { useCreateFundingSchedule } from '@monetr/interface/hooks/useCreateFundingSchedule';
+import { useCurrentLink } from '@monetr/interface/hooks/useCurrentLink';
 import useLocaleCurrency from '@monetr/interface/hooks/useLocaleCurrency';
 import { useSelectedBankAccountId } from '@monetr/interface/hooks/useSelectedBankAccountId';
 import useTimezone from '@monetr/interface/hooks/useTimezone';
@@ -29,16 +30,20 @@ interface NewFundingValues {
   ruleset: string;
   excludeWeekends: boolean;
   estimatedDeposit?: number | null;
+  autoCreateTransaction: boolean;
 }
 
 function NewFundingModal(): JSX.Element {
   const switchId = useId();
+  const autoCreateSwitchId = useId();
   const { inTimezone } = useTimezone();
   const modal = useModal();
   const ref = useRef<MModalRef>(null);
   const { enqueueSnackbar } = useSnackbar();
   const selectedBankAccountId = useSelectedBankAccountId();
   const createFundingSchedule = useCreateFundingSchedule();
+  const { data: link } = useCurrentLink();
+  const isManual = Boolean(link?.getIsManual());
   const {
     data: { friendlyToAmount },
   } = useLocaleCurrency();
@@ -51,6 +56,7 @@ function NewFundingModal(): JSX.Element {
     ruleset: '',
     excludeWeekends: false,
     estimatedDeposit: undefined,
+    autoCreateTransaction: false,
   };
 
   const submit = useCallback(
@@ -65,6 +71,9 @@ function NewFundingModal(): JSX.Element {
         ruleset: values.ruleset,
         estimatedDeposit: values.estimatedDeposit > 0 ? friendlyToAmount(values.estimatedDeposit) : null,
         excludeWeekends: values.excludeWeekends,
+        // Auto create transaction is only supported on manual links; force it
+        // off otherwise so the API will not reject the create.
+        autoCreateTransaction: isManual && values.autoCreateTransaction,
       })
         .then(created => modal.resolve(created))
         .then(() => modal.remove())
@@ -77,7 +86,7 @@ function NewFundingModal(): JSX.Element {
         )
         .finally(() => helpers.setSubmitting(false));
     },
-    [createFundingSchedule, enqueueSnackbar, friendlyToAmount, modal, selectedBankAccountId, inTimezone],
+    [createFundingSchedule, enqueueSnackbar, friendlyToAmount, modal, selectedBankAccountId, inTimezone, isManual],
   );
 
   return (
@@ -142,6 +151,27 @@ function NewFundingModal(): JSX.Element {
                   onCheckedChange={() => setFieldValue('excludeWeekends', !values.excludeWeekends)}
                 />
               </div>
+              {isManual && (
+                <div className='flex flex-row items-center justify-between rounded-lg ring-1 p-2 ring-dark-monetr-border-string mb-4'>
+                  <div className='space-y-0.5'>
+                    <label
+                      className='text-sm font-medium text-dark-monetr-content-emphasis cursor-pointer'
+                      htmlFor={autoCreateSwitchId}
+                    >
+                      Auto create transaction
+                    </label>
+                    <p className='text-sm text-dark-monetr-content'>
+                      Automatically add a deposit transaction for the estimated deposit each time the funding schedule
+                      fires.
+                    </p>
+                  </div>
+                  <Switch
+                    checked={values.autoCreateTransaction}
+                    id={autoCreateSwitchId}
+                    onCheckedChange={() => setFieldValue('autoCreateTransaction', !values.autoCreateTransaction)}
+                  />
+                </div>
+              )}
             </div>
             <div className='flex justify-end gap-2'>
               <Button data-testid='close-new-funding-modal' onClick={modal.remove} variant='destructive'>

--- a/interface/src/models/FundingSchedule.ts
+++ b/interface/src/models/FundingSchedule.ts
@@ -10,6 +10,7 @@ export default class FundingSchedule {
   nextRecurrence: Date;
   readonly nextRecurrenceOriginal: Date;
   excludeWeekends: boolean;
+  autoCreateTransaction: boolean;
   estimatedDeposit: number | null;
 
   constructor(data?: Partial<FundingSchedule>) {

--- a/interface/src/models/Spending.ts
+++ b/interface/src/models/Spending.ts
@@ -23,6 +23,7 @@ export default class Spending {
   nextContributionAmount: number;
   isBehind: boolean;
   isPaused: boolean;
+  autoCreateTransaction: boolean;
   dateCreated: Date | null;
 
   constructor(data?: Partial<Spending>) {

--- a/interface/src/models/Transaction.ts
+++ b/interface/src/models/Transaction.ts
@@ -6,6 +6,8 @@ export default class Transaction {
   amount: number;
   spendingId?: string;
   spendingAmount?: number;
+  createdBySpendingId?: string;
+  createdByFundingScheduleId?: string;
   categories: string[];
   date: Date;
   authorizedDate?: Date;

--- a/interface/src/pages/expense/details.tsx
+++ b/interface/src/pages/expense/details.tsx
@@ -10,6 +10,7 @@ import Divider from '@monetr/interface/components/Divider';
 import ExpenseTransactionList from '@monetr/interface/components/expenses/ExpenseTransactionList';
 import FormAmountField from '@monetr/interface/components/FormAmountField';
 import FormButton from '@monetr/interface/components/FormButton';
+import FormCheckbox from '@monetr/interface/components/FormCheckbox';
 import FormDatePicker from '@monetr/interface/components/FormDatePicker';
 import FormTextField from '@monetr/interface/components/FormTextField';
 import MerchantIcon from '@monetr/interface/components/MerchantIcon';
@@ -18,6 +19,7 @@ import MSelectFrequency from '@monetr/interface/components/MSelectFrequency';
 import MSelectFunding from '@monetr/interface/components/MSelectFunding';
 import MTopNavigation from '@monetr/interface/components/MTopNavigation';
 import Typography from '@monetr/interface/components/Typography';
+import { useCurrentLink } from '@monetr/interface/hooks/useCurrentLink';
 import useLocaleCurrency from '@monetr/interface/hooks/useLocaleCurrency';
 import { useRemoveSpending } from '@monetr/interface/hooks/useRemoveSpending';
 import { useSpending } from '@monetr/interface/hooks/useSpending';
@@ -36,6 +38,7 @@ interface ExpenseValues {
   nextRecurrence: Date;
   fundingScheduleId: string;
   ruleset: string;
+  autoCreateTransaction: boolean;
 }
 
 export default function ExpenseDetails(): JSX.Element {
@@ -47,6 +50,8 @@ export default function ExpenseDetails(): JSX.Element {
   const { spendingId } = useParams();
   const { enqueueSnackbar } = useSnackbar();
   const { data: spending, isLoading, isError } = useSpending(spendingId);
+  const { data: link } = useCurrentLink();
+  const isManual = Boolean(link?.getIsManual());
 
   if (!spendingId) {
     return (
@@ -119,6 +124,9 @@ export default function ExpenseDetails(): JSX.Element {
       fundingScheduleId: values.fundingScheduleId,
       ruleset: values.ruleset,
       targetAmount: locale.friendlyToAmount(values.amount),
+      // Auto create transaction is only supported on manual links; force it off
+      // otherwise so the API will not reject the update.
+      autoCreateTransaction: isManual && values.autoCreateTransaction,
     });
 
     return updateSpending(updatedSpending)
@@ -145,6 +153,7 @@ export default function ExpenseDetails(): JSX.Element {
     nextRecurrence: spending.nextRecurrence,
     fundingScheduleId: spending.fundingScheduleId,
     ruleset: spending.ruleset,
+    autoCreateTransaction: spending.autoCreateTransaction,
   };
 
   const progress = ((Math.min(spending?.currentAmount, spending?.targetAmount) / spending?.targetAmount) * 100).toFixed(
@@ -223,6 +232,14 @@ export default function ExpenseDetails(): JSX.Element {
               placeholder='Select a spending frequency...'
               required
             />
+            {isManual && (
+              <FormCheckbox
+                className='w-full'
+                description='Automatically add a transaction for this expense each time it is due, deducting from your balance.'
+                label='Auto create transaction'
+                name='autoCreateTransaction'
+              />
+            )}
             <Divider className='w-1/2 my-8' />
             <ExpenseTransactionList spending={spending} />
           </div>

--- a/interface/src/pages/funding/details.spec.tsx
+++ b/interface/src/pages/funding/details.spec.tsx
@@ -327,6 +327,6 @@ describe('funding schedule details view', () => {
     });
 
     await waitFor(() => expect(world.getByTestId('funding-details-auto-create-transaction')).toBeVisible());
-    await waitFor(() => expect(world.getByRole('checkbox', { name: /Auto create transaction/i })).toBeDisabled());
+    await waitFor(() => expect(world.getByTestId('funding-details-auto-create-transaction')).toBeDisabled());
   });
 });

--- a/interface/src/pages/funding/details.spec.tsx
+++ b/interface/src/pages/funding/details.spec.tsx
@@ -168,4 +168,165 @@ describe('funding schedule details view', () => {
     await waitFor(() => expect(world.getByTestId('funding-details-date-picker')).toBeVisible());
     await waitFor(() => expect(world.queryByTestId('funding-schedule-weekend-notice')).not.toBeInTheDocument());
   });
+
+  it('shows auto create transaction toggle when manual link has an estimated deposit', async () => {
+    mockFetch.onGet('/api/users/me').reply(200, {
+      activeUntil: '2024-09-26T00:31:38Z',
+      hasSubscription: true,
+      isActive: true,
+      isSetup: true,
+      isTrialing: false,
+      trialingUntil: null,
+      defaultCurrency: 'USD',
+      user: {
+        userId: 'user_01hym36e8ewaq0hxssb1m3k4ha',
+        loginId: 'lgn_01hym36d96ze86vz5g7883vcwg',
+        login: {
+          loginId: 'lgn_01hym36d96ze86vz5g7883vcwg',
+          email: 'example@example.com',
+          firstName: 'Elliot',
+          lastName: 'Courant',
+          passwordResetAt: null,
+          isEmailVerified: true,
+          emailVerifiedAt: '2022-09-25T00:24:25.976514Z',
+          totpEnabledAt: null,
+        },
+        accountId: 'acct_01hk84dchvxvjgp7cgap818c82',
+        account: {
+          accountId: 'acct_01hk84dchvxvjgp7cgap818c82',
+          timezone: 'America/Chicago',
+          locale: 'en_US',
+          subscriptionActiveUntil: '2024-09-26T00:31:38Z',
+          subscriptionStatus: 'active',
+          trialEndsAt: null,
+          createdAt: '2024-01-03T17:02:23.290914Z',
+        },
+      },
+    });
+    mockFetch.onGet('/api/bank_accounts/bac_01hy4rcmadc01d2kzv7vynbxxx').reply(200, {
+      bankAccountId: 'bac_01hy4rcmadc01d2kzv7vynbxxx',
+      linkId: 'link_01hy4rbb1gjdek7h2xmgy5pnwk',
+      availableBalance: 48635,
+      currentBalance: 48635,
+      mask: '2982',
+      name: 'Mercury Checking',
+      originalName: 'Mercury Checking',
+      officialName: 'Mercury Checking',
+      accountType: 'depository',
+      accountSubType: 'checking',
+      currency: 'USD',
+      status: 'active',
+      lastUpdated: '2023-07-02T04:22:52.48118Z',
+    });
+    mockFetch.onGet('/api/links/link_01hy4rbb1gjdek7h2xmgy5pnwk').reply(200, {
+      linkId: 'link_01hy4rbb1gjdek7h2xmgy5pnwk',
+      linkType: 'manual',
+      institutionName: 'Manual Link',
+    });
+
+    mockFetch
+      .onGet('/api/bank_accounts/bac_01hy4rcmadc01d2kzv7vynbxxx/funding_schedules/fund_01hy4re7c1xc2v44cf6kx302jx')
+      .reply(200, {
+        bankAccountId: 'bac_01hy4rcmadc01d2kzv7vynbxxx',
+        dateStarted: '2023-02-28T06:00:00Z',
+        description: '15th and last day of every month',
+        estimatedDeposit: 100000,
+        excludeWeekends: false,
+        fundingScheduleId: 'fund_01hy4re7c1xc2v44cf6kx302jx',
+        lastRecurrence: '2023-09-30T05:00:00Z',
+        name: "Elliot's Contribution",
+        nextRecurrence: '2023-10-15T05:00:00Z',
+        nextRecurrenceOriginal: '2023-10-15T05:00:00Z',
+        ruleset: 'FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15,-1',
+        waitForDeposit: false,
+        autoCreateTransaction: false,
+      });
+
+    const world = testRenderer(<FundingDetails />, {
+      initialRoute: '/bank/bac_01hy4rcmadc01d2kzv7vynbxxx/funding/fund_01hy4re7c1xc2v44cf6kx302jx/details',
+    });
+
+    await waitFor(() => expect(world.getByTestId('funding-details-auto-create-transaction')).toBeVisible());
+  });
+
+  it('disables auto create transaction toggle when the estimated deposit is not set', async () => {
+    mockFetch.onGet('/api/users/me').reply(200, {
+      activeUntil: '2024-09-26T00:31:38Z',
+      hasSubscription: true,
+      isActive: true,
+      isSetup: true,
+      isTrialing: false,
+      trialingUntil: null,
+      defaultCurrency: 'USD',
+      user: {
+        userId: 'user_01hym36e8ewaq0hxssb1m3k4ha',
+        loginId: 'lgn_01hym36d96ze86vz5g7883vcwg',
+        login: {
+          loginId: 'lgn_01hym36d96ze86vz5g7883vcwg',
+          email: 'example@example.com',
+          firstName: 'Elliot',
+          lastName: 'Courant',
+          passwordResetAt: null,
+          isEmailVerified: true,
+          emailVerifiedAt: '2022-09-25T00:24:25.976514Z',
+          totpEnabledAt: null,
+        },
+        accountId: 'acct_01hk84dchvxvjgp7cgap818c82',
+        account: {
+          accountId: 'acct_01hk84dchvxvjgp7cgap818c82',
+          timezone: 'America/Chicago',
+          locale: 'en_US',
+          subscriptionActiveUntil: '2024-09-26T00:31:38Z',
+          subscriptionStatus: 'active',
+          trialEndsAt: null,
+          createdAt: '2024-01-03T17:02:23.290914Z',
+        },
+      },
+    });
+    mockFetch.onGet('/api/bank_accounts/bac_01hy4rcmadc01d2kzv7vynbxxx').reply(200, {
+      bankAccountId: 'bac_01hy4rcmadc01d2kzv7vynbxxx',
+      linkId: 'link_01hy4rbb1gjdek7h2xmgy5pnwk',
+      availableBalance: 48635,
+      currentBalance: 48635,
+      mask: '2982',
+      name: 'Mercury Checking',
+      originalName: 'Mercury Checking',
+      officialName: 'Mercury Checking',
+      accountType: 'depository',
+      accountSubType: 'checking',
+      currency: 'USD',
+      status: 'active',
+      lastUpdated: '2023-07-02T04:22:52.48118Z',
+    });
+    mockFetch.onGet('/api/links/link_01hy4rbb1gjdek7h2xmgy5pnwk').reply(200, {
+      linkId: 'link_01hy4rbb1gjdek7h2xmgy5pnwk',
+      linkType: 'manual',
+      institutionName: 'Manual Link',
+    });
+
+    mockFetch
+      .onGet('/api/bank_accounts/bac_01hy4rcmadc01d2kzv7vynbxxx/funding_schedules/fund_01hy4re7c1xc2v44cf6kx302jx')
+      .reply(200, {
+        bankAccountId: 'bac_01hy4rcmadc01d2kzv7vynbxxx',
+        dateStarted: '2023-02-28T06:00:00Z',
+        description: '15th and last day of every month',
+        estimatedDeposit: null,
+        excludeWeekends: false,
+        fundingScheduleId: 'fund_01hy4re7c1xc2v44cf6kx302jx',
+        lastRecurrence: '2023-09-30T05:00:00Z',
+        name: "Elliot's Contribution",
+        nextRecurrence: '2023-10-15T05:00:00Z',
+        nextRecurrenceOriginal: '2023-10-15T05:00:00Z',
+        ruleset: 'FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15,-1',
+        waitForDeposit: false,
+        autoCreateTransaction: false,
+      });
+
+    const world = testRenderer(<FundingDetails />, {
+      initialRoute: '/bank/bac_01hy4rcmadc01d2kzv7vynbxxx/funding/fund_01hy4re7c1xc2v44cf6kx302jx/details',
+    });
+
+    await waitFor(() => expect(world.getByTestId('funding-details-auto-create-transaction')).toBeVisible());
+    await waitFor(() => expect(world.getByRole('checkbox', { name: /Auto create transaction/i })).toBeDisabled());
+  });
 });

--- a/interface/src/pages/funding/details.tsx
+++ b/interface/src/pages/funding/details.tsx
@@ -18,6 +18,7 @@ import MForm from '@monetr/interface/components/MForm';
 import MSelectFrequency from '@monetr/interface/components/MSelectFrequency';
 import MTopNavigation from '@monetr/interface/components/MTopNavigation';
 import Typography from '@monetr/interface/components/Typography';
+import { useCurrentLink } from '@monetr/interface/hooks/useCurrentLink';
 import { useFundingSchedule } from '@monetr/interface/hooks/useFundingSchedule';
 import useLocaleCurrency from '@monetr/interface/hooks/useLocaleCurrency';
 import { usePatchFundingSchedule } from '@monetr/interface/hooks/usePatchFundingSchedule';
@@ -32,6 +33,7 @@ interface FundingValues {
   ruleset: string;
   excludeWeekends: boolean;
   estimatedDeposit: number | null;
+  autoCreateTransaction: boolean;
 }
 
 export default function FundingDetails(): JSX.Element {
@@ -43,6 +45,8 @@ export default function FundingDetails(): JSX.Element {
   const match = useMatch('/bank/:bankId/funding/:fundingId/details');
   const fundingId = match?.params?.fundingId || null;
   const { data: funding } = useFundingSchedule(fundingId);
+  const { data: link } = useCurrentLink();
+  const isManual = Boolean(link?.getIsManual());
   const navigate = useNavigate();
   const patchFundingSchedule = usePatchFundingSchedule();
   const removeFundingSchedule = useRemoveFundingSchedule();
@@ -88,6 +92,9 @@ export default function FundingDetails(): JSX.Element {
       ruleset: values.ruleset,
       excludeWeekends: values.excludeWeekends,
       estimatedDeposit: locale.friendlyToAmount(values.estimatedDeposit),
+      // Auto create transaction is only supported on manual links; force it off
+      // otherwise so the API will not reject the update.
+      autoCreateTransaction: isManual && values.autoCreateTransaction,
     })
       .then(
         () =>
@@ -137,6 +144,7 @@ export default function FundingDetails(): JSX.Element {
     excludeWeekends: funding.excludeWeekends,
     // Because we store all amounts in cents, in order to use them in the UI we need to convert them back to dollars.
     estimatedDeposit: locale.amountToFriendly(funding.estimatedDeposit),
+    autoCreateTransaction: funding.autoCreateTransaction,
   };
 
   return (
@@ -191,6 +199,14 @@ export default function FundingDetails(): JSX.Element {
               name='estimatedDeposit'
               placeholder='Example: $ 1,000.00'
             />
+            {isManual && (
+              <FormCheckbox
+                data-testid='funding-details-auto-create-transaction'
+                description='Automatically add a deposit transaction for the estimated deposit each time the funding schedule would occur.'
+                label='Auto create transaction'
+                name='autoCreateTransaction'
+              />
+            )}
           </div>
           <Divider className='block md:hidden w-1/2' />
           <div className='w-full md:w-1/2 flex flex-col gap-2'>

--- a/interface/src/pages/funding/details.tsx
+++ b/interface/src/pages/funding/details.tsx
@@ -1,6 +1,6 @@
 import { useId } from 'react';
 import { format, isEqual, startOfDay, startOfTomorrow } from 'date-fns';
-import type { FormikErrors, FormikHelpers } from 'formik';
+import { type FormikErrors, type FormikHelpers, useFormikContext } from 'formik';
 import { CalendarSync, HeartCrack, Save, Trash } from 'lucide-react';
 import { useSnackbar } from 'notistack';
 import { useMatch, useNavigate } from 'react-router-dom';
@@ -92,9 +92,9 @@ export default function FundingDetails(): JSX.Element {
       ruleset: values.ruleset,
       excludeWeekends: values.excludeWeekends,
       estimatedDeposit: locale.friendlyToAmount(values.estimatedDeposit),
-      // Auto create transaction is only supported on manual links; force it off
-      // otherwise so the API will not reject the update.
-      autoCreateTransaction: isManual && values.autoCreateTransaction,
+      // Auto create transaction requires a manual link and a non-zero estimated
+      // deposit; force it off otherwise so the API will not reject the update.
+      autoCreateTransaction: isManual && (values.estimatedDeposit ?? 0) > 0 && values.autoCreateTransaction,
     })
       .then(
         () =>
@@ -199,14 +199,7 @@ export default function FundingDetails(): JSX.Element {
               name='estimatedDeposit'
               placeholder='Example: $ 1,000.00'
             />
-            {isManual && (
-              <FormCheckbox
-                data-testid='funding-details-auto-create-transaction'
-                description='Automatically add a deposit transaction for the estimated deposit each time the funding schedule would occur.'
-                label='Auto create transaction'
-                name='autoCreateTransaction'
-              />
-            )}
+            {isManual && <AutoCreateTransactionToggle />}
           </div>
           <Divider className='block md:hidden w-1/2' />
           <div className='w-full md:w-1/2 flex flex-col gap-2'>
@@ -218,6 +211,23 @@ export default function FundingDetails(): JSX.Element {
         </div>
       </div>
     </MForm>
+  );
+}
+
+function AutoCreateTransactionToggle(): React.JSX.Element {
+  const { values } = useFormikContext<FundingValues>();
+  // The toggle is always visible on a manual link but is only usable once a
+  // non-zero estimated deposit has been provided.
+  const hasDeposit = (values.estimatedDeposit ?? 0) > 0;
+
+  return (
+    <FormCheckbox
+      data-testid='funding-details-auto-create-transaction'
+      description='Automatically add a deposit transaction for the estimated deposit each time the funding schedule would occur.'
+      disabled={!hasDeposit}
+      label='Auto create transaction'
+      name='autoCreateTransaction'
+    />
   );
 }
 

--- a/interface/src/pages/transactions.tsx
+++ b/interface/src/pages/transactions.tsx
@@ -152,7 +152,7 @@ export default function Transactions(): JSX.Element {
 function AddTransactionButton(): JSX.Element {
   const { data: link } = useCurrentLink();
 
-  if (!link || !link.getIsManual()) {
+  if (!link?.getIsManual()) {
     return null;
   }
 

--- a/server/controller/funding_schedules.go
+++ b/server/controller/funding_schedules.go
@@ -94,6 +94,9 @@ func (c *Controller) postFundingSchedules(ctx echo.Context) error {
 	}
 
 	if fundingSchedule.AutoCreateTransaction {
+		if fundingSchedule.EstimatedDeposit == nil || *fundingSchedule.EstimatedDeposit <= 0 {
+			return c.badRequest(ctx, "Auto create transaction requires a non-zero estimated deposit")
+		}
 		isManual, err := repo.GetLinkIsManualByBankAccountId(c.getContext(ctx), bankAccountId)
 		if err != nil {
 			return c.wrapPgError(ctx, err, "failed to validate if link is manual")
@@ -181,6 +184,9 @@ func (c *Controller) putFundingSchedules(ctx echo.Context) error {
 	}
 
 	if request.AutoCreateTransaction {
+		if request.EstimatedDeposit == nil || *request.EstimatedDeposit <= 0 {
+			return c.badRequest(ctx, "Auto create transaction requires a non-zero estimated deposit")
+		}
 		isManual, err := repo.GetLinkIsManualByBankAccountId(c.getContext(ctx), bankAccountId)
 		if err != nil {
 			return c.wrapPgError(ctx, err, "failed to validate if link is manual")
@@ -307,6 +313,9 @@ func (c *Controller) patchFundingSchedule(ctx echo.Context) error {
 	}
 
 	if fundingSchedule.AutoCreateTransaction {
+		if fundingSchedule.EstimatedDeposit == nil || *fundingSchedule.EstimatedDeposit <= 0 {
+			return c.badRequest(ctx, "Auto create transaction requires a non-zero estimated deposit")
+		}
 		isManual, err := repo.GetLinkIsManualByBankAccountId(c.getContext(ctx), bankAccountId)
 		if err != nil {
 			return c.wrapPgError(ctx, err, "failed to validate if link is manual")

--- a/server/controller/funding_schedules.go
+++ b/server/controller/funding_schedules.go
@@ -93,6 +93,16 @@ func (c *Controller) postFundingSchedules(ctx echo.Context) error {
 		return c.wrapPgError(ctx, err, "failed to retrieve bank account")
 	}
 
+	if fundingSchedule.AutoCreateTransaction {
+		isManual, err := repo.GetLinkIsManualByBankAccountId(c.getContext(ctx), bankAccountId)
+		if err != nil {
+			return c.wrapPgError(ctx, err, "failed to validate if link is manual")
+		}
+		if !isManual {
+			return c.badRequest(ctx, "Auto create transaction is only supported for manual links")
+		}
+	}
+
 	// Set the next occurrence based on the provided rule.
 
 	// If the next occurrence is not specified then assume that the rule is relative to now. If it is specified though
@@ -168,6 +178,16 @@ func (c *Controller) putFundingSchedules(ctx echo.Context) error {
 
 	if request.EstimatedDeposit != nil && *request.EstimatedDeposit < 0 {
 		return c.badRequest(ctx, "Estimated deposit must be greater than or equal to zero")
+	}
+
+	if request.AutoCreateTransaction {
+		isManual, err := repo.GetLinkIsManualByBankAccountId(c.getContext(ctx), bankAccountId)
+		if err != nil {
+			return c.wrapPgError(ctx, err, "failed to validate if link is manual")
+		}
+		if !isManual {
+			return c.badRequest(ctx, "Auto create transaction is only supported for manual links")
+		}
 	}
 
 	recalculateSpending := false
@@ -284,6 +304,16 @@ func (c *Controller) patchFundingSchedule(ctx echo.Context) error {
 		break
 	default:
 		return c.wrapAndReturnError(ctx, err, http.StatusBadRequest, "failed to parse patch request")
+	}
+
+	if fundingSchedule.AutoCreateTransaction {
+		isManual, err := repo.GetLinkIsManualByBankAccountId(c.getContext(ctx), bankAccountId)
+		if err != nil {
+			return c.wrapPgError(ctx, err, "failed to validate if link is manual")
+		}
+		if !isManual {
+			return c.badRequest(ctx, "Auto create transaction is only supported for manual links")
+		}
 	}
 
 	// Check if the changes made to the funding schedule would require that we

--- a/server/controller/funding_schedules_test.go
+++ b/server/controller/funding_schedules_test.go
@@ -268,6 +268,75 @@ func TestPostFundingSchedules(t *testing.T) {
 			response.JSON().Path("$.error").String().IsEqual("failed to retrieve bank account: record does not exist")
 		}
 	})
+
+	t.Run("rejects auto create transaction without an estimated deposit", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, models.DepositoryBankAccountType, models.CheckingBankAccountSubType)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		response := e.POST("/api/bank_accounts/{bankAccountId}/funding_schedules").
+			WithPath("bankAccountId", bank.BankAccountId).
+			WithCookie(TestCookieName, token).
+			WithJSON(map[string]any{
+				"name":                  "Payday",
+				"description":           "15th and the Last day of every month",
+				"ruleset":               FifthteenthAndLastDayOfEveryMonth,
+				"autoCreateTransaction": true,
+			}).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.error").String().IsEqual("Auto create transaction requires a non-zero estimated deposit")
+	})
+
+	t.Run("rejects auto create transaction on plaid link", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAPlaidLink(t, app.Clock, user)
+		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, models.DepositoryBankAccountType, models.CheckingBankAccountSubType)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		response := e.POST("/api/bank_accounts/{bankAccountId}/funding_schedules").
+			WithPath("bankAccountId", bank.BankAccountId).
+			WithCookie(TestCookieName, token).
+			WithJSON(map[string]any{
+				"name":                  "Payday",
+				"description":           "15th and the Last day of every month",
+				"ruleset":               FifthteenthAndLastDayOfEveryMonth,
+				"estimatedDeposit":      100000,
+				"autoCreateTransaction": true,
+			}).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.error").String().IsEqual("Auto create transaction is only supported for manual links")
+	})
+
+	t.Run("creates funding schedule with auto create transaction enabled", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, models.DepositoryBankAccountType, models.CheckingBankAccountSubType)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		response := e.POST("/api/bank_accounts/{bankAccountId}/funding_schedules").
+			WithPath("bankAccountId", bank.BankAccountId).
+			WithCookie(TestCookieName, token).
+			WithJSON(map[string]any{
+				"name":                  "Payday",
+				"description":           "15th and the Last day of every month",
+				"ruleset":               FifthteenthAndLastDayOfEveryMonth,
+				"estimatedDeposit":      100000,
+				"autoCreateTransaction": true,
+			}).
+			Expect()
+
+		response.Status(http.StatusOK)
+		response.JSON().Path("$.autoCreateTransaction").Boolean().IsTrue()
+		response.JSON().Path("$.estimatedDeposit").Number().IsEqual(100000)
+	})
 }
 
 func TestPutFundingSchedules(t *testing.T) {
@@ -415,6 +484,73 @@ func TestPutFundingSchedules(t *testing.T) {
 			response.Status(http.StatusNotFound)
 			response.JSON().Path("$.error").String().IsEqual("failed to verify funding schedule exists: record does not exist")
 		}
+	})
+
+	t.Run("rejects auto create transaction without an estimated deposit during update", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, models.DepositoryBankAccountType, models.CheckingBankAccountSubType)
+		fundingSchedule := fixtures.GivenIHaveAFundingSchedule(t, app.Clock, &bank, "FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15,-1", false)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		fundingSchedule.AutoCreateTransaction = true
+
+		response := e.PUT("/api/bank_accounts/{bankAccountId}/funding_schedules/{fundingScheduleId}").
+			WithPath("bankAccountId", fundingSchedule.BankAccountId).
+			WithPath("fundingScheduleId", fundingSchedule.FundingScheduleId).
+			WithJSON(fundingSchedule).
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.error").String().IsEqual("Auto create transaction requires a non-zero estimated deposit")
+	})
+
+	t.Run("rejects auto create transaction on plaid link during update", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAPlaidLink(t, app.Clock, user)
+		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, models.DepositoryBankAccountType, models.CheckingBankAccountSubType)
+		fundingSchedule := fixtures.GivenIHaveAFundingSchedule(t, app.Clock, &bank, "FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15,-1", false)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		estimatedDeposit := int64(100000)
+		fundingSchedule.EstimatedDeposit = &estimatedDeposit
+		fundingSchedule.AutoCreateTransaction = true
+
+		response := e.PUT("/api/bank_accounts/{bankAccountId}/funding_schedules/{fundingScheduleId}").
+			WithPath("bankAccountId", fundingSchedule.BankAccountId).
+			WithPath("fundingScheduleId", fundingSchedule.FundingScheduleId).
+			WithJSON(fundingSchedule).
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.error").String().IsEqual("Auto create transaction is only supported for manual links")
+	})
+
+	t.Run("can toggle auto create transaction on manual link", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, models.DepositoryBankAccountType, models.CheckingBankAccountSubType)
+		fundingSchedule := fixtures.GivenIHaveAFundingSchedule(t, app.Clock, &bank, "FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15,-1", false)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		estimatedDeposit := int64(100000)
+		fundingSchedule.EstimatedDeposit = &estimatedDeposit
+		fundingSchedule.AutoCreateTransaction = true
+
+		response := e.PUT("/api/bank_accounts/{bankAccountId}/funding_schedules/{fundingScheduleId}").
+			WithPath("bankAccountId", fundingSchedule.BankAccountId).
+			WithPath("fundingScheduleId", fundingSchedule.FundingScheduleId).
+			WithJSON(fundingSchedule).
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusOK)
+		response.JSON().Path("$.fundingSchedule.autoCreateTransaction").Boolean().IsTrue()
 	})
 }
 
@@ -695,6 +831,78 @@ func TestPatchFundingSchedule(t *testing.T) {
 			response.Status(http.StatusNotFound)
 			response.JSON().Path("$.error").String().IsEqual("failed to verify funding schedule exists: record does not exist")
 		}
+	})
+
+	t.Run("rejects auto create transaction without an estimated deposit via patch", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		// Hack to fix the mock clock thing for now.
+		app.Clock.Add(time.Since(app.Clock.Now()))
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, models.DepositoryBankAccountType, models.CheckingBankAccountSubType)
+		fundingSchedule := fixtures.GivenIHaveAFundingSchedule(t, app.Clock, &bank, "FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15,-1", false)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		response := e.PATCH("/api/bank_accounts/{bankAccountId}/funding_schedules/{fundingScheduleId}").
+			WithPath("bankAccountId", fundingSchedule.BankAccountId).
+			WithPath("fundingScheduleId", fundingSchedule.FundingScheduleId).
+			WithJSON(map[string]any{
+				"autoCreateTransaction": true,
+			}).
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.error").String().IsEqual("Auto create transaction requires a non-zero estimated deposit")
+	})
+
+	t.Run("rejects auto create transaction on plaid link", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		// Hack to fix the mock clock thing for now.
+		app.Clock.Add(time.Since(app.Clock.Now()))
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAPlaidLink(t, app.Clock, user)
+		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, models.DepositoryBankAccountType, models.CheckingBankAccountSubType)
+		fundingSchedule := fixtures.GivenIHaveAFundingSchedule(t, app.Clock, &bank, "FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15,-1", false)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		response := e.PATCH("/api/bank_accounts/{bankAccountId}/funding_schedules/{fundingScheduleId}").
+			WithPath("bankAccountId", fundingSchedule.BankAccountId).
+			WithPath("fundingScheduleId", fundingSchedule.FundingScheduleId).
+			WithJSON(map[string]any{
+				"estimatedDeposit":      100000,
+				"autoCreateTransaction": true,
+			}).
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.error").String().IsEqual("Auto create transaction is only supported for manual links")
+	})
+
+	t.Run("can toggle auto create transaction on manual link via patch", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		// Hack to fix the mock clock thing for now.
+		app.Clock.Add(time.Since(app.Clock.Now()))
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, models.DepositoryBankAccountType, models.CheckingBankAccountSubType)
+		fundingSchedule := fixtures.GivenIHaveAFundingSchedule(t, app.Clock, &bank, "FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15,-1", false)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		response := e.PATCH("/api/bank_accounts/{bankAccountId}/funding_schedules/{fundingScheduleId}").
+			WithPath("bankAccountId", fundingSchedule.BankAccountId).
+			WithPath("fundingScheduleId", fundingSchedule.FundingScheduleId).
+			WithJSON(map[string]any{
+				"estimatedDeposit":      100000,
+				"autoCreateTransaction": true,
+			}).
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusOK)
+		response.JSON().Path("$.fundingSchedule.autoCreateTransaction").Boolean().IsTrue()
+		response.JSON().Path("$.fundingSchedule.estimatedDeposit").Number().IsEqual(100000)
 	})
 }
 

--- a/server/controller/spending.go
+++ b/server/controller/spending.go
@@ -116,6 +116,19 @@ func (c *Controller) postSpending(ctx echo.Context) error {
 		}
 	}
 
+	if spending.AutoCreateTransaction {
+		if spending.SpendingType != SpendingTypeExpense {
+			return c.badRequest(ctx, "auto create transaction is only supported for expenses")
+		}
+		isManual, err := repo.GetLinkIsManualByBankAccountId(c.getContext(ctx), bankAccountId)
+		if err != nil {
+			return c.wrapPgError(ctx, err, "failed to validate if link is manual")
+		}
+		if !isManual {
+			return c.badRequest(ctx, "auto create transaction is only supported for manual links")
+		}
+	}
+
 	// Make sure that the next recurrence date is properly in the user's timezone.
 	nextRecurrence, err := c.midnightInLocal(ctx, next)
 	if err != nil {
@@ -333,6 +346,19 @@ func (c *Controller) putSpending(ctx echo.Context) error {
 
 	if updatedSpending.SpendingType == SpendingTypeExpense && updatedSpending.RuleSet == nil {
 		return c.badRequest(ctx, "Expense must have a recurrence rule provided")
+	}
+
+	if updatedSpending.AutoCreateTransaction {
+		if updatedSpending.SpendingType != SpendingTypeExpense {
+			return c.badRequest(ctx, "auto create transaction is only supported for expenses")
+		}
+		isManual, err := repo.GetLinkIsManualByBankAccountId(c.getContext(ctx), bankAccountId)
+		if err != nil {
+			return c.wrapPgError(ctx, err, "failed to validate if link is manual")
+		}
+		if !isManual {
+			return c.badRequest(ctx, "auto create transaction is only supported for manual links")
+		}
 	}
 
 	recalculateSpending := false

--- a/server/controller/spending_test.go
+++ b/server/controller/spending_test.go
@@ -607,6 +607,91 @@ func TestPostSpending(t *testing.T) {
 			response.JSON().Path("$.error").String().IsEqual("failed to create spending: a similar object already exists")
 		}
 	})
+
+	t.Run("rejects auto create transaction on goal", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+		fundingSchedule := fixtures.GivenIHaveAFundingSchedule(t, app.Clock, &bank, FifthteenthAndLastDayOfEveryMonth, false)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		response := e.POST("/api/bank_accounts/{bankAccountId}/spending").
+			WithPath("bankAccountId", bank.BankAccountId).
+			WithCookie(TestCookieName, token).
+			WithJSON(map[string]any{
+				"name":                  "Vacation Savings",
+				"fundingScheduleId":     fundingSchedule.FundingScheduleId,
+				"targetAmount":          1000,
+				"spendingType":          SpendingTypeGoal,
+				"nextRecurrence":        app.Clock.Now().Add(30 * 24 * time.Hour),
+				"autoCreateTransaction": true,
+			}).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.error").String().IsEqual("auto create transaction is only supported for expenses")
+	})
+
+	t.Run("rejects auto create transaction on plaid link", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAPlaidLink(t, app.Clock, user)
+		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+		fundingSchedule := fixtures.GivenIHaveAFundingSchedule(t, app.Clock, &bank, FifthteenthAndLastDayOfEveryMonth, false)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		now := app.Clock.Now()
+		ruleset := testutils.Must(t, NewRuleSet, FirstDayOfEveryMonth)
+		nextRecurrence := ruleset.After(now, false)
+
+		response := e.POST("/api/bank_accounts/{bankAccountId}/spending").
+			WithPath("bankAccountId", bank.BankAccountId).
+			WithCookie(TestCookieName, token).
+			WithJSON(map[string]any{
+				"name":                  "Some Monthly Expense",
+				"ruleset":               FirstDayOfEveryMonth,
+				"fundingScheduleId":     fundingSchedule.FundingScheduleId,
+				"targetAmount":          1000,
+				"spendingType":          SpendingTypeExpense,
+				"nextRecurrence":        nextRecurrence,
+				"autoCreateTransaction": true,
+			}).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.error").String().IsEqual("auto create transaction is only supported for manual links")
+	})
+
+	t.Run("creates expense with auto create transaction enabled", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+		fundingSchedule := fixtures.GivenIHaveAFundingSchedule(t, app.Clock, &bank, FifthteenthAndLastDayOfEveryMonth, false)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		now := app.Clock.Now()
+		ruleset := testutils.Must(t, NewRuleSet, FirstDayOfEveryMonth)
+		nextRecurrence := ruleset.After(now, false)
+
+		response := e.POST("/api/bank_accounts/{bankAccountId}/spending").
+			WithPath("bankAccountId", bank.BankAccountId).
+			WithCookie(TestCookieName, token).
+			WithJSON(map[string]any{
+				"name":                  "Some Monthly Expense",
+				"ruleset":               FirstDayOfEveryMonth,
+				"fundingScheduleId":     fundingSchedule.FundingScheduleId,
+				"targetAmount":          1000,
+				"spendingType":          SpendingTypeExpense,
+				"nextRecurrence":        nextRecurrence,
+				"autoCreateTransaction": true,
+			}).
+			Expect()
+
+		response.Status(http.StatusOK)
+		response.JSON().Path("$.autoCreateTransaction").Boolean().IsTrue()
+	})
 }
 
 func TestGetSpending(t *testing.T) {
@@ -1916,6 +2001,182 @@ func TestPutSpending(t *testing.T) {
 
 			response.Status(http.StatusNotFound)
 			response.JSON().Path("$.error").String().IsEqual("failed to find existing spending: record does not exist")
+		}
+	})
+
+	t.Run("rejects auto create transaction on goal during update", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+		fundingSchedule := fixtures.GivenIHaveAFundingSchedule(t, app.Clock, &bank, FifthteenthAndLastDayOfEveryMonth, false)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		nextRecurrence := app.Clock.Now().Add(30 * 24 * time.Hour)
+
+		var spendingId ID[Spending]
+		{ // Create a goal
+			response := e.POST("/api/bank_accounts/{bankAccountId}/spending").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithCookie(TestCookieName, token).
+				WithJSON(map[string]any{
+					"name":              "Vacation Savings",
+					"fundingScheduleId": fundingSchedule.FundingScheduleId,
+					"targetAmount":      1000,
+					"spendingType":      SpendingTypeGoal,
+					"nextRecurrence":    nextRecurrence,
+				}).
+				Expect()
+
+			response.Status(http.StatusOK)
+			spendingId = ID[Spending](response.JSON().Path("$.spendingId").String().Raw())
+			assert.False(t, spendingId.IsZero(), "must be able to extract the spending ID")
+		}
+
+		{ // Attempt to enable auto create transaction on the goal
+			response := e.PUT("/api/bank_accounts/{bankAccountId}/spending/{spendingId}").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithPath("spendingId", spendingId).
+				WithCookie(TestCookieName, token).
+				WithJSON(map[string]any{
+					"name":                  "Vacation Savings",
+					"fundingScheduleId":     fundingSchedule.FundingScheduleId,
+					"targetAmount":          1000,
+					"spendingType":          SpendingTypeGoal,
+					"nextRecurrence":        nextRecurrence,
+					"autoCreateTransaction": true,
+				}).
+				Expect()
+
+			response.Status(http.StatusBadRequest)
+			response.JSON().Path("$.error").String().IsEqual("auto create transaction is only supported for expenses")
+		}
+	})
+
+	t.Run("rejects auto create transaction on plaid link during update", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAPlaidLink(t, app.Clock, user)
+		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+		fundingSchedule := fixtures.GivenIHaveAFundingSchedule(t, app.Clock, &bank, FifthteenthAndLastDayOfEveryMonth, false)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		now := app.Clock.Now()
+		ruleset := testutils.Must(t, NewRuleSet, FirstDayOfEveryMonth)
+		nextRecurrence := ruleset.After(now, false)
+
+		var spendingId ID[Spending]
+		{ // Create an expense on a Plaid link
+			response := e.POST("/api/bank_accounts/{bankAccountId}/spending").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithCookie(TestCookieName, token).
+				WithJSON(map[string]any{
+					"name":              "Some Monthly Expense",
+					"ruleset":           FirstDayOfEveryMonth,
+					"fundingScheduleId": fundingSchedule.FundingScheduleId,
+					"targetAmount":      1000,
+					"spendingType":      SpendingTypeExpense,
+					"nextRecurrence":    nextRecurrence,
+				}).
+				Expect()
+
+			response.Status(http.StatusOK)
+			spendingId = ID[Spending](response.JSON().Path("$.spendingId").String().Raw())
+			assert.False(t, spendingId.IsZero(), "must be able to extract the spending ID")
+		}
+
+		{ // Attempt to enable auto create transaction on the Plaid expense
+			response := e.PUT("/api/bank_accounts/{bankAccountId}/spending/{spendingId}").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithPath("spendingId", spendingId).
+				WithCookie(TestCookieName, token).
+				WithJSON(map[string]any{
+					"name":                  "Some Monthly Expense",
+					"ruleset":               FirstDayOfEveryMonth,
+					"fundingScheduleId":     fundingSchedule.FundingScheduleId,
+					"targetAmount":          1000,
+					"spendingType":          SpendingTypeExpense,
+					"nextRecurrence":        nextRecurrence,
+					"autoCreateTransaction": true,
+				}).
+				Expect()
+
+			response.Status(http.StatusBadRequest)
+			response.JSON().Path("$.error").String().IsEqual("auto create transaction is only supported for manual links")
+		}
+	})
+
+	t.Run("can toggle auto create transaction on manual link expense", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+		fundingSchedule := fixtures.GivenIHaveAFundingSchedule(t, app.Clock, &bank, FifthteenthAndLastDayOfEveryMonth, false)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		now := app.Clock.Now()
+		ruleset := testutils.Must(t, NewRuleSet, FirstDayOfEveryMonth)
+		nextRecurrence := ruleset.After(now, false)
+
+		var spendingId ID[Spending]
+		{ // Create an expense with auto create transaction off
+			response := e.POST("/api/bank_accounts/{bankAccountId}/spending").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithCookie(TestCookieName, token).
+				WithJSON(map[string]any{
+					"name":              "Some Monthly Expense",
+					"ruleset":           FirstDayOfEveryMonth,
+					"fundingScheduleId": fundingSchedule.FundingScheduleId,
+					"targetAmount":      1000,
+					"spendingType":      SpendingTypeExpense,
+					"nextRecurrence":    nextRecurrence,
+				}).
+				Expect()
+
+			response.Status(http.StatusOK)
+			response.JSON().Path("$.autoCreateTransaction").Boolean().IsFalse()
+			spendingId = ID[Spending](response.JSON().Path("$.spendingId").String().Raw())
+			assert.False(t, spendingId.IsZero(), "must be able to extract the spending ID")
+		}
+
+		{ // Toggle auto create transaction on
+			response := e.PUT("/api/bank_accounts/{bankAccountId}/spending/{spendingId}").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithPath("spendingId", spendingId).
+				WithCookie(TestCookieName, token).
+				WithJSON(map[string]any{
+					"name":                  "Some Monthly Expense",
+					"ruleset":               FirstDayOfEveryMonth,
+					"fundingScheduleId":     fundingSchedule.FundingScheduleId,
+					"targetAmount":          1000,
+					"spendingType":          SpendingTypeExpense,
+					"nextRecurrence":        nextRecurrence,
+					"autoCreateTransaction": true,
+				}).
+				Expect()
+
+			response.Status(http.StatusOK)
+			response.JSON().Path("$.autoCreateTransaction").Boolean().IsTrue()
+		}
+
+		{ // Toggle auto create transaction back off
+			response := e.PUT("/api/bank_accounts/{bankAccountId}/spending/{spendingId}").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithPath("spendingId", spendingId).
+				WithCookie(TestCookieName, token).
+				WithJSON(map[string]any{
+					"name":                  "Some Monthly Expense",
+					"ruleset":               FirstDayOfEveryMonth,
+					"fundingScheduleId":     fundingSchedule.FundingScheduleId,
+					"targetAmount":          1000,
+					"spendingType":          SpendingTypeExpense,
+					"nextRecurrence":        nextRecurrence,
+					"autoCreateTransaction": false,
+				}).
+				Expect()
+
+			response.Status(http.StatusOK)
+			response.JSON().Path("$.autoCreateTransaction").Boolean().IsFalse()
 		}
 	})
 }

--- a/server/controller/spending_test.go
+++ b/server/controller/spending_test.go
@@ -613,15 +613,34 @@ func TestPostSpending(t *testing.T) {
 		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
 		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
 		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
-		fundingSchedule := fixtures.GivenIHaveAFundingSchedule(t, app.Clock, &bank, FifthteenthAndLastDayOfEveryMonth, false)
 		token := GivenILogin(t, e, user.Login.Email, password)
+
+		var fundingScheduleId ID[FundingSchedule]
+		{ // Create the funding schedule
+			response := e.POST("/api/bank_accounts/{bankAccountId}/funding_schedules").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithCookie(TestCookieName, token).
+				WithJSON(map[string]any{
+					"name":            "Payday",
+					"description":     "15th and the Last day of every month",
+					"ruleset":         FifthteenthAndLastDayOfEveryMonth,
+					"excludeWeekends": true,
+				}).
+				Expect()
+
+			response.Status(http.StatusOK)
+			response.JSON().Path("$.bankAccountId").IsEqual(bank.BankAccountId)
+			response.JSON().Path("$.fundingScheduleId").String().IsASCII()
+			fundingScheduleId = ID[FundingSchedule](response.JSON().Path("$.fundingScheduleId").String().Raw())
+			assert.False(t, fundingScheduleId.IsZero(), "must be able to extract the funding schedule ID")
+		}
 
 		response := e.POST("/api/bank_accounts/{bankAccountId}/spending").
 			WithPath("bankAccountId", bank.BankAccountId).
 			WithCookie(TestCookieName, token).
 			WithJSON(map[string]any{
 				"name":                  "Vacation Savings",
-				"fundingScheduleId":     fundingSchedule.FundingScheduleId,
+				"fundingScheduleId":     fundingScheduleId,
 				"targetAmount":          1000,
 				"spendingType":          SpendingTypeGoal,
 				"nextRecurrence":        app.Clock.Now().Add(30 * 24 * time.Hour),
@@ -638,8 +657,27 @@ func TestPostSpending(t *testing.T) {
 		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
 		link := fixtures.GivenIHaveAPlaidLink(t, app.Clock, user)
 		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
-		fundingSchedule := fixtures.GivenIHaveAFundingSchedule(t, app.Clock, &bank, FifthteenthAndLastDayOfEveryMonth, false)
 		token := GivenILogin(t, e, user.Login.Email, password)
+
+		var fundingScheduleId ID[FundingSchedule]
+		{ // Create the funding schedule
+			response := e.POST("/api/bank_accounts/{bankAccountId}/funding_schedules").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithCookie(TestCookieName, token).
+				WithJSON(map[string]any{
+					"name":            "Payday",
+					"description":     "15th and the Last day of every month",
+					"ruleset":         FifthteenthAndLastDayOfEveryMonth,
+					"excludeWeekends": true,
+				}).
+				Expect()
+
+			response.Status(http.StatusOK)
+			response.JSON().Path("$.bankAccountId").IsEqual(bank.BankAccountId)
+			response.JSON().Path("$.fundingScheduleId").String().IsASCII()
+			fundingScheduleId = ID[FundingSchedule](response.JSON().Path("$.fundingScheduleId").String().Raw())
+			assert.False(t, fundingScheduleId.IsZero(), "must be able to extract the funding schedule ID")
+		}
 
 		now := app.Clock.Now()
 		ruleset := testutils.Must(t, NewRuleSet, FirstDayOfEveryMonth)
@@ -651,7 +689,7 @@ func TestPostSpending(t *testing.T) {
 			WithJSON(map[string]any{
 				"name":                  "Some Monthly Expense",
 				"ruleset":               FirstDayOfEveryMonth,
-				"fundingScheduleId":     fundingSchedule.FundingScheduleId,
+				"fundingScheduleId":     fundingScheduleId,
 				"targetAmount":          1000,
 				"spendingType":          SpendingTypeExpense,
 				"nextRecurrence":        nextRecurrence,
@@ -668,8 +706,27 @@ func TestPostSpending(t *testing.T) {
 		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
 		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
 		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
-		fundingSchedule := fixtures.GivenIHaveAFundingSchedule(t, app.Clock, &bank, FifthteenthAndLastDayOfEveryMonth, false)
 		token := GivenILogin(t, e, user.Login.Email, password)
+
+		var fundingScheduleId ID[FundingSchedule]
+		{ // Create the funding schedule
+			response := e.POST("/api/bank_accounts/{bankAccountId}/funding_schedules").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithCookie(TestCookieName, token).
+				WithJSON(map[string]any{
+					"name":            "Payday",
+					"description":     "15th and the Last day of every month",
+					"ruleset":         FifthteenthAndLastDayOfEveryMonth,
+					"excludeWeekends": true,
+				}).
+				Expect()
+
+			response.Status(http.StatusOK)
+			response.JSON().Path("$.bankAccountId").IsEqual(bank.BankAccountId)
+			response.JSON().Path("$.fundingScheduleId").String().IsASCII()
+			fundingScheduleId = ID[FundingSchedule](response.JSON().Path("$.fundingScheduleId").String().Raw())
+			assert.False(t, fundingScheduleId.IsZero(), "must be able to extract the funding schedule ID")
+		}
 
 		now := app.Clock.Now()
 		ruleset := testutils.Must(t, NewRuleSet, FirstDayOfEveryMonth)
@@ -681,7 +738,7 @@ func TestPostSpending(t *testing.T) {
 			WithJSON(map[string]any{
 				"name":                  "Some Monthly Expense",
 				"ruleset":               FirstDayOfEveryMonth,
-				"fundingScheduleId":     fundingSchedule.FundingScheduleId,
+				"fundingScheduleId":     fundingScheduleId,
 				"targetAmount":          1000,
 				"spendingType":          SpendingTypeExpense,
 				"nextRecurrence":        nextRecurrence,
@@ -2009,8 +2066,25 @@ func TestPutSpending(t *testing.T) {
 		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
 		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
 		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
-		fundingSchedule := fixtures.GivenIHaveAFundingSchedule(t, app.Clock, &bank, FifthteenthAndLastDayOfEveryMonth, false)
 		token := GivenILogin(t, e, user.Login.Email, password)
+
+		var fundingScheduleId ID[FundingSchedule]
+		{ // Create the funding schedule
+			response := e.POST("/api/bank_accounts/{bankAccountId}/funding_schedules").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithCookie(TestCookieName, token).
+				WithJSON(map[string]any{
+					"name":            "Payday",
+					"description":     "15th and the Last day of every month",
+					"ruleset":         FifthteenthAndLastDayOfEveryMonth,
+					"excludeWeekends": true,
+				}).
+				Expect()
+
+			response.Status(http.StatusOK)
+			fundingScheduleId = ID[FundingSchedule](response.JSON().Path("$.fundingScheduleId").String().Raw())
+			assert.False(t, fundingScheduleId.IsZero(), "must be able to extract the funding schedule ID")
+		}
 
 		nextRecurrence := app.Clock.Now().Add(30 * 24 * time.Hour)
 
@@ -2021,7 +2095,7 @@ func TestPutSpending(t *testing.T) {
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
 					"name":              "Vacation Savings",
-					"fundingScheduleId": fundingSchedule.FundingScheduleId,
+					"fundingScheduleId": fundingScheduleId,
 					"targetAmount":      1000,
 					"spendingType":      SpendingTypeGoal,
 					"nextRecurrence":    nextRecurrence,
@@ -2040,7 +2114,7 @@ func TestPutSpending(t *testing.T) {
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
 					"name":                  "Vacation Savings",
-					"fundingScheduleId":     fundingSchedule.FundingScheduleId,
+					"fundingScheduleId":     fundingScheduleId,
 					"targetAmount":          1000,
 					"spendingType":          SpendingTypeGoal,
 					"nextRecurrence":        nextRecurrence,
@@ -2058,8 +2132,25 @@ func TestPutSpending(t *testing.T) {
 		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
 		link := fixtures.GivenIHaveAPlaidLink(t, app.Clock, user)
 		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
-		fundingSchedule := fixtures.GivenIHaveAFundingSchedule(t, app.Clock, &bank, FifthteenthAndLastDayOfEveryMonth, false)
 		token := GivenILogin(t, e, user.Login.Email, password)
+
+		var fundingScheduleId ID[FundingSchedule]
+		{ // Create the funding schedule
+			response := e.POST("/api/bank_accounts/{bankAccountId}/funding_schedules").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithCookie(TestCookieName, token).
+				WithJSON(map[string]any{
+					"name":            "Payday",
+					"description":     "15th and the Last day of every month",
+					"ruleset":         FifthteenthAndLastDayOfEveryMonth,
+					"excludeWeekends": true,
+				}).
+				Expect()
+
+			response.Status(http.StatusOK)
+			fundingScheduleId = ID[FundingSchedule](response.JSON().Path("$.fundingScheduleId").String().Raw())
+			assert.False(t, fundingScheduleId.IsZero(), "must be able to extract the funding schedule ID")
+		}
 
 		now := app.Clock.Now()
 		ruleset := testutils.Must(t, NewRuleSet, FirstDayOfEveryMonth)
@@ -2073,7 +2164,7 @@ func TestPutSpending(t *testing.T) {
 				WithJSON(map[string]any{
 					"name":              "Some Monthly Expense",
 					"ruleset":           FirstDayOfEveryMonth,
-					"fundingScheduleId": fundingSchedule.FundingScheduleId,
+					"fundingScheduleId": fundingScheduleId,
 					"targetAmount":      1000,
 					"spendingType":      SpendingTypeExpense,
 					"nextRecurrence":    nextRecurrence,
@@ -2093,7 +2184,7 @@ func TestPutSpending(t *testing.T) {
 				WithJSON(map[string]any{
 					"name":                  "Some Monthly Expense",
 					"ruleset":               FirstDayOfEveryMonth,
-					"fundingScheduleId":     fundingSchedule.FundingScheduleId,
+					"fundingScheduleId":     fundingScheduleId,
 					"targetAmount":          1000,
 					"spendingType":          SpendingTypeExpense,
 					"nextRecurrence":        nextRecurrence,
@@ -2111,8 +2202,25 @@ func TestPutSpending(t *testing.T) {
 		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
 		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
 		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
-		fundingSchedule := fixtures.GivenIHaveAFundingSchedule(t, app.Clock, &bank, FifthteenthAndLastDayOfEveryMonth, false)
 		token := GivenILogin(t, e, user.Login.Email, password)
+
+		var fundingScheduleId ID[FundingSchedule]
+		{ // Create the funding schedule
+			response := e.POST("/api/bank_accounts/{bankAccountId}/funding_schedules").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithCookie(TestCookieName, token).
+				WithJSON(map[string]any{
+					"name":            "Payday",
+					"description":     "15th and the Last day of every month",
+					"ruleset":         FifthteenthAndLastDayOfEveryMonth,
+					"excludeWeekends": true,
+				}).
+				Expect()
+
+			response.Status(http.StatusOK)
+			fundingScheduleId = ID[FundingSchedule](response.JSON().Path("$.fundingScheduleId").String().Raw())
+			assert.False(t, fundingScheduleId.IsZero(), "must be able to extract the funding schedule ID")
+		}
 
 		now := app.Clock.Now()
 		ruleset := testutils.Must(t, NewRuleSet, FirstDayOfEveryMonth)
@@ -2126,7 +2234,7 @@ func TestPutSpending(t *testing.T) {
 				WithJSON(map[string]any{
 					"name":              "Some Monthly Expense",
 					"ruleset":           FirstDayOfEveryMonth,
-					"fundingScheduleId": fundingSchedule.FundingScheduleId,
+					"fundingScheduleId": fundingScheduleId,
 					"targetAmount":      1000,
 					"spendingType":      SpendingTypeExpense,
 					"nextRecurrence":    nextRecurrence,
@@ -2147,7 +2255,7 @@ func TestPutSpending(t *testing.T) {
 				WithJSON(map[string]any{
 					"name":                  "Some Monthly Expense",
 					"ruleset":               FirstDayOfEveryMonth,
-					"fundingScheduleId":     fundingSchedule.FundingScheduleId,
+					"fundingScheduleId":     fundingScheduleId,
 					"targetAmount":          1000,
 					"spendingType":          SpendingTypeExpense,
 					"nextRecurrence":        nextRecurrence,
@@ -2167,7 +2275,7 @@ func TestPutSpending(t *testing.T) {
 				WithJSON(map[string]any{
 					"name":                  "Some Monthly Expense",
 					"ruleset":               FirstDayOfEveryMonth,
-					"fundingScheduleId":     fundingSchedule.FundingScheduleId,
+					"fundingScheduleId":     fundingScheduleId,
 					"targetAmount":          1000,
 					"spendingType":          SpendingTypeExpense,
 					"nextRecurrence":        nextRecurrence,

--- a/server/funding/funding_jobs/process_funding_schedules.go
+++ b/server/funding/funding_jobs/process_funding_schedules.go
@@ -104,7 +104,18 @@ func ProcessFundingSchedule(ctx queue.Context, args ProcessFundingScheduleArgume
 			return err
 		}
 
+		// Only manual links can have transactions auto-created on their behalf;
+		// Plaid links and others already receive real transactions from the
+		// institution.
+		isManual, err := repo.GetLinkIsManualByBankAccountId(ctx, args.BankAccountId)
+		if err != nil {
+			log.ErrorContext(ctx, "failed to determine if link is manual", "err", err)
+			return err
+		}
+
 		expensesToUpdate := make([]models.Spending, 0)
+		transactionsToCreate := make([]models.Transaction, 0)
+		var bankAccount *models.BankAccount
 
 		initialBalances, err := repo.GetBalances(ctx, args.BankAccountId)
 		if err != nil {
@@ -148,6 +159,9 @@ func ProcessFundingSchedule(ctx queue.Context, args ProcessFundingScheduleArgume
 				}
 			}
 
+			// Capture the funding date before CalculateNextOccurrence bumps the
+			// recurrence forward; this is the date the funding schedule fired.
+			fundingDate := fundingSchedule.NextRecurrence
 			if !fundingSchedule.CalculateNextOccurrence(ctx, ctx.Clock().Now(), timezone) {
 				crumbs.IndicateBug(ctx, "bug: funding schedule for processing occurs in the future", map[string]any{
 					"nextOccurrence": fundingSchedule.NextRecurrence,
@@ -164,9 +178,54 @@ func ProcessFundingSchedule(ctx queue.Context, args ProcessFundingScheduleArgume
 				return err
 			}
 
-			expenses, err := repo.GetSpendingByFundingSchedule(ctx, args.BankAccountId, fundingScheduleId)
+			// If this funding schedule has auto create transaction enabled, create a
+			// deposit transaction for its estimated deposit amount.
+			if isManual &&
+				fundingSchedule.AutoCreateTransaction &&
+				fundingSchedule.EstimatedDeposit != nil &&
+				*fundingSchedule.EstimatedDeposit > 0 {
+				if bankAccount == nil {
+					bankAccount, err = repo.GetBankAccount(ctx, args.BankAccountId)
+					if err != nil {
+						fundingLog.ErrorContext(
+							ctx,
+							"failed to retrieve bank account for auto created deposit",
+							"err", err,
+						)
+						return err
+					}
+				}
+
+				txn := models.Transaction{
+					BankAccountId: args.BankAccountId,
+					// Credits are stored as negative values in monetr.
+					Amount:       -*fundingSchedule.EstimatedDeposit,
+					Date:         fundingDate,
+					Name:         fundingSchedule.Name,
+					OriginalName: fundingSchedule.Name,
+					IsPending:    false,
+					Source:       models.TransactionSourceManual,
+				}
+
+				// Always subtract from our available balance. Subtract because credits
+				// are represented as negative values in monetr.
+				bankAccount.AvailableBalance -= txn.Amount
+				bankAccount.CurrentBalance -= txn.Amount
+
+				transactionsToCreate = append(transactionsToCreate, txn)
+			}
+
+			expenses, err := repo.GetSpendingByFundingSchedule(
+				ctx,
+				args.BankAccountId,
+				fundingScheduleId,
+			)
 			if err != nil {
-				fundingLog.ErrorContext(ctx, "failed to retrieve expenses for processing", "err", err)
+				fundingLog.ErrorContext(
+					ctx,
+					"failed to retrieve expenses for processing",
+					"err", err,
+				)
 				return err
 			}
 
@@ -237,21 +296,35 @@ func ProcessFundingSchedule(ctx queue.Context, args ProcessFundingScheduleArgume
 			}
 		}
 
-		if len(expensesToUpdate) == 0 {
+		if len(expensesToUpdate) == 0 && len(transactionsToCreate) == 0 {
 			crumbs.Debug(ctx, "No spending objects to update for funding schedule", nil)
 			log.InfoContext(ctx, "no spending objects to update for funding schedule")
 			return nil
 		}
 
-		log.DebugContext(ctx, fmt.Sprintf("preparing to update %d spending(s)", len(expensesToUpdate)))
+		if len(expensesToUpdate) > 0 {
+			log.DebugContext(ctx, fmt.Sprintf("preparing to update %d spending(s)", len(expensesToUpdate)))
 
-		crumbs.Debug(ctx, "Updating spending objects with recalculated contributions", map[string]any{
-			"count": len(expensesToUpdate),
-		})
+			crumbs.Debug(ctx, "Updating spending objects with recalculated contributions", map[string]any{
+				"count": len(expensesToUpdate),
+			})
 
-		if err = repo.UpdateSpending(ctx, args.BankAccountId, expensesToUpdate); err != nil {
-			log.ErrorContext(ctx, "failed to update spending", "err", err)
-			return err
+			if err = repo.UpdateSpending(ctx, args.BankAccountId, expensesToUpdate); err != nil {
+				log.ErrorContext(ctx, "failed to update spending", "err", err)
+				return err
+			}
+		}
+
+		if bankAccount != nil {
+			if err = repo.UpdateBankAccount(ctx, bankAccount); err != nil {
+				return errors.Wrap(err, "failed to update bank account for auto created deposits")
+			}
+		}
+
+		for i := range transactionsToCreate {
+			if err = repo.CreateTransaction(ctx, args.BankAccountId, &transactionsToCreate[i]); err != nil {
+				return errors.Wrap(err, "failed to create auto created deposit transaction")
+			}
 		}
 
 		updatedBalances, err := repo.GetBalances(ctx, args.BankAccountId)

--- a/server/funding/funding_jobs/process_funding_schedules.go
+++ b/server/funding/funding_jobs/process_funding_schedules.go
@@ -199,12 +199,13 @@ func ProcessFundingSchedule(ctx queue.Context, args ProcessFundingScheduleArgume
 				txn := models.Transaction{
 					BankAccountId: args.BankAccountId,
 					// Credits are stored as negative values in monetr.
-					Amount:       -*fundingSchedule.EstimatedDeposit,
-					Date:         fundingDate,
-					Name:         fundingSchedule.Name,
-					OriginalName: fundingSchedule.Name,
-					IsPending:    false,
-					Source:       models.TransactionSourceManual,
+					Amount:                     -*fundingSchedule.EstimatedDeposit,
+					Date:                       fundingDate,
+					Name:                       fundingSchedule.Name,
+					OriginalName:               fundingSchedule.Name,
+					IsPending:                  false,
+					Source:                     models.TransactionSourceManual,
+					CreatedByFundingScheduleId: &fundingSchedule.FundingScheduleId,
 				}
 
 				// Always subtract from our available balance. Subtract because credits

--- a/server/funding/funding_jobs/process_funding_schedules_test.go
+++ b/server/funding/funding_jobs/process_funding_schedules_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/monetr/monetr/server/internal/mockqueue"
 	"github.com/monetr/monetr/server/internal/testutils"
 	"github.com/monetr/monetr/server/models"
+	"github.com/monetr/monetr/server/repository"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -760,5 +761,297 @@ func TestProcessFundingSchedule(t *testing.T) {
 		updatedFundingSchedule2 := testutils.MustRetrieve(t, fundingSchedule2)
 		assert.Greater(t, updatedFundingSchedule2.NextRecurrence, fundingSchedule2.NextRecurrence,
 			"second funding schedule next recurrence should have been advanced")
+	})
+
+	t.Run("auto creates deposit transaction on manual link", func(t *testing.T) {
+		clock := clock.NewMock()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		log := testutils.GetLog(t)
+		db := testutils.GetPgDatabase(t)
+
+		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
+		link := fixtures.GivenIHaveAManualLink(t, clock, user)
+		bankAccount := fixtures.GivenIHaveABankAccount(
+			t,
+			clock,
+			&link,
+			models.DepositoryBankAccountType,
+			models.CheckingBankAccountSubType,
+		)
+
+		timezone := testutils.MustEz(t, user.Account.GetTimezone)
+		fundingRule := testutils.RuleToSet(t, timezone, "FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15,-1", clock.Now())
+		estimatedDeposit := int64(100000)
+		expectedFundingDate := fundingRule.After(clock.Now(), false)
+		fundingSchedule := testutils.MustInsert(t, models.FundingSchedule{
+			AccountId:              bankAccount.AccountId,
+			BankAccountId:          bankAccount.BankAccountId,
+			Name:                   "Payday",
+			Description:            "Payday",
+			RuleSet:                fundingRule,
+			NextRecurrence:         expectedFundingDate,
+			NextRecurrenceOriginal: expectedFundingDate,
+			EstimatedDeposit:       &estimatedDeposit,
+			AutoCreateTransaction:  true,
+		})
+
+		// Move time forward past the funding schedule's next recurrence.
+		clock.Add(32 * 24 * time.Hour)
+
+		{
+			context := mockgen.NewMockContext(ctrl)
+			context.EXPECT().Clock().Return(clock).AnyTimes()
+			context.EXPECT().DB().Return(db).AnyTimes()
+			context.EXPECT().Log().Return(log).AnyTimes()
+			context.EXPECT().RunInTransaction(gomock.Any(), gomock.Any()).Times(1)
+
+			err := funding_jobs.ProcessFundingSchedule(
+				mockqueue.NewMockContext(context),
+				funding_jobs.ProcessFundingScheduleArguments{
+					AccountId:          bankAccount.AccountId,
+					BankAccountId:      bankAccount.BankAccountId,
+					FundingScheduleIds: []models.ID[models.FundingSchedule]{fundingSchedule.FundingScheduleId},
+				},
+			)
+			assert.NoError(t, err, "should process funding schedule successfully")
+		}
+
+		// Verify the bank account balance was incremented by the deposit.
+		updatedBankAccount := testutils.MustRetrieve(t, bankAccount)
+		assert.EqualValues(t, bankAccount.AvailableBalance+estimatedDeposit, updatedBankAccount.AvailableBalance,
+			"available balance should have been incremented by the deposit")
+		assert.EqualValues(t, bankAccount.CurrentBalance+estimatedDeposit, updatedBankAccount.CurrentBalance,
+			"current balance should have been incremented by the deposit")
+
+		// Verify a deposit transaction was created.
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
+		transactions, err := repo.GetTransactions(t.Context(), bankAccount.BankAccountId, 100, 0)
+		assert.NoError(t, err, "should retrieve transactions")
+		assert.Len(t, transactions, 1, "exactly one deposit transaction should have been created")
+		assert.EqualValues(t, -estimatedDeposit, transactions[0].Amount, "deposit amount should be negative")
+		assert.Equal(t, models.TransactionSourceManual, transactions[0].Source, "transaction source should be manual")
+		assert.Equal(t, fundingSchedule.Name, transactions[0].Name, "transaction name should match the funding schedule name")
+		assert.Nil(t, transactions[0].SpendingId, "deposit should not be allocated to a spending")
+		assert.True(t, transactions[0].Date.Equal(expectedFundingDate), "transaction date should match the funding date")
+	})
+
+	t.Run("does not auto create deposit on non-manual link", func(t *testing.T) {
+		clock := clock.NewMock()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		log := testutils.GetLog(t)
+		db := testutils.GetPgDatabase(t)
+
+		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
+		link := fixtures.GivenIHaveAPlaidLink(t, clock, user)
+		bankAccount := fixtures.GivenIHaveABankAccount(
+			t,
+			clock,
+			&link,
+			models.DepositoryBankAccountType,
+			models.CheckingBankAccountSubType,
+		)
+
+		timezone := testutils.MustEz(t, user.Account.GetTimezone)
+		fundingRule := testutils.RuleToSet(t, timezone, "FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15,-1", clock.Now())
+		estimatedDeposit := int64(100000)
+		fundingSchedule := testutils.MustInsert(t, models.FundingSchedule{
+			AccountId:              bankAccount.AccountId,
+			BankAccountId:          bankAccount.BankAccountId,
+			Name:                   "Payday",
+			Description:            "Payday",
+			RuleSet:                fundingRule,
+			NextRecurrence:         fundingRule.After(clock.Now(), false),
+			NextRecurrenceOriginal: fundingRule.After(clock.Now(), false),
+			EstimatedDeposit:       &estimatedDeposit,
+			AutoCreateTransaction:  true,
+		})
+
+		clock.Add(32 * 24 * time.Hour)
+
+		{
+			context := mockgen.NewMockContext(ctrl)
+			context.EXPECT().Clock().Return(clock).AnyTimes()
+			context.EXPECT().DB().Return(db).AnyTimes()
+			context.EXPECT().Log().Return(log).AnyTimes()
+			context.EXPECT().RunInTransaction(gomock.Any(), gomock.Any()).Times(1)
+
+			err := funding_jobs.ProcessFundingSchedule(
+				mockqueue.NewMockContext(context),
+				funding_jobs.ProcessFundingScheduleArguments{
+					AccountId:          bankAccount.AccountId,
+					BankAccountId:      bankAccount.BankAccountId,
+					FundingScheduleIds: []models.ID[models.FundingSchedule]{fundingSchedule.FundingScheduleId},
+				},
+			)
+			assert.NoError(t, err, "should process funding schedule successfully")
+		}
+
+		// Verify the bank account balance did not change on a non-manual link.
+		updatedBankAccount := testutils.MustRetrieve(t, bankAccount)
+		assert.EqualValues(t, bankAccount.AvailableBalance, updatedBankAccount.AvailableBalance, "available balance should not change")
+		assert.EqualValues(t, bankAccount.CurrentBalance, updatedBankAccount.CurrentBalance, "current balance should not change")
+
+		// Verify no transactions were created.
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
+		transactions, err := repo.GetTransactions(t.Context(), bankAccount.BankAccountId, 100, 0)
+		assert.NoError(t, err, "should retrieve transactions")
+		assert.Empty(t, transactions, "no transactions should have been created on a non-manual link")
+	})
+
+	t.Run("does not auto create deposit when estimated deposit is nil", func(t *testing.T) {
+		clock := clock.NewMock()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		log := testutils.GetLog(t)
+		db := testutils.GetPgDatabase(t)
+
+		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
+		link := fixtures.GivenIHaveAManualLink(t, clock, user)
+		bankAccount := fixtures.GivenIHaveABankAccount(
+			t,
+			clock,
+			&link,
+			models.DepositoryBankAccountType,
+			models.CheckingBankAccountSubType,
+		)
+
+		timezone := testutils.MustEz(t, user.Account.GetTimezone)
+		fundingRule := testutils.RuleToSet(t, timezone, "FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15,-1", clock.Now())
+		fundingSchedule := testutils.MustInsert(t, models.FundingSchedule{
+			AccountId:              bankAccount.AccountId,
+			BankAccountId:          bankAccount.BankAccountId,
+			Name:                   "Payday",
+			Description:            "Payday",
+			RuleSet:                fundingRule,
+			NextRecurrence:         fundingRule.After(clock.Now(), false),
+			NextRecurrenceOriginal: fundingRule.After(clock.Now(), false),
+			EstimatedDeposit:       nil,
+			AutoCreateTransaction:  true,
+		})
+
+		clock.Add(32 * 24 * time.Hour)
+
+		{
+			context := mockgen.NewMockContext(ctrl)
+			context.EXPECT().Clock().Return(clock).AnyTimes()
+			context.EXPECT().DB().Return(db).AnyTimes()
+			context.EXPECT().Log().Return(log).AnyTimes()
+			context.EXPECT().RunInTransaction(gomock.Any(), gomock.Any()).Times(1)
+
+			err := funding_jobs.ProcessFundingSchedule(
+				mockqueue.NewMockContext(context),
+				funding_jobs.ProcessFundingScheduleArguments{
+					AccountId:          bankAccount.AccountId,
+					BankAccountId:      bankAccount.BankAccountId,
+					FundingScheduleIds: []models.ID[models.FundingSchedule]{fundingSchedule.FundingScheduleId},
+				},
+			)
+			assert.NoError(t, err, "should process funding schedule successfully")
+		}
+
+		// Verify the bank account balance did not change without an estimated deposit.
+		updatedBankAccount := testutils.MustRetrieve(t, bankAccount)
+		assert.EqualValues(t, bankAccount.AvailableBalance, updatedBankAccount.AvailableBalance, "available balance should not change")
+		assert.EqualValues(t, bankAccount.CurrentBalance, updatedBankAccount.CurrentBalance, "current balance should not change")
+
+		// Verify no transactions were created.
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
+		transactions, err := repo.GetTransactions(t.Context(), bankAccount.BankAccountId, 100, 0)
+		assert.NoError(t, err, "should retrieve transactions")
+		assert.Empty(t, transactions, "no transactions should have been created without an estimated deposit")
+	})
+
+	t.Run("does not auto create deposit when flag is off", func(t *testing.T) {
+		clock := clock.NewMock()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		log := testutils.GetLog(t)
+		db := testutils.GetPgDatabase(t)
+
+		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
+		link := fixtures.GivenIHaveAManualLink(t, clock, user)
+		bankAccount := fixtures.GivenIHaveABankAccount(
+			t,
+			clock,
+			&link,
+			models.DepositoryBankAccountType,
+			models.CheckingBankAccountSubType,
+		)
+
+		timezone := testutils.MustEz(t, user.Account.GetTimezone)
+		fundingRule := testutils.RuleToSet(t, timezone, "FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15,-1", clock.Now())
+		estimatedDeposit := int64(100000)
+		fundingSchedule := testutils.MustInsert(t, models.FundingSchedule{
+			AccountId:              bankAccount.AccountId,
+			BankAccountId:          bankAccount.BankAccountId,
+			Name:                   "Payday",
+			Description:            "Payday",
+			RuleSet:                fundingRule,
+			NextRecurrence:         fundingRule.After(clock.Now(), false),
+			NextRecurrenceOriginal: fundingRule.After(clock.Now(), false),
+			EstimatedDeposit:       &estimatedDeposit,
+			AutoCreateTransaction:  false,
+		})
+
+		clock.Add(32 * 24 * time.Hour)
+
+		{
+			context := mockgen.NewMockContext(ctrl)
+			context.EXPECT().Clock().Return(clock).AnyTimes()
+			context.EXPECT().DB().Return(db).AnyTimes()
+			context.EXPECT().Log().Return(log).AnyTimes()
+			context.EXPECT().RunInTransaction(gomock.Any(), gomock.Any()).Times(1)
+
+			err := funding_jobs.ProcessFundingSchedule(
+				mockqueue.NewMockContext(context),
+				funding_jobs.ProcessFundingScheduleArguments{
+					AccountId:          bankAccount.AccountId,
+					BankAccountId:      bankAccount.BankAccountId,
+					FundingScheduleIds: []models.ID[models.FundingSchedule]{fundingSchedule.FundingScheduleId},
+				},
+			)
+			assert.NoError(t, err, "should process funding schedule successfully")
+		}
+
+		// Verify the bank account balance did not change when the flag is off.
+		updatedBankAccount := testutils.MustRetrieve(t, bankAccount)
+		assert.EqualValues(t, bankAccount.AvailableBalance, updatedBankAccount.AvailableBalance, "available balance should not change")
+		assert.EqualValues(t, bankAccount.CurrentBalance, updatedBankAccount.CurrentBalance, "current balance should not change")
+
+		// Verify no transactions were created.
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
+		transactions, err := repo.GetTransactions(t.Context(), bankAccount.BankAccountId, 100, 0)
+		assert.NoError(t, err, "should retrieve transactions")
+		assert.Empty(t, transactions, "no transactions should have been created when the flag is off")
 	})
 }

--- a/server/migrations/schema/2026041900_AutoCreateTransactions.tx.up.sql
+++ b/server/migrations/schema/2026041900_AutoCreateTransactions.tx.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "spending" ADD COLUMN "auto_create_transaction" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "funding_schedules" ADD COLUMN "auto_create_transaction" BOOLEAN NOT NULL DEFAULT false;

--- a/server/migrations/schema/2026041900_AutoCreateTransactions.tx.up.sql
+++ b/server/migrations/schema/2026041900_AutoCreateTransactions.tx.up.sql
@@ -1,2 +1,13 @@
 ALTER TABLE "spending" ADD COLUMN "auto_create_transaction" BOOLEAN NOT NULL DEFAULT false;
 ALTER TABLE "funding_schedules" ADD COLUMN "auto_create_transaction" BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE "transactions" ADD COLUMN "created_by_spending_id" VARCHAR(32);
+ALTER TABLE "transactions" ADD COLUMN "created_by_funding_schedule_id" VARCHAR(32);
+
+ALTER TABLE "transactions" ADD CONSTRAINT "fk_transactions_created_by_spending"
+  FOREIGN KEY ("created_by_spending_id", "account_id", "bank_account_id") REFERENCES "spending" ("spending_id", "account_id", "bank_account_id")
+  ON DELETE SET NULL;
+
+ALTER TABLE "transactions" ADD CONSTRAINT "fk_transactions_created_by_funding_schedule"
+  FOREIGN KEY ("created_by_funding_schedule_id", "account_id", "bank_account_id") REFERENCES "funding_schedules" ("funding_schedule_id", "account_id", "bank_account_id")
+  ON DELETE SET NULL;

--- a/server/models/funding_schedule.go
+++ b/server/models/funding_schedule.go
@@ -29,6 +29,7 @@ type FundingSchedule struct {
 	RuleSet                *RuleSet            `json:"ruleset" pg:"ruleset,notnull,type:'text'"`
 	ExcludeWeekends        bool                `json:"excludeWeekends" pg:"exclude_weekends,notnull,use_zero"`
 	WaitForDeposit         bool                `json:"waitForDeposit" pg:"wait_for_deposit,notnull,use_zero"`
+	AutoCreateTransaction  bool                `json:"autoCreateTransaction" pg:"auto_create_transaction,notnull,use_zero"`
 	EstimatedDeposit       *int64              `json:"estimatedDeposit" pg:"estimated_deposit"`
 	LastRecurrence         *time.Time          `json:"lastRecurrence" pg:"last_recurrence"`
 	NextRecurrence         time.Time           `json:"nextRecurrence" pg:"next_recurrence,notnull"`

--- a/server/models/funding_schedule.go
+++ b/server/models/funding_schedule.go
@@ -213,6 +213,10 @@ func (FundingSchedule) CreateValidators() []*validation.KeyRules {
 			validation.In(true, false).Error("Exclude weekends must be a valid boolean"),
 		).Required(validators.Optional),
 		validation.Key(
+			"autoCreateTransaction",
+			validation.In(true, false).Error("Auto create transaction must be a valid boolean"),
+		).Required(validators.Optional),
+		validation.Key(
 			"estimatedDeposit",
 			validation.Min(float64(0)).Error("Estimated deposit cannot be less than 0"),
 		).Required(validators.Optional),
@@ -237,6 +241,10 @@ func (FundingSchedule) UpdateValidators() []*validation.KeyRules {
 		validation.Key(
 			"excludeWeekends",
 			validation.In(true, false).Error("Exclude weekends must be a valid boolean"),
+		).Required(validators.Optional),
+		validation.Key(
+			"autoCreateTransaction",
+			validation.In(true, false).Error("Auto create transaction must be a valid boolean"),
 		).Required(validators.Optional),
 		validation.Key(
 			"estimatedDeposit",

--- a/server/models/spending.go
+++ b/server/models/spending.go
@@ -42,6 +42,7 @@ type Spending struct {
 	NextContributionAmount int64               `json:"nextContributionAmount" pg:"next_contribution_amount,notnull,use_zero"`
 	IsBehind               bool                `json:"isBehind" pg:"is_behind,notnull,use_zero"`
 	IsPaused               bool                `json:"isPaused" pg:"is_paused,notnull,use_zero"`
+	AutoCreateTransaction  bool                `json:"autoCreateTransaction" pg:"auto_create_transaction,notnull,use_zero"`
 	CreatedAt              time.Time           `json:"createdAt" pg:"created_at,notnull"`
 }
 

--- a/server/models/transaction.go
+++ b/server/models/transaction.go
@@ -43,6 +43,19 @@ type Transaction struct {
 	// currently has allocated. If the transaction were to be deleted or changed
 	// we want to make sure we return the correct amount to the expense.
 	SpendingAmount       *int64            `json:"spendingAmount,omitempty" pg:"spending_amount,use_zero"`
+	// CreatedBySpendingId is set when the transaction was auto-created by the
+	// ProcessSpending job for an expense with AutoCreateTransaction enabled. It
+	// points at the spending that caused the transaction to be created and is
+	// not user-mutable. This is distinct from SpendingId, which may be changed
+	// by the user to re-allocate a transaction.
+	CreatedBySpendingId        *ID[Spending]        `json:"createdBySpendingId" pg:"created_by_spending_id,on_delete:SET NULL"`
+	CreatedBySpending          *Spending            `json:"-" pg:"rel:has-one,fk:created_by_"`
+	// CreatedByFundingScheduleId is set when the transaction was auto-created
+	// by the ProcessFundingSchedule job for a funding schedule with
+	// AutoCreateTransaction enabled. It points at the funding schedule that
+	// caused the transaction to be created and is not user-mutable.
+	CreatedByFundingScheduleId *ID[FundingSchedule] `json:"createdByFundingScheduleId" pg:"created_by_funding_schedule_id,on_delete:SET NULL"`
+	CreatedByFundingSchedule   *FundingSchedule     `json:"-" pg:"rel:has-one,fk:created_by_"`
 	Categories           []string          `json:"categories" pg:"categories,type:'text[]'"`
 	Category             *string           `json:"category" pg:"category"`
 	Date                 time.Time         `json:"date" pg:"date,notnull"`

--- a/server/spending/spending_jobs/process_spending.go
+++ b/server/spending/spending_jobs/process_spending.go
@@ -95,6 +95,14 @@ func ProcessSpending(ctx queue.Context, args ProcessSpendingArguments) error {
 			return err
 		}
 
+		// Only manual links can have transactions auto-created on their behalf;
+		// Plaid links already receive real transactions from the institution.
+		isManual, err := repo.GetLinkIsManualByBankAccountId(ctx, args.BankAccountId)
+		if err != nil {
+			log.ErrorContext(ctx, "failed to determine if link is manual", "err", err)
+			return err
+		}
+
 		now := ctx.Clock().Now()
 		allSpending, err := repo.GetSpending(ctx, args.BankAccountId)
 		if err != nil {
@@ -105,6 +113,8 @@ func ProcessSpending(ctx queue.Context, args ProcessSpendingArguments) error {
 		fundingSchedules := map[models.ID[models.FundingSchedule]]*models.FundingSchedule{}
 
 		spendingToUpdate := make([]models.Spending, 0, len(allSpending))
+		transactionsToCreate := make([]models.Transaction, 0)
+		var bankAccount *models.BankAccount
 		for i := range allSpending {
 			// Avoid funky pointer issues with arrays and for loops.
 			spending := allSpending[i]
@@ -129,6 +139,9 @@ func ProcessSpending(ctx queue.Context, args ProcessSpendingArguments) error {
 				fundingSchedules[spending.FundingScheduleId] = fundingSchedule
 			}
 
+			// Capture the due date before CalculateNextContribution bumps the
+			// recurrence forward; this is the date the expense was due.
+			dueDate := spending.NextRecurrence
 			spending.CalculateNextContribution(
 				ctx,
 				timezone,
@@ -136,6 +149,57 @@ func ProcessSpending(ctx queue.Context, args ProcessSpendingArguments) error {
 				now,
 				log,
 			)
+
+			// If this expense has auto create transaction enabled, create a
+			// transaction for the just-passed due date and allocate it from the
+			// expense. Goals are excluded by design.
+			if isManual &&
+				spending.SpendingType == models.SpendingTypeExpense &&
+				spending.AutoCreateTransaction &&
+				spending.TargetAmount > 0 {
+				if bankAccount == nil {
+					bankAccount, err = repo.GetBankAccount(ctx, args.BankAccountId)
+					if err != nil {
+						log.ErrorContext(
+							ctx,
+							"failed to retrieve bank account for auto created transaction",
+							"err", err,
+						)
+						return err
+					}
+				}
+
+				txn := models.Transaction{
+					BankAccountId: spending.BankAccountId,
+					Amount:        spending.TargetAmount,
+					Date:          dueDate,
+					Name:          spending.Name,
+					OriginalName:  spending.Name,
+					IsPending:     false,
+					Source:        models.TransactionSourceManual,
+					SpendingId:    &spending.SpendingId,
+				}
+
+				// AddExpenseToTransaction recalculates the contribution using
+				// spending.FundingSchedule, so make sure that relation is set.
+				spending.FundingSchedule = fundingSchedule
+
+				if err = repo.AddExpenseToTransaction(ctx, &txn, &spending); err != nil {
+					log.ErrorContext(
+						ctx,
+						"failed to add expense to auto created transaction",
+						"err", err,
+					)
+					return err
+				}
+
+				// Always subtract from our available balance. Subtract because credits
+				// are represented as negative values in monetr.
+				bankAccount.AvailableBalance -= txn.Amount
+				bankAccount.CurrentBalance -= txn.Amount
+
+				transactionsToCreate = append(transactionsToCreate, txn)
+			}
 
 			spendingToUpdate = append(spendingToUpdate, spending)
 		}
@@ -147,10 +211,26 @@ func ProcessSpending(ctx queue.Context, args ProcessSpendingArguments) error {
 
 		log.InfoContext(ctx, "updating stale spending objects", "count", len(spendingToUpdate))
 
-		return errors.Wrap(repo.UpdateSpending(
+		if err = repo.UpdateSpending(
 			ctx,
 			args.BankAccountId,
 			spendingToUpdate,
-		), "failed to update stale spending")
+		); err != nil {
+			return errors.Wrap(err, "failed to update stale spending")
+		}
+
+		if bankAccount != nil {
+			if err = repo.UpdateBankAccount(ctx, bankAccount); err != nil {
+				return errors.Wrap(err, "failed to update bank account for auto created transactions")
+			}
+		}
+
+		for i := range transactionsToCreate {
+			if err = repo.CreateTransaction(ctx, args.BankAccountId, &transactionsToCreate[i]); err != nil {
+				return errors.Wrap(err, "failed to create auto created transaction")
+			}
+		}
+
+		return nil
 	})
 }

--- a/server/spending/spending_jobs/process_spending.go
+++ b/server/spending/spending_jobs/process_spending.go
@@ -170,14 +170,15 @@ func ProcessSpending(ctx queue.Context, args ProcessSpendingArguments) error {
 				}
 
 				txn := models.Transaction{
-					BankAccountId: spending.BankAccountId,
-					Amount:        spending.TargetAmount,
-					Date:          dueDate,
-					Name:          spending.Name,
-					OriginalName:  spending.Name,
-					IsPending:     false,
-					Source:        models.TransactionSourceManual,
-					SpendingId:    &spending.SpendingId,
+					BankAccountId:       spending.BankAccountId,
+					Amount:              spending.TargetAmount,
+					Date:                dueDate,
+					Name:                spending.Name,
+					OriginalName:        spending.Name,
+					IsPending:           false,
+					Source:              models.TransactionSourceManual,
+					SpendingId:          &spending.SpendingId,
+					CreatedBySpendingId: &spending.SpendingId,
 				}
 
 				// AddExpenseToTransaction recalculates the contribution using

--- a/server/spending/spending_jobs/process_spending_test.go
+++ b/server/spending/spending_jobs/process_spending_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/monetr/monetr/server/internal/mockqueue"
 	"github.com/monetr/monetr/server/internal/testutils"
 	"github.com/monetr/monetr/server/models"
+	"github.com/monetr/monetr/server/repository"
 	"github.com/monetr/monetr/server/spending/spending_jobs"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -79,5 +80,331 @@ func TestProcessSpending(t *testing.T) {
 
 		updatedSpending := testutils.MustRetrieve(t, spending)
 		assert.Greater(t, updatedSpending.NextRecurrence, spending.NextRecurrence, "make sure the next recurrence field was updated")
+	})
+
+	t.Run("auto creates transaction for stale expense on manual link", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		clock := clock.NewMock()
+		log := testutils.GetLog(t)
+		db := testutils.GetPgDatabase(t)
+
+		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
+		link := fixtures.GivenIHaveAManualLink(t, clock, user)
+		bankAccount := fixtures.GivenIHaveABankAccount(t, clock, &link, models.DepositoryBankAccountType, models.CheckingBankAccountSubType)
+		timezone := testutils.MustEz(t, user.Account.GetTimezone)
+
+		fundingRule := testutils.RuleToSet(t, timezone, "FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15,-1", clock.Now())
+		fundingSchedule := testutils.MustInsert(t, models.FundingSchedule{
+			AccountId:              bankAccount.AccountId,
+			BankAccountId:          bankAccount.BankAccountId,
+			Name:                   "Payday",
+			Description:            "Payday",
+			RuleSet:                fundingRule,
+			NextRecurrence:         fundingRule.After(clock.Now(), false),
+			NextRecurrenceOriginal: fundingRule.After(clock.Now(), false),
+		})
+
+		spendingRule := testutils.RuleToSet(t, timezone, "FREQ=WEEKLY;INTERVAL=1;BYDAY=MO", clock.Now())
+		spendingRule.DTStart(clock.Now().Add(-8 * 24 * time.Hour)) // Allow past times.
+		expectedDueDate := spendingRule.Before(clock.Now(), true)
+		spending := testutils.MustInsert(t, models.Spending{
+			AccountId:             bankAccount.AccountId,
+			BankAccountId:         bankAccount.BankAccountId,
+			FundingScheduleId:     fundingSchedule.FundingScheduleId,
+			SpendingType:          models.SpendingTypeExpense,
+			Name:                  "Auto Expense",
+			Description:           "Auto expense",
+			TargetAmount:          5000,
+			CurrentAmount:         5000,
+			RuleSet:               spendingRule,
+			NextRecurrence:        expectedDueDate, // Make it so it recurs next in the past. (STALE)
+			AutoCreateTransaction: true,
+			CreatedAt:             clock.Now(),
+		})
+
+		{
+			context := mockgen.NewMockContext(ctrl)
+			context.EXPECT().Clock().Return(clock).AnyTimes()
+			context.EXPECT().DB().Return(db).AnyTimes()
+			context.EXPECT().Log().Return(log).AnyTimes()
+			context.EXPECT().RunInTransaction(gomock.Any(), gomock.Any()).Times(1)
+
+			err := spending_jobs.ProcessSpending(
+				mockqueue.NewMockContext(context),
+				spending_jobs.ProcessSpendingArguments{
+					AccountId:     spending.AccountId,
+					BankAccountId: spending.BankAccountId,
+				},
+			)
+			assert.NoError(t, err, "should run job successfully")
+		}
+
+		// Verify the expense was allocated to the new transaction.
+		updatedSpending := testutils.MustRetrieve(t, spending)
+		assert.EqualValues(t, int64(0), updatedSpending.CurrentAmount, "current amount should have been deducted")
+
+		// Verify the bank account balance was decremented by the target amount.
+		updatedBankAccount := testutils.MustRetrieve(t, bankAccount)
+		assert.EqualValues(t, bankAccount.AvailableBalance-5000, updatedBankAccount.AvailableBalance, "available balance should have been decremented")
+		assert.EqualValues(t, bankAccount.CurrentBalance-5000, updatedBankAccount.CurrentBalance, "current balance should have been decremented")
+
+		// Verify a transaction was created for the expense.
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
+		transactions, err := repo.GetTransactions(t.Context(), bankAccount.BankAccountId, 100, 0)
+		assert.NoError(t, err, "should retrieve transactions")
+		assert.Len(t, transactions, 1, "exactly one transaction should have been created")
+		assert.EqualValues(t, int64(5000), transactions[0].Amount, "transaction amount should match the expense target")
+		assert.Equal(t, models.TransactionSourceManual, transactions[0].Source, "transaction source should be manual")
+		assert.Equal(t, spending.Name, transactions[0].Name, "transaction name should match the expense name")
+		assert.NotNil(t, transactions[0].SpendingId, "transaction should be allocated to a spending")
+		assert.Equal(t, spending.SpendingId, *transactions[0].SpendingId, "transaction should be allocated to the auto-create expense")
+		assert.True(t, transactions[0].Date.Equal(expectedDueDate), "transaction date should match the expense due date")
+	})
+
+	t.Run("does not auto create transaction on non-manual link", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		clock := clock.NewMock()
+		log := testutils.GetLog(t)
+		db := testutils.GetPgDatabase(t)
+
+		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
+		link := fixtures.GivenIHaveAPlaidLink(t, clock, user)
+		bankAccount := fixtures.GivenIHaveABankAccount(t, clock, &link, models.DepositoryBankAccountType, models.CheckingBankAccountSubType)
+		timezone := testutils.MustEz(t, user.Account.GetTimezone)
+
+		fundingRule := testutils.RuleToSet(t, timezone, "FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15,-1", clock.Now())
+		fundingSchedule := testutils.MustInsert(t, models.FundingSchedule{
+			AccountId:              bankAccount.AccountId,
+			BankAccountId:          bankAccount.BankAccountId,
+			Name:                   "Payday",
+			Description:            "Payday",
+			RuleSet:                fundingRule,
+			NextRecurrence:         fundingRule.After(clock.Now(), false),
+			NextRecurrenceOriginal: fundingRule.After(clock.Now(), false),
+		})
+
+		spendingRule := testutils.RuleToSet(t, timezone, "FREQ=WEEKLY;INTERVAL=1;BYDAY=MO", clock.Now())
+		spendingRule.DTStart(clock.Now().Add(-8 * 24 * time.Hour))
+		spending := testutils.MustInsert(t, models.Spending{
+			AccountId:             bankAccount.AccountId,
+			BankAccountId:         bankAccount.BankAccountId,
+			FundingScheduleId:     fundingSchedule.FundingScheduleId,
+			SpendingType:          models.SpendingTypeExpense,
+			Name:                  "Plaid Expense",
+			Description:           "Plaid expense",
+			TargetAmount:          5000,
+			CurrentAmount:         5000,
+			RuleSet:               spendingRule,
+			NextRecurrence:        spendingRule.Before(clock.Now(), true),
+			AutoCreateTransaction: true,
+			CreatedAt:             clock.Now(),
+		})
+
+		{
+			context := mockgen.NewMockContext(ctrl)
+			context.EXPECT().Clock().Return(clock).AnyTimes()
+			context.EXPECT().DB().Return(db).AnyTimes()
+			context.EXPECT().Log().Return(log).AnyTimes()
+			context.EXPECT().RunInTransaction(gomock.Any(), gomock.Any()).Times(1)
+
+			err := spending_jobs.ProcessSpending(
+				mockqueue.NewMockContext(context),
+				spending_jobs.ProcessSpendingArguments{
+					AccountId:     spending.AccountId,
+					BankAccountId: spending.BankAccountId,
+				},
+			)
+			assert.NoError(t, err, "should run job successfully")
+		}
+
+		// Verify the expense was not deducted from on a non-manual link.
+		updatedSpending := testutils.MustRetrieve(t, spending)
+		assert.EqualValues(t, int64(5000), updatedSpending.CurrentAmount, "current amount should not change on a non-manual link")
+
+		// Verify the bank account balance did not change.
+		updatedBankAccount := testutils.MustRetrieve(t, bankAccount)
+		assert.EqualValues(t, bankAccount.AvailableBalance, updatedBankAccount.AvailableBalance, "available balance should not change")
+		assert.EqualValues(t, bankAccount.CurrentBalance, updatedBankAccount.CurrentBalance, "current balance should not change")
+
+		// Verify no transactions were created.
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
+		transactions, err := repo.GetTransactions(t.Context(), bankAccount.BankAccountId, 100, 0)
+		assert.NoError(t, err, "should retrieve transactions")
+		assert.Empty(t, transactions, "no transactions should have been created on a non-manual link")
+	})
+
+	t.Run("does not auto create transaction for goal", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		clock := clock.NewMock()
+		log := testutils.GetLog(t)
+		db := testutils.GetPgDatabase(t)
+
+		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
+		link := fixtures.GivenIHaveAManualLink(t, clock, user)
+		bankAccount := fixtures.GivenIHaveABankAccount(t, clock, &link, models.DepositoryBankAccountType, models.CheckingBankAccountSubType)
+		timezone := testutils.MustEz(t, user.Account.GetTimezone)
+
+		fundingRule := testutils.RuleToSet(t, timezone, "FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15,-1", clock.Now())
+		fundingSchedule := testutils.MustInsert(t, models.FundingSchedule{
+			AccountId:              bankAccount.AccountId,
+			BankAccountId:          bankAccount.BankAccountId,
+			Name:                   "Payday",
+			Description:            "Payday",
+			RuleSet:                fundingRule,
+			NextRecurrence:         fundingRule.After(clock.Now(), false),
+			NextRecurrenceOriginal: fundingRule.After(clock.Now(), false),
+		})
+
+		// Goals do not use a recurrence rule, but they have a single NextRecurrence
+		// in the past to make them stale.
+		goal := testutils.MustInsert(t, models.Spending{
+			AccountId:             bankAccount.AccountId,
+			BankAccountId:         bankAccount.BankAccountId,
+			FundingScheduleId:     fundingSchedule.FundingScheduleId,
+			SpendingType:          models.SpendingTypeGoal,
+			Name:                  "Auto Goal",
+			Description:           "Auto goal",
+			TargetAmount:          5000,
+			CurrentAmount:         5000,
+			NextRecurrence:        clock.Now().Add(-24 * time.Hour),
+			AutoCreateTransaction: true, // Defensive: jobs must skip goals even if the flag was set somehow.
+			CreatedAt:             clock.Now(),
+		})
+
+		{
+			context := mockgen.NewMockContext(ctrl)
+			context.EXPECT().Clock().Return(clock).AnyTimes()
+			context.EXPECT().DB().Return(db).AnyTimes()
+			context.EXPECT().Log().Return(log).AnyTimes()
+			context.EXPECT().RunInTransaction(gomock.Any(), gomock.Any()).Times(1)
+
+			err := spending_jobs.ProcessSpending(
+				mockqueue.NewMockContext(context),
+				spending_jobs.ProcessSpendingArguments{
+					AccountId:     goal.AccountId,
+					BankAccountId: goal.BankAccountId,
+				},
+			)
+			assert.NoError(t, err, "should run job successfully")
+		}
+
+		// Verify the goal was not deducted from.
+		updatedGoal := testutils.MustRetrieve(t, goal)
+		assert.EqualValues(t, int64(5000), updatedGoal.CurrentAmount, "current amount should not change for a goal")
+
+		// Verify the bank account balance did not change.
+		updatedBankAccount := testutils.MustRetrieve(t, bankAccount)
+		assert.EqualValues(t, bankAccount.AvailableBalance, updatedBankAccount.AvailableBalance, "available balance should not change")
+		assert.EqualValues(t, bankAccount.CurrentBalance, updatedBankAccount.CurrentBalance, "current balance should not change")
+
+		// Verify no transactions were created.
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
+		transactions, err := repo.GetTransactions(t.Context(), bankAccount.BankAccountId, 100, 0)
+		assert.NoError(t, err, "should retrieve transactions")
+		assert.Empty(t, transactions, "no transactions should have been created for a goal")
+	})
+
+	t.Run("does not auto create transaction when flag is off", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		clock := clock.NewMock()
+		log := testutils.GetLog(t)
+		db := testutils.GetPgDatabase(t)
+
+		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
+		link := fixtures.GivenIHaveAManualLink(t, clock, user)
+		bankAccount := fixtures.GivenIHaveABankAccount(t, clock, &link, models.DepositoryBankAccountType, models.CheckingBankAccountSubType)
+		timezone := testutils.MustEz(t, user.Account.GetTimezone)
+
+		fundingRule := testutils.RuleToSet(t, timezone, "FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15,-1", clock.Now())
+		fundingSchedule := testutils.MustInsert(t, models.FundingSchedule{
+			AccountId:              bankAccount.AccountId,
+			BankAccountId:          bankAccount.BankAccountId,
+			Name:                   "Payday",
+			Description:            "Payday",
+			RuleSet:                fundingRule,
+			NextRecurrence:         fundingRule.After(clock.Now(), false),
+			NextRecurrenceOriginal: fundingRule.After(clock.Now(), false),
+		})
+
+		spendingRule := testutils.RuleToSet(t, timezone, "FREQ=WEEKLY;INTERVAL=1;BYDAY=MO", clock.Now())
+		spendingRule.DTStart(clock.Now().Add(-8 * 24 * time.Hour))
+		spending := testutils.MustInsert(t, models.Spending{
+			AccountId:             bankAccount.AccountId,
+			BankAccountId:         bankAccount.BankAccountId,
+			FundingScheduleId:     fundingSchedule.FundingScheduleId,
+			SpendingType:          models.SpendingTypeExpense,
+			Name:                  "Manual Expense",
+			Description:           "Manual expense without auto create",
+			TargetAmount:          5000,
+			CurrentAmount:         5000,
+			RuleSet:               spendingRule,
+			NextRecurrence:        spendingRule.Before(clock.Now(), true),
+			AutoCreateTransaction: false,
+			CreatedAt:             clock.Now(),
+		})
+
+		{
+			context := mockgen.NewMockContext(ctrl)
+			context.EXPECT().Clock().Return(clock).AnyTimes()
+			context.EXPECT().DB().Return(db).AnyTimes()
+			context.EXPECT().Log().Return(log).AnyTimes()
+			context.EXPECT().RunInTransaction(gomock.Any(), gomock.Any()).Times(1)
+
+			err := spending_jobs.ProcessSpending(
+				mockqueue.NewMockContext(context),
+				spending_jobs.ProcessSpendingArguments{
+					AccountId:     spending.AccountId,
+					BankAccountId: spending.BankAccountId,
+				},
+			)
+			assert.NoError(t, err, "should run job successfully")
+		}
+
+		// Verify the expense was not deducted from.
+		updatedSpending := testutils.MustRetrieve(t, spending)
+		assert.EqualValues(t, int64(5000), updatedSpending.CurrentAmount, "current amount should not change when flag is off")
+
+		// Verify the bank account balance did not change.
+		updatedBankAccount := testutils.MustRetrieve(t, bankAccount)
+		assert.EqualValues(t, bankAccount.AvailableBalance, updatedBankAccount.AvailableBalance, "available balance should not change")
+		assert.EqualValues(t, bankAccount.CurrentBalance, updatedBankAccount.CurrentBalance, "current balance should not change")
+
+		// Verify no transactions were created.
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
+		transactions, err := repo.GetTransactions(t.Context(), bankAccount.BankAccountId, 100, 0)
+		assert.NoError(t, err, "should retrieve transactions")
+		assert.Empty(t, transactions, "no transactions should have been created when flag is off")
 	})
 }


### PR DESCRIPTION
If you are using a manual budget, expenses and funding schedules can now
automatically create transactions when they recur. This way if you are
manually entering things, you don't need to manually enter these
transactions every time.

This can be enabled per expense and per funding schedule, and is only
supported on manual links.

Resolves https://github.com/monetr/monetr/issues/3125