### PR TITLE
refactor(api): Laying groundwork for CSV imports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/jarcoal/httpmock v1.4.1
 	github.com/labstack/echo/v4 v4.15.1
+	github.com/monetr/devslog v0.0.17
 	github.com/monetr/validation v1.0.5
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/openbao/openbao/api/v2 v2.5.1

--- a/go.sum
+++ b/go.sum
@@ -348,6 +348,8 @@ github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQ
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/monetr/devslog v0.0.17 h1:BHpYtqWBGVQawkEyfhgFwqnhQtPBxg4bPMD2tMxsgow=
+github.com/monetr/devslog v0.0.17/go.mod h1:nzUwy/SXXIzjEmPSWWSzm14ytUBh1d9RGr2mxSDZ3Iw=
 github.com/monetr/validation v1.0.5 h1:clGPYUfyPQRhhfDdje647xIreTclWIaqZQgMAULmj7w=
 github.com/monetr/validation v1.0.5/go.mod h1:mFBjreq4v2Z/K1PAJSGmRgVfcjdezcptqYe+9gSu2oc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=

--- a/interface/src/models/TransactionImportMapping.ts
+++ b/interface/src/models/TransactionImportMapping.ts
@@ -1,0 +1,100 @@
+// FieldRef references either a named column from the input file or a derived value computed at processing time, never
+// both. The discriminated union enforces this at compile time: setting both `name` and `derivedKind` is a type error.
+export enum DerivedKind {
+  RowNumber = 'rowNumber',
+  RowNumberPerDay = 'rowNumberPerDay',
+  RowNumberPerDayPerAmount = 'rowNumberPerDayPerAmount',
+}
+
+export type FieldRef = { name: string; derivedKind?: never } | { name?: never; derivedKind: DerivedKind };
+
+// IDSpec is not a union; both kinds use the same shape. Kind chooses the strategy used to build the unique identifier
+// from the supplied fields.
+export enum IDSpecKind {
+  Native = 'native',
+  Hashed = 'hashed',
+}
+
+export interface IDSpec {
+  kind: IDSpecKind;
+  fields: FieldRef[];
+}
+
+// AmountSpec is a three-way discriminated union on `kind`:
+//   - sign:   one field, no credit/debit
+//   - type:   two fields plus a credit and debit string for the type column
+//   - column: two fields, one debit and one credit, no credit/debit strings
+export enum AmountKind {
+  Sign = 'sign',
+  Type = 'type',
+  Column = 'column',
+}
+
+interface AmountSpecBase {
+  invert?: boolean;
+  fields: FieldRef[];
+}
+
+export interface SignAmountSpec extends AmountSpecBase {
+  kind: AmountKind.Sign;
+  credit?: never;
+  debit?: never;
+}
+
+export interface TypeAmountSpec extends AmountSpecBase {
+  kind: AmountKind.Type;
+  credit: string;
+  debit: string;
+}
+
+export interface ColumnAmountSpec extends AmountSpecBase {
+  kind: AmountKind.Column;
+  credit?: never;
+  debit?: never;
+}
+
+export type AmountSpec = SignAmountSpec | TypeAmountSpec | ColumnAmountSpec;
+
+export interface DateSpec {
+  fields: FieldRef[];
+  format: string;
+}
+
+export interface PostedSpec {
+  fields: FieldRef[];
+  posted?: string;
+}
+
+// BalanceSpec is a discriminated union on `kind`:
+//   - none / sum: fields must be absent
+//   - field:      fields contains exactly the column to read the balance from
+export enum BalanceKind {
+  None = 'none',
+  Field = 'field',
+  Sum = 'sum',
+}
+
+export interface NoneOrSumBalanceSpec {
+  kind: BalanceKind.None | BalanceKind.Sum;
+  fields?: never;
+}
+
+export interface FieldBalanceSpec {
+  kind: BalanceKind.Field;
+  fields: FieldRef[];
+}
+
+export type BalanceSpec = NoneOrSumBalanceSpec | FieldBalanceSpec;
+
+interface TransactionImportMapping {
+  id: IDSpec;
+  amount: AmountSpec;
+  memo: FieldRef;
+  merchant?: FieldRef;
+  date: DateSpec;
+  posted?: PostedSpec;
+  balance: BalanceSpec;
+  headers: string[];
+}
+
+export default TransactionImportMapping;

--- a/server/controller/errors.go
+++ b/server/controller/errors.go
@@ -149,3 +149,15 @@ func (c *Controller) invalidJsonError(ctx echo.Context, err error) error {
 func (c *Controller) notFound(ctx echo.Context, msg string, args ...any) error {
 	return c.returnError(ctx, http.StatusNotFound, msg, args...)
 }
+
+// jsonError returns an *echo.HTTPError whose body is written verbatim from the
+// provided map. The error middleware in routes.go detects a non-string
+// Message of type map[string]any and emits it as-is, so callers can shape the
+// response body (e.g. validation responses with a "problems" tree) without
+// writing the JSON inline. Returning the *echo.HTTPError lets the handler
+// short-circuit cleanly: subsequent code in the handler does not run, which
+// avoids the double-body bug seen when ctx.JSON is called from a helper that
+// then returns nil.
+func (c *Controller) jsonError(ctx echo.Context, status int, body map[string]any) error {
+	return echo.NewHTTPError(status, body)
+}

--- a/server/controller/funding_schedules.go
+++ b/server/controller/funding_schedules.go
@@ -66,22 +66,14 @@ func (c *Controller) postFundingSchedules(ctx echo.Context) error {
 
 	var fundingSchedule FundingSchedule
 	fundingSchedule.BankAccountId = bankAccountId
-	err = fundingSchedule.UnmarshalRequest(
-		c.getContext(ctx),
-		ctx.Request().Body,
-		fundingSchedule.CreateValidators()...,
+	fundingSchedule, err = parse(
+		c,
+		ctx,
+		&fundingSchedule,
+		validation.Map(fundingSchedule.CreateValidators()...),
 	)
-	switch errors.Cause(err).(type) {
-	case validation.Errors:
-		return ctx.JSON(http.StatusBadRequest, map[string]any{
-			"error":    "Invalid request",
-			"problems": err,
-		})
-	case *json.SyntaxError:
-		return c.invalidJsonError(ctx, err)
-	case nil:
-	default:
-		return c.badRequestError(ctx, err, "failed to parse post request")
+	if err != nil {
+		return err
 	}
 
 	repo := c.mustGetAuthenticatedRepository(ctx)

--- a/server/controller/helpers.go
+++ b/server/controller/helpers.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"encoding/json"
+	"net/http"
 	"strings"
 	"time"
 
@@ -13,6 +14,8 @@ import (
 	"github.com/monetr/monetr/server/repository"
 	"github.com/monetr/monetr/server/security"
 	"github.com/monetr/monetr/server/util"
+	"github.com/monetr/monetr/server/validators"
+	"github.com/monetr/validation"
 	"github.com/pkg/errors"
 )
 
@@ -308,4 +311,41 @@ func enqueueJob[T any](
 		job,
 		args,
 	)
+}
+
+func parse[T any](
+	c *Controller,
+	ctx echo.Context,
+	existing *T,
+	schemas ...validation.MapRule,
+) (T, error) {
+	if existing == nil {
+		existing = new(T)
+	}
+
+	rawData := map[string]any{}
+	decoder := json.NewDecoder(ctx.Request().Body)
+	decoder.UseNumber()
+	if err := decoder.Decode(&rawData); err != nil {
+		return *existing, c.invalidJsonError(ctx, err)
+	}
+
+	output, err := validators.OneOf(
+		c.getContext(ctx),
+		existing,
+		rawData,
+		schemas...,
+	)
+	switch errors.Cause(err).(type) {
+	case validators.OneOfError:
+		return output, c.jsonError(ctx, http.StatusBadRequest, map[string]any{
+			"error":    "Invalid request",
+			"problems": validators.MarshalErrorTree(err),
+		})
+	case nil:
+	default:
+		return output, c.badRequestError(ctx, err, "failed to parse request")
+	}
+
+	return output, nil
 }

--- a/server/controller/routes.go
+++ b/server/controller/routes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"runtime/debug"
 	"time"
@@ -16,8 +17,6 @@ import (
 	"github.com/monetr/monetr/server/internal/sentryecho"
 	"github.com/monetr/monetr/server/security"
 	"github.com/monetr/monetr/server/util"
-	"log/slog"
-
 	"github.com/pkg/errors"
 )
 
@@ -202,6 +201,9 @@ func (c *Controller) RegisterRoutes(app *echo.Echo) {
 						return ctx.JSON(actualError.Code, internalError)
 					}
 				default:
+					if body, ok := actualError.Message.(map[string]any); ok {
+						return ctx.JSON(actualError.Code, body)
+					}
 					return ctx.JSON(actualError.Code, map[string]any{
 						"error": actualError.Message,
 					})
@@ -305,6 +307,9 @@ func (c *Controller) RegisterRoutes(app *echo.Echo) {
 	billed.GET("/bank_accounts/:bankAccountId/transactions/upload/:transactionUploadId/progress", c.getTransactionUploadProgress)
 	billed.PUT("/bank_accounts/:bankAccountId/transactions/:transactionId", c.putTransactions)
 	billed.DELETE("/bank_accounts/:bankAccountId/transactions/:transactionId", c.deleteTransactions)
+	// Mappings
+	billed.GET("/mappings", c.getTransactionImportMappings)
+	billed.POST("/mappings", c.postTransactionImportMapping)
 	// Uploads
 	billed.GET("/files", c.getFiles)
 	// Funding schedules

--- a/server/controller/transaction_import_mappings.go
+++ b/server/controller/transaction_import_mappings.go
@@ -1,0 +1,83 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/monetr/monetr/server/datasources/table"
+	. "github.com/monetr/monetr/server/models"
+	"github.com/monetr/monetr/server/validators"
+	"github.com/monetr/validation"
+	"github.com/pkg/errors"
+)
+
+func (c *Controller) getTransactionImportMappings(ctx echo.Context) error {
+	limit := urlParamIntDefault(ctx, "limit", 10)
+	offset := urlParamIntDefault(ctx, "offset", 0)
+
+	if limit < 1 {
+		return c.badRequest(ctx, "limit must be at least 1")
+	} else if limit > 10 {
+		return c.badRequest(ctx, "limit cannot be greater than 10")
+	}
+
+	if offset < 0 {
+		return c.badRequest(ctx, "offset cannot be less than 0")
+	}
+
+	repo := c.mustGetAuthenticatedRepository(ctx)
+
+	var mappings []TransactionImportMapping
+	var err error
+	if signature := ctx.QueryParam("signature"); signature != "" {
+		mappings, err = repo.GetTransactionImportMappingsBySignature(
+			c.getContext(ctx),
+			signature,
+			limit,
+			offset,
+		)
+	} else {
+		mappings, err = repo.GetTransactionImportMappings(
+			c.getContext(ctx),
+			limit,
+			offset,
+		)
+	}
+	if err != nil {
+		return c.wrapPgError(ctx, err, "failed to retrieve transaction import mappings")
+	}
+
+	return ctx.JSON(http.StatusOK, mappings)
+}
+
+func (c *Controller) postTransactionImportMapping(ctx echo.Context) error {
+	var data struct {
+		Mapping table.Mapping `json:"mapping"`
+	}
+	if err := ctx.Bind(&data); err != nil {
+		return c.invalidJson(ctx)
+	}
+
+	if err := data.Mapping.Validate(c.getContext(ctx)); err != nil {
+		switch errors.Cause(err).(type) {
+		case validation.Errors, validators.OneOfError:
+			return c.jsonError(ctx, http.StatusBadRequest, map[string]any{
+				"error":    "Invalid request",
+				"problems": validators.MarshalErrorTree(err),
+			})
+		default:
+			return c.badRequestError(ctx, err, "failed to parse request")
+		}
+	}
+
+	mapping := TransactionImportMapping{
+		Mapping: data.Mapping,
+	}
+
+	repo := c.mustGetAuthenticatedRepository(ctx)
+	if err := repo.CreateTransactionImportMapping(c.getContext(ctx), &mapping); err != nil {
+		return c.wrapPgError(ctx, err, "failed to create transaction import mapping")
+	}
+
+	return ctx.JSON(http.StatusOK, mapping)
+}

--- a/server/controller/transaction_import_mappings_test.go
+++ b/server/controller/transaction_import_mappings_test.go
@@ -1,0 +1,407 @@
+package controller_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/monetr/monetr/server/internal/fixtures"
+)
+
+func TestPostTransactionImportMapping(t *testing.T) {
+	t.Run("empty mapping returns the full structured validation error", func(t *testing.T) {
+		// An empty mapping triggers every required-field error across every
+		// sub-spec. The response body is asserted as a complete map so that any
+		// drift in the JSON shape (added/removed fields, wrong nesting, lost oneOf
+		// envelope) trips this test.
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		response := e.POST("/api/mappings").
+			WithCookie(TestCookieName, token).
+			WithJSON(map[string]any{
+				"mapping": map[string]any{
+					"amount": map[string]any{
+						"kind": "test",
+						"fields": []any{
+							map[string]any{
+								"name": "foo",
+							},
+						},
+					},
+					"headers": []string{
+						"test",
+					},
+				},
+			}).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Object().IsEqual(map[string]any{
+			"error": "Invalid request",
+			"problems": map[string]any{
+				"amount": map[string]any{
+					"oneOf": []any{
+						map[string]any{
+							"fields": map[string]any{
+								"0": map[string]any{
+									"oneOf": []any{
+										map[string]any{
+											"name": `must be one of: ["test"]`,
+										},
+										map[string]any{
+											"derivedKind": "cannot be blank",
+											"name":        "must be blank",
+										},
+									},
+								},
+							},
+							"kind": `must equal "sign"`,
+						},
+						map[string]any{
+							"credit": "cannot be blank",
+							"debit":  "cannot be blank",
+							"fields": map[string]any{
+								"0": map[string]any{
+									"oneOf": []any{
+										map[string]any{
+											"name": `must be one of: ["test"]`,
+										},
+										map[string]any{
+											"derivedKind": "cannot be blank",
+											"name":        "must be blank",
+										},
+									},
+								},
+							},
+							"kind": `must equal "type"`,
+						},
+						map[string]any{
+							"fields": map[string]any{
+								"0": map[string]any{
+									"oneOf": []any{
+										map[string]any{
+											"name": `must be one of: ["test"]`,
+										},
+										map[string]any{
+											"derivedKind": "cannot be blank",
+											"name":        "must be blank",
+										},
+									},
+								},
+							},
+							"kind": `must equal "column"`,
+						},
+					},
+				},
+				"balance": map[string]any{
+					"oneOf": []any{
+						map[string]any{
+							"kind": "cannot be blank",
+						},
+						map[string]any{
+							"fields": "cannot be blank",
+							"kind":   `must equal "field"`,
+						},
+					},
+				},
+				"date": map[string]any{
+					"fields": "cannot be blank",
+					"format": "cannot be blank",
+				},
+				"id": map[string]any{
+					"fields": "cannot be blank",
+					"kind":   "cannot be blank",
+				},
+				"memo": map[string]any{
+					"oneOf": []any{
+						map[string]any{
+							"name": "cannot be blank",
+						},
+						map[string]any{
+							"derivedKind": "cannot be blank",
+						},
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("valid mapping is accepted", func(t *testing.T) {
+		// A fully consistent mapping satisfies one variant of every union and every
+		// required field, with FieldRef names referencing entries in Headers. The
+		// endpoint does not yet persist or echo the mapping back, so the assertion
+		// here is just that validation passes (200, no problems body).
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		response := e.POST("/api/mappings").
+			WithCookie(TestCookieName, token).
+			WithJSON(map[string]any{
+				"mapping": map[string]any{
+					"id": map[string]any{
+						"kind": "native",
+						"fields": []any{
+							map[string]any{
+								"name": "Id",
+							},
+						},
+					},
+					"amount": map[string]any{
+						"kind": "sign",
+						"fields": []any{
+							map[string]any{
+								"name": "Amount",
+							},
+						},
+					},
+					"memo": map[string]any{
+						"name": "Description",
+					},
+					"date": map[string]any{
+						"fields": []any{
+							map[string]any{
+								"name": "Date",
+							},
+						},
+						"format": "YYYY-MM-DD",
+					},
+					"balance": map[string]any{
+						"kind": "none",
+					},
+					"headers": []string{
+						"Date",
+						"Description",
+						"Amount",
+						"Id",
+					},
+				},
+			}).
+			Expect()
+
+		response.Status(http.StatusOK)
+	})
+}
+
+func TestGetTransactionImportMappings(t *testing.T) {
+	t.Run("empty list", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		response := e.GET("/api/mappings").
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusOK)
+		response.JSON().Array().IsEmpty()
+	})
+
+	t.Run("returns mappings ordered most-recent first", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		first := e.POST("/api/mappings").
+			WithCookie(TestCookieName, token).
+			WithJSON(map[string]any{
+				"mapping": map[string]any{
+					"id":      map[string]any{"kind": "native", "fields": []any{map[string]any{"name": "Id"}}},
+					"amount":  map[string]any{"kind": "sign", "fields": []any{map[string]any{"name": "Amount"}}},
+					"memo":    map[string]any{"name": "Description"},
+					"date":    map[string]any{"fields": []any{map[string]any{"name": "Date"}}, "format": "YYYY-MM-DD"},
+					"balance": map[string]any{"kind": "none"},
+					"headers": []string{"Date", "Description", "Amount", "Id"},
+				},
+			}).
+			Expect()
+		first.Status(http.StatusOK)
+		firstId := first.JSON().Path("$.transactionImportMapping").String().Raw()
+
+		app.Clock.Add(1 * time.Minute)
+
+		second := e.POST("/api/mappings").
+			WithCookie(TestCookieName, token).
+			WithJSON(map[string]any{
+				"mapping": map[string]any{
+					"id":      map[string]any{"kind": "native", "fields": []any{map[string]any{"name": "Reference"}}},
+					"amount":  map[string]any{"kind": "sign", "fields": []any{map[string]any{"name": "Value"}}},
+					"memo":    map[string]any{"name": "Memo"},
+					"date":    map[string]any{"fields": []any{map[string]any{"name": "Posted"}}, "format": "YYYY-MM-DD"},
+					"balance": map[string]any{"kind": "none"},
+					"headers": []string{"Posted", "Memo", "Value", "Reference"},
+				},
+			}).
+			Expect()
+		second.Status(http.StatusOK)
+		secondId := second.JSON().Path("$.transactionImportMapping").String().Raw()
+
+		response := e.GET("/api/mappings").
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusOK)
+		response.JSON().Array().Length().IsEqual(2)
+		response.JSON().Path("$[0].transactionImportMapping").IsEqual(secondId)
+		response.JSON().Path("$[1].transactionImportMapping").IsEqual(firstId)
+	})
+
+	t.Run("filters by signature", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		matching := e.POST("/api/mappings").
+			WithCookie(TestCookieName, token).
+			WithJSON(map[string]any{
+				"mapping": map[string]any{
+					"id":      map[string]any{"kind": "native", "fields": []any{map[string]any{"name": "Id"}}},
+					"amount":  map[string]any{"kind": "sign", "fields": []any{map[string]any{"name": "Amount"}}},
+					"memo":    map[string]any{"name": "Description"},
+					"date":    map[string]any{"fields": []any{map[string]any{"name": "Date"}}, "format": "YYYY-MM-DD"},
+					"balance": map[string]any{"kind": "none"},
+					"headers": []string{"Date", "Description", "Amount", "Id"},
+				},
+			}).
+			Expect()
+		matching.Status(http.StatusOK)
+		matchingId := matching.JSON().Path("$.transactionImportMapping").String().Raw()
+		signature := matching.JSON().Path("$.signature").String().Raw()
+
+		other := e.POST("/api/mappings").
+			WithCookie(TestCookieName, token).
+			WithJSON(map[string]any{
+				"mapping": map[string]any{
+					"id":      map[string]any{"kind": "native", "fields": []any{map[string]any{"name": "Reference"}}},
+					"amount":  map[string]any{"kind": "sign", "fields": []any{map[string]any{"name": "Value"}}},
+					"memo":    map[string]any{"name": "Memo"},
+					"date":    map[string]any{"fields": []any{map[string]any{"name": "Posted"}}, "format": "YYYY-MM-DD"},
+					"balance": map[string]any{"kind": "none"},
+					"headers": []string{"Posted", "Memo", "Value", "Reference"},
+				},
+			}).
+			Expect()
+		other.Status(http.StatusOK)
+
+		response := e.GET("/api/mappings").
+			WithQuery("signature", signature).
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusOK)
+		response.JSON().Array().Length().IsEqual(1)
+		response.JSON().Path("$[0].transactionImportMapping").IsEqual(matchingId)
+		response.JSON().Path("$[0].signature").IsEqual(signature)
+	})
+
+	t.Run("paginates with limit and offset", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		for i := 0; i < 3; i++ {
+			response := e.POST("/api/mappings").
+				WithCookie(TestCookieName, token).
+				WithJSON(map[string]any{
+					"mapping": map[string]any{
+						"id":      map[string]any{"kind": "native", "fields": []any{map[string]any{"name": "Id"}}},
+						"amount":  map[string]any{"kind": "sign", "fields": []any{map[string]any{"name": "Amount"}}},
+						"memo":    map[string]any{"name": "Description"},
+						"date":    map[string]any{"fields": []any{map[string]any{"name": "Date"}}, "format": "YYYY-MM-DD"},
+						"balance": map[string]any{"kind": "none"},
+						"headers": []string{"Date", "Description", "Amount", "Id"},
+					},
+				}).
+				Expect()
+			response.Status(http.StatusOK)
+			app.Clock.Add(1 * time.Minute)
+		}
+
+		page1 := e.GET("/api/mappings").
+			WithQuery("limit", 2).
+			WithCookie(TestCookieName, token).
+			Expect()
+		page1.Status(http.StatusOK)
+		page1.JSON().Array().Length().IsEqual(2)
+
+		page2 := e.GET("/api/mappings").
+			WithQuery("limit", 2).
+			WithQuery("offset", 2).
+			WithCookie(TestCookieName, token).
+			Expect()
+		page2.Status(http.StatusOK)
+		page2.JSON().Array().Length().IsEqual(1)
+	})
+
+	t.Run("rejects limit above 10", func(t *testing.T) {
+		_, e := NewTestApplication(t)
+		token := GivenIHaveToken(t, e)
+
+		response := e.GET("/api/mappings").
+			WithQuery("limit", 11).
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.error").IsEqual("limit cannot be greater than 10")
+	})
+
+	t.Run("rejects limit below 1", func(t *testing.T) {
+		_, e := NewTestApplication(t)
+		token := GivenIHaveToken(t, e)
+
+		response := e.GET("/api/mappings").
+			WithQuery("limit", 0).
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.error").IsEqual("limit must be at least 1")
+	})
+
+	t.Run("rejects negative offset", func(t *testing.T) {
+		_, e := NewTestApplication(t)
+		token := GivenIHaveToken(t, e)
+
+		response := e.GET("/api/mappings").
+			WithQuery("offset", -1).
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.error").IsEqual("offset cannot be less than 0")
+	})
+
+	t.Run("isolates by account", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		userA, passwordA := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		tokenA := GivenILogin(t, e, userA.Login.Email, passwordA)
+
+		seedA := e.POST("/api/mappings").
+			WithCookie(TestCookieName, tokenA).
+			WithJSON(map[string]any{
+				"mapping": map[string]any{
+					"id":      map[string]any{"kind": "native", "fields": []any{map[string]any{"name": "Id"}}},
+					"amount":  map[string]any{"kind": "sign", "fields": []any{map[string]any{"name": "Amount"}}},
+					"memo":    map[string]any{"name": "Description"},
+					"date":    map[string]any{"fields": []any{map[string]any{"name": "Date"}}, "format": "YYYY-MM-DD"},
+					"balance": map[string]any{"kind": "none"},
+					"headers": []string{"Date", "Description", "Amount", "Id"},
+				},
+			}).
+			Expect()
+		seedA.Status(http.StatusOK)
+
+		userB, passwordB := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		tokenB := GivenILogin(t, e, userB.Login.Email, passwordB)
+
+		response := e.GET("/api/mappings").
+			WithCookie(TestCookieName, tokenB).
+			Expect()
+
+		response.Status(http.StatusOK)
+		response.JSON().Array().IsEmpty()
+	})
+}

--- a/server/datasources/table/CMakeLists.txt
+++ b/server/datasources/table/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(GolangTestUtils)
+
+provision_golang_tests(${CMAKE_CURRENT_SOURCE_DIR})

--- a/server/datasources/table/amount.go
+++ b/server/datasources/table/amount.go
@@ -1,0 +1,164 @@
+package table
+
+import (
+	"context"
+
+	"github.com/monetr/monetr/server/validators"
+	"github.com/monetr/validation"
+	"github.com/monetr/validation/is"
+)
+
+type AmountKind string
+
+const (
+	// AmountKindSign means that the single amount column can be used to derive
+	// the sign of the amount. If it is negative then its a debit, positive means
+	// credit.
+	AmountKindSign AmountKind = "sign"
+	// AmountKindType means that there is a column that contains some values, such
+	// as DEBIT or CREDIT which we must map off of.
+	AmountKindType AmountKind = "type"
+	// AmountKindColumn means there are two separate columns to derive the amount
+	// from, one column for debits, one for credits.
+	AmountKindColumn AmountKind = "column"
+)
+
+// AmountSpec derives the amount of the transaction from the document row. It
+// allows for the amount to be specified as a standalone column in the first
+// value of [AmountSpec.Fields], or specified as a pair of columns
+// ([AmountSpec.Fields]). The pair of columns is either an amount and a
+// direction, or each column represents a specific direction independently.
+// monetr treats amounts as inverted, deposits are negative and debits are
+// positive. So the [AmountSpec.Invert] field is not there to adjust for
+// monetr's representation. The invert field is there to adjust only the input
+// representation.
+type AmountSpec struct {
+	Kind AmountKind `json:"kind"`
+	// Invert the sign after parsing, for example; negative values become
+	// positive.
+	Invert bool `json:"invert"`
+
+	// If it is [AmountKindSign] then this must be a single value.
+	// If it is [AmountKindType] then the first field here is the amount, the
+	// second is the type of amount.
+	// If it is [AmountKindColumn] then the first field is debit and the second
+	// field is credit.
+	Fields []FieldRef `json:"fields,omitempty"`
+
+	// Credit is the value we look for (case-insensitively) in the second field
+	// when we are [AmountKindType].
+	Credit string `json:"credit,omitempty"`
+	// Debit is the value we look for (case-insensitively) in the second field
+	// when we are [AmountKindType].
+	Debit string `json:"debit,omitempty"`
+}
+
+func (s *AmountSpec) Validate(ctx context.Context) error {
+	return validators.OneOfStruct(
+		ctx,
+		s,
+		// When we are [AmountKindSign] then only [AmountSpec.Fields] should be
+		// provided with exactly one item. [AmountSpec.Credit] and
+		// [AmountSpec.Debit] must be empty.
+		[]*validation.FieldRules{
+			validation.Field(
+				&s.Kind,
+				validators.Eq(AmountKindSign),
+				validation.Required,
+			),
+			validation.Field(
+				&s.Invert,
+				validation.In(true, false),
+			),
+			validation.Field(
+				&s.Fields,
+				validation.Each(
+					validators.By(func(ctx context.Context, field FieldRef) error {
+						return field.Validate(ctx)
+					}),
+				),
+				validation.Required,
+				validation.Length(1, 1),
+				validators.Unique[FieldRef](),
+			),
+			validation.Field(
+				&s.Credit,
+				validation.Empty.Error(`when kind is "sign" credit cannot be specified`),
+			),
+			validation.Field(
+				&s.Debit,
+				validation.Empty.Error(`when kind is "sign" debit cannot be specified`),
+			),
+		},
+		// When we are [AmountKindType] then [AmountSpec.Credit] and
+		// [AmountSpec.Debit] must both be provided, and [AmountSpec.Fields] must
+		// have exactly two items.
+		[]*validation.FieldRules{
+			validation.Field(
+				&s.Kind,
+				validators.Eq(AmountKindType),
+				validation.Required,
+			),
+			validation.Field(
+				&s.Invert,
+				validation.In(true, false),
+			),
+			validation.Field(
+				&s.Fields,
+				validation.Each(
+					validators.By(func(ctx context.Context, field FieldRef) error {
+						return field.Validate(ctx)
+					}),
+				),
+				validation.Required,
+				validation.Length(2, 2),
+				validators.Unique[FieldRef](),
+			),
+			validation.Field(
+				&s.Credit,
+				validation.Required,
+				is.PrintableASCII,
+				validation.Length(1, 100),
+			),
+			validation.Field(
+				&s.Debit,
+				validation.Required,
+				is.PrintableASCII,
+				validation.Length(1, 100),
+			),
+		},
+		// When we are [AmountKindColumn] then The [AmountSpec.Credit] and
+		// [AmountSpec.Debit] fields must be empty, and [AmountSpec.Fields] must
+		// have exactly two unique items.
+		[]*validation.FieldRules{
+			validation.Field(
+				&s.Kind,
+				validators.Eq(AmountKindColumn),
+				validation.Required,
+			),
+			validation.Field(
+				&s.Invert,
+				validation.In(true, false),
+			),
+			validation.Field(
+				&s.Fields,
+				validation.Each(
+					validators.By(func(ctx context.Context, field FieldRef) error {
+						return field.Validate(ctx)
+					}),
+				),
+				validation.Required,
+				validation.Length(2, 2),
+				validators.Unique[FieldRef](),
+			),
+			validation.Field(
+				&s.Credit,
+				validation.Empty.Error(`when kind is "column" credit cannot be specified`),
+			),
+			validation.Field(
+				&s.Debit,
+				validation.Empty.Error(`when kind is "column" debit cannot be specified`),
+			),
+		},
+	)
+}

--- a/server/datasources/table/amount_test.go
+++ b/server/datasources/table/amount_test.go
@@ -1,0 +1,280 @@
+package table_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/monetr/monetr/server/datasources/table"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAmountSpec_Validate(t *testing.T) {
+	// AmountSpec has three valid shapes, selected by Kind:
+	//   - Sign:   exactly one Fields entry, no Credit/Debit strings
+	//   - Type:   exactly two Fields entries, both Credit and Debit strings set
+	//   - Column: exactly two Fields entries, no Credit/Debit strings
+	// Invert may be either true or false regardless of Kind.
+	ctx := table.WithColumns(
+		t.Context(),
+		[]string{"Date", "Amount", "DebitAmt", "CreditAmt", "TransType"},
+	)
+	cases := []struct {
+		name    string
+		spec    table.AmountSpec
+		wantErr string
+	}{
+		{
+			name: "Sign with one field, Invert false",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindSign,
+				Invert: false,
+				Fields: []table.FieldRef{{Name: "Amount"}},
+			},
+			wantErr: "",
+		},
+		{
+			name: "Sign with one field, Invert true",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindSign,
+				Invert: true,
+				Fields: []table.FieldRef{{Name: "Amount"}},
+			},
+			wantErr: "",
+		},
+		{
+			name: "Type with two fields and credit/debit, Invert false",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindType,
+				Invert: false,
+				Fields: []table.FieldRef{{Name: "Amount"}, {Name: "TransType"}},
+				Credit: "CREDIT",
+				Debit:  "DEBIT",
+			},
+			wantErr: "",
+		},
+		{
+			name: "Type with two fields and credit/debit, Invert true",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindType,
+				Invert: true,
+				Fields: []table.FieldRef{{Name: "Amount"}, {Name: "TransType"}},
+				Credit: "CREDIT",
+				Debit:  "DEBIT",
+			},
+			wantErr: "",
+		},
+		{
+			name: "Column with two fields, Invert false",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindColumn,
+				Invert: false,
+				Fields: []table.FieldRef{{Name: "DebitAmt"}, {Name: "CreditAmt"}},
+			},
+			wantErr: "",
+		},
+		{
+			name: "Column with two fields, Invert true",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindColumn,
+				Invert: true,
+				Fields: []table.FieldRef{{Name: "DebitAmt"}, {Name: "CreditAmt"}},
+			},
+			wantErr: "",
+		},
+		{
+			// Branch 3 (Column) now also reports "kind: cannot be blank" because
+			// Required was added to its Kind rule. Prior to that fix, empty Kind
+			// slipped through the Column branch.
+			name:    "empty",
+			spec:    table.AmountSpec{},
+			wantErr: "input must be considered valid by: fields: cannot be blank; kind: must equal \"sign\". or credit: cannot be blank; debit: cannot be blank; fields: cannot be blank; kind: must equal \"type\". or fields: cannot be blank; kind: must equal \"column\".",
+		},
+		{
+			name:    "unknown kind with no fields",
+			spec:    table.AmountSpec{Kind: table.AmountKind("bogus")},
+			wantErr: "input must be considered valid by: fields: cannot be blank; kind: must equal \"sign\". or credit: cannot be blank; debit: cannot be blank; fields: cannot be blank; kind: must equal \"type\". or fields: cannot be blank; kind: must equal \"column\".",
+		},
+		{
+			name: "Sign with two fields violates length",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindSign,
+				Fields: []table.FieldRef{{Name: "Amount"}, {Name: "TransType"}},
+			},
+			wantErr: "input must be considered valid by: fields: the length must be exactly 1. or credit: cannot be blank; debit: cannot be blank; kind: must equal \"type\". or kind: must equal \"column\".",
+		},
+		{
+			name: "Sign with Credit set",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindSign,
+				Fields: []table.FieldRef{{Name: "Amount"}},
+				Credit: "CREDIT",
+			},
+			wantErr: "input must be considered valid by: credit: when kind is \"sign\" credit cannot be specified. or debit: cannot be blank; fields: the length must be exactly 2; kind: must equal \"type\". or credit: when kind is \"column\" credit cannot be specified; fields: the length must be exactly 2; kind: must equal \"column\".",
+		},
+		{
+			name: "Sign with field name not in headers",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindSign,
+				Fields: []table.FieldRef{{Name: "NotPresent"}},
+			},
+			wantErr: "input must be considered valid by: fields: (0: input must be considered valid by: name: must be one of: [\"Date\", \"Amount\", \"DebitAmt\", \"CreditAmt\", \"TransType\"]. or derivedKind: cannot be blank; name: must be blank..). or credit: cannot be blank; debit: cannot be blank; fields: (0: input must be considered valid by: name: must be one of: [\"Date\", \"Amount\", \"DebitAmt\", \"CreditAmt\", \"TransType\"]. or derivedKind: cannot be blank; name: must be blank..); kind: must equal \"type\". or fields: (0: input must be considered valid by: name: must be one of: [\"Date\", \"Amount\", \"DebitAmt\", \"CreditAmt\", \"TransType\"]. or derivedKind: cannot be blank; name: must be blank..); kind: must equal \"column\".",
+		},
+		{
+			name: "Type missing Credit",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindType,
+				Fields: []table.FieldRef{{Name: "Amount"}, {Name: "TransType"}},
+				Debit:  "DEBIT",
+			},
+			wantErr: "input must be considered valid by: debit: when kind is \"sign\" debit cannot be specified; fields: the length must be exactly 1; kind: must equal \"sign\". or credit: cannot be blank. or debit: when kind is \"column\" debit cannot be specified; kind: must equal \"column\".",
+		},
+		{
+			name: "Type with only one field violates length",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindType,
+				Fields: []table.FieldRef{{Name: "Amount"}},
+				Credit: "CREDIT",
+				Debit:  "DEBIT",
+			},
+			wantErr: "input must be considered valid by: credit: when kind is \"sign\" credit cannot be specified; debit: when kind is \"sign\" debit cannot be specified; kind: must equal \"sign\". or fields: the length must be exactly 2. or credit: when kind is \"column\" credit cannot be specified; debit: when kind is \"column\" debit cannot be specified; fields: the length must be exactly 2; kind: must equal \"column\".",
+		},
+		{
+			name: "Column with Credit set",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindColumn,
+				Fields: []table.FieldRef{{Name: "DebitAmt"}, {Name: "CreditAmt"}},
+				Credit: "X",
+			},
+			wantErr: "input must be considered valid by: credit: when kind is \"sign\" credit cannot be specified; fields: the length must be exactly 1; kind: must equal \"sign\". or debit: cannot be blank; kind: must equal \"type\". or credit: when kind is \"column\" credit cannot be specified.",
+		},
+		{
+			name: "Type with duplicate fields",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindType,
+				Fields: []table.FieldRef{{Name: "Amount"}, {Name: "Amount"}},
+				Credit: "CREDIT",
+				Debit:  "DEBIT",
+			},
+			wantErr: "input must be considered valid by: credit: when kind is \"sign\" credit cannot be specified; debit: when kind is \"sign\" debit cannot be specified; fields: the length must be exactly 1; kind: must equal \"sign\". or fields: fields[1] is a duplicate of an earlier entry. or credit: when kind is \"column\" credit cannot be specified; debit: when kind is \"column\" debit cannot be specified; fields: fields[1] is a duplicate of an earlier entry; kind: must equal \"column\".",
+		},
+		{
+			name: "Column with duplicate fields",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindColumn,
+				Fields: []table.FieldRef{{Name: "Amount"}, {Name: "Amount"}},
+			},
+			wantErr: "input must be considered valid by: fields: the length must be exactly 1; kind: must equal \"sign\". or credit: cannot be blank; debit: cannot be blank; fields: fields[1] is a duplicate of an earlier entry; kind: must equal \"type\". or fields: fields[1] is a duplicate of an earlier entry.",
+		},
+		{
+			// Regression guard: an empty Kind used to pass the Column branch because
+			// that branch only had validation.In(AmountKindColumn) with no Required;
+			// In allows empty values. After Required was added to the Column branch's
+			// Kind rule, all three branches now reject an empty Kind even when the
+			// rest of the shape happens to look like a valid Column spec.
+			name: "empty Kind with valid Column-shaped Fields",
+			spec: table.AmountSpec{
+				Fields: []table.FieldRef{{Name: "DebitAmt"}, {Name: "CreditAmt"}},
+			},
+			wantErr: "input must be considered valid by: fields: the length must be exactly 1; kind: must equal \"sign\". or credit: cannot be blank; debit: cannot be blank; kind: must equal \"type\". or kind: must equal \"column\".",
+		},
+		{
+			// Credit at exactly 100 chars; upper boundary of Length(1, 100).
+			name: "Type with Credit at max length boundary",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindType,
+				Fields: []table.FieldRef{{Name: "Amount"}, {Name: "TransType"}},
+				Credit: strings.Repeat("A", 100),
+				Debit:  "DEBIT",
+			},
+			wantErr: "",
+		},
+		{
+			// Debit at exactly 100 chars; upper boundary of Length(1, 100).
+			name: "Type with Debit at max length boundary",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindType,
+				Fields: []table.FieldRef{{Name: "Amount"}, {Name: "TransType"}},
+				Credit: "CREDIT",
+				Debit:  strings.Repeat("A", 100),
+			},
+			wantErr: "",
+		},
+		{
+			name: "Type with Credit exceeds max length",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindType,
+				Fields: []table.FieldRef{{Name: "Amount"}, {Name: "TransType"}},
+				Credit: strings.Repeat("A", 101),
+				Debit:  "DEBIT",
+			},
+			wantErr: "input must be considered valid by: credit: when kind is \"sign\" credit cannot be specified; debit: when kind is \"sign\" debit cannot be specified; fields: the length must be exactly 1; kind: must equal \"sign\". or credit: the length must be between 1 and 100. or credit: when kind is \"column\" credit cannot be specified; debit: when kind is \"column\" debit cannot be specified; kind: must equal \"column\".",
+		},
+		{
+			name: "Type with Debit exceeds max length",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindType,
+				Fields: []table.FieldRef{{Name: "Amount"}, {Name: "TransType"}},
+				Credit: "CREDIT",
+				Debit:  strings.Repeat("A", 101),
+			},
+			wantErr: "input must be considered valid by: credit: when kind is \"sign\" credit cannot be specified; debit: when kind is \"sign\" debit cannot be specified; fields: the length must be exactly 1; kind: must equal \"sign\". or debit: the length must be between 1 and 100. or credit: when kind is \"column\" credit cannot be specified; debit: when kind is \"column\" debit cannot be specified; kind: must equal \"column\".",
+		},
+		{
+			// Tab is ASCII but not printable ASCII; the recent switch from is.ASCII
+			// to is.PrintableASCII on Credit is what catches this.
+			name: "Type with Credit containing tab",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindType,
+				Fields: []table.FieldRef{{Name: "Amount"}, {Name: "TransType"}},
+				Credit: "CR\tEDIT",
+				Debit:  "DEBIT",
+			},
+			wantErr: "input must be considered valid by: credit: when kind is \"sign\" credit cannot be specified; debit: when kind is \"sign\" debit cannot be specified; fields: the length must be exactly 1; kind: must equal \"sign\". or credit: must contain printable ASCII characters only. or credit: when kind is \"column\" credit cannot be specified; debit: when kind is \"column\" debit cannot be specified; kind: must equal \"column\".",
+		},
+		{
+			name: "Type with Debit containing non-ASCII",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindType,
+				Fields: []table.FieldRef{{Name: "Amount"}, {Name: "TransType"}},
+				Credit: "CREDIT",
+				Debit:  "Débit",
+			},
+			wantErr: "input must be considered valid by: credit: when kind is \"sign\" credit cannot be specified; debit: when kind is \"sign\" debit cannot be specified; fields: the length must be exactly 1; kind: must equal \"sign\". or debit: must contain printable ASCII characters only. or credit: when kind is \"column\" credit cannot be specified; debit: when kind is \"column\" debit cannot be specified; kind: must equal \"column\".",
+		},
+		{
+			// Type-branch Each coverage: second field is a blank FieldRef (first is
+			// valid). Every other rule in the Type branch passes; Each surfaces the
+			// invalid child via index 1.
+			name: "Type with second child blank FieldRef",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindType,
+				Fields: []table.FieldRef{{Name: "Amount"}, {}},
+				Credit: "CREDIT",
+				Debit:  "DEBIT",
+			},
+			wantErr: "input must be considered valid by: credit: when kind is \"sign\" credit cannot be specified; debit: when kind is \"sign\" debit cannot be specified; fields: (1: input must be considered valid by: name: cannot be blank. or derivedKind: cannot be blank..); kind: must equal \"sign\". or fields: (1: input must be considered valid by: name: cannot be blank. or derivedKind: cannot be blank..). or credit: when kind is \"column\" credit cannot be specified; debit: when kind is \"column\" debit cannot be specified; fields: (1: input must be considered valid by: name: cannot be blank. or derivedKind: cannot be blank..); kind: must equal \"column\".",
+		},
+		{
+			// Column-branch Each coverage: first field references a column
+			// that isn't in the context.
+			name: "Column with first child name not in headers",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindColumn,
+				Fields: []table.FieldRef{{Name: "NotPresent"}, {Name: "CreditAmt"}},
+			},
+			wantErr: "input must be considered valid by: fields: (0: input must be considered valid by: name: must be one of: [\"Date\", \"Amount\", \"DebitAmt\", \"CreditAmt\", \"TransType\"]. or derivedKind: cannot be blank; name: must be blank..); kind: must equal \"sign\". or credit: cannot be blank; debit: cannot be blank; fields: (0: input must be considered valid by: name: must be one of: [\"Date\", \"Amount\", \"DebitAmt\", \"CreditAmt\", \"TransType\"]. or derivedKind: cannot be blank; name: must be blank..); kind: must equal \"type\". or fields: (0: input must be considered valid by: name: must be one of: [\"Date\", \"Amount\", \"DebitAmt\", \"CreditAmt\", \"TransType\"]. or derivedKind: cannot be blank; name: must be blank..).",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.spec.Validate(ctx)
+			if tc.wantErr == "" {
+				assert.NoError(t, err, "AmountSpec must be accepted")
+			} else {
+				assert.EqualError(t, err, tc.wantErr, "AmountSpec must be rejected with the expected message")
+			}
+		})
+	}
+}

--- a/server/datasources/table/balance.go
+++ b/server/datasources/table/balance.go
@@ -1,0 +1,76 @@
+package table
+
+import (
+	"context"
+
+	"github.com/monetr/monetr/server/validators"
+	"github.com/monetr/validation"
+)
+
+type BalanceKind string
+
+const (
+	// BalanceKindNone means that balance will not be adjusted at all as part of
+	// this import.
+	BalanceKindNone BalanceKind = "none"
+	// BalanceKindField means that the balance will be derived from the most
+	// recent field in the import.
+	BalanceKindField BalanceKind = "field"
+	// BalanceKindSum means the balance will be adjusted based on the sum of the
+	// transactions being added. Transactions that already exist will not count
+	// towards the balance adjustment.
+	BalanceKindSum BalanceKind = "sum"
+)
+
+// BalanceSpec determines how we will figure out balance adjustments for the
+// imported file. Potentially a no-op depending on [BalanceSpec.Kind].
+type BalanceSpec struct {
+	// Kind determines how balance will be treated for this document.
+	Kind BalanceKind `json:"kind"`
+	// Field is the name of the balance field if we are deriving a balance from a
+	// specific field.
+	Fields []FieldRef `json:"fields,omitempty"`
+}
+
+func (s *BalanceSpec) Validate(ctx context.Context) error {
+	return validators.OneOfStruct(
+		ctx,
+		s,
+		// If [BalanceSpec.Kind] is [BalanceKindNone] or [BalanceKindSum] then
+		// don't allow a field to be provided.
+		[]*validation.FieldRules{
+			validation.Field(
+				&s.Kind,
+				validators.In(
+					BalanceKindNone,
+					BalanceKindSum,
+				),
+				validation.Required,
+			),
+			validation.Field(
+				&s.Fields,
+				validation.Empty,
+			),
+		},
+		// If [BalanceSpec.Kind] is [BalanceKindField] then require that a field
+		// is specified.
+		[]*validation.FieldRules{
+			validation.Field(
+				&s.Kind,
+				validators.Eq(BalanceKindField),
+				validation.Required,
+			),
+			validation.Field(
+				&s.Fields,
+				validation.Each(
+					validators.By(func(ctx context.Context, field FieldRef) error {
+						return field.Validate(ctx)
+					}),
+				),
+				validation.Length(1, 1),
+				validators.Unique[FieldRef](),
+				validation.Required,
+			),
+		},
+	)
+}

--- a/server/datasources/table/balance_test.go
+++ b/server/datasources/table/balance_test.go
@@ -1,0 +1,266 @@
+package table_test
+
+import (
+	"testing"
+
+	"github.com/monetr/monetr/server/datasources/table"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBalanceSpec_Validate(t *testing.T) {
+	// BalanceSpec uses a two-branch JoinErrorMaybe structure:
+	//   Branch 1 (Kind is none or sum): Fields must be empty.
+	//   Branch 2 (Kind is field):       Fields must contain exactly one valid
+	//                                   FieldRef.
+	// At least one branch must succeed for the value to validate. When both
+	// branches fail, their errors are joined with "\n" and the whole thing is
+	// wrapped with "input must be considered valid by: ". Sub-errors within
+	// each branch are sorted alphabetically by JSON tag and separated by "; ".
+	ctx := table.WithColumns(
+		t.Context(),
+		[]string{"Date", "Description", "Amount", "RunningBalance"},
+	)
+	cases := []struct {
+		name    string
+		spec    table.BalanceSpec
+		wantErr string
+	}{
+		// --- Happy paths (at least one branch passes) ---
+		{
+			name: "none with nil Fields",
+			spec: table.BalanceSpec{
+				Kind: table.BalanceKindNone,
+			},
+			wantErr: "",
+		},
+		{
+			name: "none with empty slice Fields",
+			spec: table.BalanceSpec{
+				Kind:   table.BalanceKindNone,
+				Fields: []table.FieldRef{},
+			},
+			wantErr: "",
+		},
+		{
+			name: "sum with nil Fields",
+			spec: table.BalanceSpec{
+				Kind: table.BalanceKindSum,
+			},
+			wantErr: "",
+		},
+		{
+			name: "sum with empty slice Fields",
+			spec: table.BalanceSpec{
+				Kind:   table.BalanceKindSum,
+				Fields: []table.FieldRef{},
+			},
+			wantErr: "",
+		},
+		{
+			name: "field with single named field",
+			spec: table.BalanceSpec{
+				Kind:   table.BalanceKindField,
+				Fields: []table.FieldRef{{Name: "RunningBalance"}},
+			},
+			wantErr: "",
+		},
+		{
+			name: "field with derived row number",
+			spec: table.BalanceSpec{
+				Kind:   table.BalanceKindField,
+				Fields: []table.FieldRef{{DerivedKind: table.DerivedKindRowNumber}},
+			},
+			wantErr: "",
+		},
+		{
+			name: "field with derived row number per day",
+			spec: table.BalanceSpec{
+				Kind:   table.BalanceKindField,
+				Fields: []table.FieldRef{{DerivedKind: table.DerivedKindRowNumberPerDay}},
+			},
+			wantErr: "",
+		},
+		{
+			name: "field with derived row number per day per amount",
+			spec: table.BalanceSpec{
+				Kind:   table.BalanceKindField,
+				Fields: []table.FieldRef{{DerivedKind: table.DerivedKindRowNumberPerDayPerAmount}},
+			},
+			wantErr: "",
+		},
+
+		// --- Cross-validation: Kind and Fields must agree ---
+		{
+			// Rejected because none forbids fields (branch 1) and the kind isn't
+			// "field" (branch 2). Previously accepted under the single-branch schema;
+			// its rejection is the primary reason for this rewrite.
+			name: "none with a single field",
+			spec: table.BalanceSpec{
+				Kind:   table.BalanceKindNone,
+				Fields: []table.FieldRef{{Name: "RunningBalance"}},
+			},
+			wantErr: "input must be considered valid by: fields: must be blank. or kind: must equal \"field\".",
+		},
+		{
+			name: "sum with a single field",
+			spec: table.BalanceSpec{
+				Kind:   table.BalanceKindSum,
+				Fields: []table.FieldRef{{Name: "RunningBalance"}},
+			},
+			wantErr: "input must be considered valid by: fields: must be blank. or kind: must equal \"field\".",
+		},
+		{
+			// Two-fields cases expose a different branch-2 error (length) than the
+			// single-field cross-validation above, so both are worth distinguishing.
+			name: "none with multiple fields",
+			spec: table.BalanceSpec{
+				Kind:   table.BalanceKindNone,
+				Fields: []table.FieldRef{{Name: "RunningBalance"}, {Name: "Amount"}},
+			},
+			wantErr: "input must be considered valid by: fields: must be blank. or fields: the length must be exactly 1; kind: must equal \"field\".",
+		},
+		{
+			name: "sum with multiple fields",
+			spec: table.BalanceSpec{
+				Kind:   table.BalanceKindSum,
+				Fields: []table.FieldRef{{Name: "RunningBalance"}, {Name: "Amount"}},
+			},
+			wantErr: "input must be considered valid by: fields: must be blank. or fields: the length must be exactly 1; kind: must equal \"field\".",
+		},
+		{
+			name: "field with no Fields",
+			spec: table.BalanceSpec{
+				Kind: table.BalanceKindField,
+			},
+			wantErr: "input must be considered valid by: kind: must be one of: [\"none\", \"sum\"]. or fields: cannot be blank.",
+		},
+		{
+			// An explicitly empty slice is treated the same as nil for Required
+			// because IsEmpty([]) is true.
+			name: "field with empty slice Fields",
+			spec: table.BalanceSpec{
+				Kind:   table.BalanceKindField,
+				Fields: []table.FieldRef{},
+			},
+			wantErr: "input must be considered valid by: kind: must be one of: [\"none\", \"sum\"]. or fields: cannot be blank.",
+		},
+
+		// --- Kind-layer invalid ---
+		{
+			name:    "empty",
+			spec:    table.BalanceSpec{},
+			wantErr: "input must be considered valid by: kind: cannot be blank. or fields: cannot be blank; kind: must equal \"field\".",
+		},
+		{
+			name: "unknown kind with no Fields",
+			spec: table.BalanceSpec{
+				Kind: table.BalanceKind("bogus"),
+			},
+			wantErr: "input must be considered valid by: kind: must be one of: [\"none\", \"sum\"]. or fields: cannot be blank; kind: must equal \"field\".",
+		},
+		{
+			// Branch 2 accepts the field but rejects the kind, so only the kind error
+			// appears in branch 2. Branch 1 rejects both.
+			name: "unknown kind with a valid single field",
+			spec: table.BalanceSpec{
+				Kind:   table.BalanceKind("bogus"),
+				Fields: []table.FieldRef{{Name: "RunningBalance"}},
+			},
+			wantErr: "input must be considered valid by: fields: must be blank; kind: must be one of: [\"none\", \"sum\"]. or kind: must equal \"field\".",
+		},
+
+		// --- Length violation in branch 2 (kind=field with multiple fields) ---
+		{
+			name: "field with two named fields violates length",
+			spec: table.BalanceSpec{
+				Kind:   table.BalanceKindField,
+				Fields: []table.FieldRef{{Name: "RunningBalance"}, {Name: "Amount"}},
+			},
+			wantErr: "input must be considered valid by: fields: must be blank; kind: must be one of: [\"none\", \"sum\"]. or fields: the length must be exactly 1.",
+		},
+		{
+			name: "field with three fields violates length",
+			spec: table.BalanceSpec{
+				Kind:   table.BalanceKindField,
+				Fields: []table.FieldRef{{Name: "RunningBalance"}, {Name: "Amount"}, {Name: "Date"}},
+			},
+			wantErr: "input must be considered valid by: fields: must be blank; kind: must be one of: [\"none\", \"sum\"]. or fields: the length must be exactly 1.",
+		},
+		{
+			// Length(1,1) fails before Unique runs, so the duplicate case reports the
+			// length error rather than the uniqueness error.
+			name: "duplicate fields are caught by length check first",
+			spec: table.BalanceSpec{
+				Kind:   table.BalanceKindField,
+				Fields: []table.FieldRef{{Name: "RunningBalance"}, {Name: "RunningBalance"}},
+			},
+			wantErr: "input must be considered valid by: fields: must be blank; kind: must be one of: [\"none\", \"sum\"]. or fields: the length must be exactly 1.",
+		},
+
+		// --- Child FieldRef invalid (exercises Each inside branch 2) ---
+		{
+			name: "field with blank child FieldRef",
+			spec: table.BalanceSpec{
+				Kind:   table.BalanceKindField,
+				Fields: []table.FieldRef{{}},
+			},
+			wantErr: "input must be considered valid by: fields: must be blank; kind: must be one of: [\"none\", \"sum\"]. or fields: (0: input must be considered valid by: name: cannot be blank. or derivedKind: cannot be blank..).",
+		},
+		{
+			name: "field with child name not in headers",
+			spec: table.BalanceSpec{
+				Kind:   table.BalanceKindField,
+				Fields: []table.FieldRef{{Name: "NotPresent"}},
+			},
+			wantErr: "input must be considered valid by: fields: must be blank; kind: must be one of: [\"none\", \"sum\"]. or fields: (0: input must be considered valid by: name: must be one of: [\"Date\", \"Description\", \"Amount\", \"RunningBalance\"]. or derivedKind: cannot be blank; name: must be blank..).",
+		},
+		{
+			name: "field with child that sets both name and derived kind",
+			spec: table.BalanceSpec{
+				Kind:   table.BalanceKindField,
+				Fields: []table.FieldRef{{Name: "RunningBalance", DerivedKind: table.DerivedKindRowNumber}},
+			},
+			wantErr: "input must be considered valid by: fields: must be blank; kind: must be one of: [\"none\", \"sum\"]. or fields: (0: input must be considered valid by: derivedKind: must be blank. or name: must be blank..).",
+		},
+		{
+			name: "field with child that has unknown derived kind",
+			spec: table.BalanceSpec{
+				Kind:   table.BalanceKindField,
+				Fields: []table.FieldRef{{DerivedKind: table.DerivedKind("bogus")}},
+			},
+			wantErr: "input must be considered valid by: fields: must be blank; kind: must be one of: [\"none\", \"sum\"]. or fields: (0: input must be considered valid by: derivedKind: must be blank; name: cannot be blank. or derivedKind: must be one of: [\"rowNumber\", \"rowNumberPerDay\", \"rowNumberPerDayPerAmount\"]..).",
+		},
+
+		// --- Combined (both kind and fields misbehaving) ---
+		{
+			// Empty kind fails Required in both branches; adding two fields surfaces
+			// the Empty rule in branch 1 and Length in branch 2, so both branches
+			// produce two keys sorted alphabetically.
+			name: "empty kind with two fields",
+			spec: table.BalanceSpec{
+				Fields: []table.FieldRef{{Name: "RunningBalance"}, {Name: "Amount"}},
+			},
+			wantErr: "input must be considered valid by: fields: must be blank; kind: cannot be blank. or fields: the length must be exactly 1; kind: must equal \"field\".",
+		},
+		{
+			name: "unknown kind with invalid child",
+			spec: table.BalanceSpec{
+				Kind:   table.BalanceKind("bogus"),
+				Fields: []table.FieldRef{{}},
+			},
+			wantErr: "input must be considered valid by: fields: must be blank; kind: must be one of: [\"none\", \"sum\"]. or fields: (0: input must be considered valid by: name: cannot be blank. or derivedKind: cannot be blank..); kind: must equal \"field\".",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.spec.Validate(ctx)
+			if tc.wantErr == "" {
+				assert.NoError(t, err, "BalanceSpec must be accepted")
+			} else {
+				assert.EqualError(t, err, tc.wantErr, "BalanceSpec must be rejected with the expected message")
+			}
+		})
+	}
+}

--- a/server/datasources/table/date.go
+++ b/server/datasources/table/date.go
@@ -1,0 +1,63 @@
+package table
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/monetr/monetr/server/validators"
+	"github.com/monetr/validation"
+	"github.com/pkg/errors"
+)
+
+type DateSpec struct {
+	Fields []FieldRef `json:"fields"`
+	// Format specified the date format to use for parsing dates from the CSV
+	// file. These are stored in a format like `YYYY-MM-DD` or `MM/DD/YYYY` or
+	// something of the sort, and then converted to Go's date format when the file
+	// is actually processed.
+	Format string `json:"format"`
+}
+
+func (s *DateSpec) Validate(ctx context.Context) error {
+	return errors.Wrapf(
+		validation.ValidateStructWithContext(
+			ctx,
+			s,
+			validation.Field(
+				&s.Fields,
+				validation.Each(
+					validators.By(func(ctx context.Context, field FieldRef) error {
+						return field.Validate(ctx)
+					}),
+				),
+				validation.Length(1, 1),
+				validators.Unique[FieldRef](),
+				validation.Required,
+			),
+			validation.Field(
+				&s.Format,
+				// We want to be able to convert a human readable date format such as
+				// `YYYY-MM-DD` into golangs date format such as `2006-01-02`.
+				// Validate that the year format, YY or YYYY can only happen once in the
+				// string.
+				validation.Match(regexp.MustCompile(`^[^Y]*(?:YYYY|YY){1}[^Y]*$`)).
+					Error("Date format does not include the year"),
+				// Validate that they month format, M or MM can only happen once in the
+				// string.
+				validation.Match(regexp.MustCompile(`^[^M]*(?:MM|M){1}[^M]*$`)).
+					Error("Date format does not include the month"),
+				// Validate that the day format, D or DD can only happen once in the
+				// string.
+				validation.Match(regexp.MustCompile(`^[^D]*(?:DD|D){1}[^D]*$`)).
+					Error("Date format does not include the day of the month"),
+				// Validate that only these characters are allowed in the string at all.
+				validation.Match(regexp.MustCompile(`^(Y|M|D|\.| |-|/)+$`)).
+					Error("Date format contains invalid characters"),
+				validation.Length(6, 10),
+				validation.Required,
+			),
+		),
+		"failed to validate %T",
+		s,
+	)
+}

--- a/server/datasources/table/date_test.go
+++ b/server/datasources/table/date_test.go
@@ -1,0 +1,275 @@
+package table_test
+
+import (
+	"testing"
+
+	"github.com/monetr/monetr/server/datasources/table"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDateSpec_Validate(t *testing.T) {
+	// DateSpec must have exactly one FieldRef (valid against the column set in
+	// context) and a non-empty human-readable Format like YYYY-MM-DD.
+	ctx := table.WithColumns(
+		t.Context(),
+		[]string{"Date", "PostDate", "Amount"},
+	)
+	cases := []struct {
+		name    string
+		spec    table.DateSpec
+		wantErr string
+	}{
+		{
+			name: "YYYY-MM-DD",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YYYY-MM-DD",
+			},
+			wantErr: "",
+		},
+		{
+			name: "MM/DD/YYYY",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "MM/DD/YYYY",
+			},
+			wantErr: "",
+		},
+		{
+			name: "M/D/YYYY single-digit month and day",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "M/D/YYYY",
+			},
+			wantErr: "",
+		},
+		{
+			name: "DD-MM-YY two-digit year",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "DD-MM-YY",
+			},
+			wantErr: "",
+		},
+		{
+			name:    "empty",
+			spec:    table.DateSpec{},
+			wantErr: "failed to validate *table.DateSpec: fields: cannot be blank; format: cannot be blank.",
+		},
+		{
+			name:    "missing fields",
+			spec:    table.DateSpec{Format: "YYYY-MM-DD"},
+			wantErr: "failed to validate *table.DateSpec: fields: cannot be blank.",
+		},
+		{
+			name: "missing format",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+			},
+			wantErr: "failed to validate *table.DateSpec: format: cannot be blank.",
+		},
+		{
+			name: "two fields violates length",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}, {Name: "PostDate"}},
+				Format: "YYYY-MM-DD",
+			},
+			wantErr: "failed to validate *table.DateSpec: fields: the length must be exactly 1.",
+		},
+		{
+			name: "field name not in headers",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "NotPresent"}},
+				Format: "YYYY-MM-DD",
+			},
+			wantErr: "failed to validate *table.DateSpec: fields: (0: input must be considered valid by: name: must be one of: [\"Date\", \"PostDate\", \"Amount\"]. or derivedKind: cannot be blank; name: must be blank..).",
+		},
+		{
+			name: "field with both name and derived kind set",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date", DerivedKind: table.DerivedKindRowNumber}},
+				Format: "YYYY-MM-DD",
+			},
+			wantErr: "failed to validate *table.DateSpec: fields: (0: input must be considered valid by: derivedKind: must be blank. or name: must be blank..).",
+		},
+		{
+			name: "format is purely junk letters",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "hello",
+			},
+			wantErr: "failed to validate *table.DateSpec: format: Date format does not include the year.",
+		},
+		{
+			name: "format is only separators",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "---",
+			},
+			wantErr: "failed to validate *table.DateSpec: format: Date format does not include the year.",
+		},
+		{
+			name: "format missing day component",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YYYY-MM",
+			},
+			wantErr: "failed to validate *table.DateSpec: format: Date format does not include the day of the month.",
+		},
+		{
+			name: "format missing year component",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "MM-DD",
+			},
+			wantErr: "failed to validate *table.DateSpec: format: Date format does not include the year.",
+		},
+		{
+			name: "format missing month component",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YYYY-DD",
+			},
+			wantErr: "failed to validate *table.DateSpec: format: Date format does not include the month.",
+		},
+		{
+			name: "format has two year tokens",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YYYY-YY-MM-DD",
+			},
+			wantErr: "failed to validate *table.DateSpec: format: Date format does not include the year.",
+		},
+		{
+			// YYYY-MM-MM is exactly 10 chars, so Length passes and the input drives
+			// the month regex straight into its "exactly one" failure.
+			name: "format has two month tokens",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YYYY-MM-MM",
+			},
+			wantErr: "failed to validate *table.DateSpec: format: Date format does not include the month.",
+		},
+		{
+			name: "format has two day tokens",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YYYY-MM-DD-DD",
+			},
+			wantErr: "failed to validate *table.DateSpec: format: Date format does not include the day of the month.",
+		},
+		{
+			name: "format has three Y run (neither YY nor YYYY)",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YYY-MM-DD",
+			},
+			wantErr: "failed to validate *table.DateSpec: format: Date format does not include the year.",
+		},
+		{
+			name: "format has five Y run",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YYYYY-MM-DD",
+			},
+			wantErr: "failed to validate *table.DateSpec: format: Date format does not include the year.",
+		},
+		{
+			name: "format has three M run",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YYYY-MMM-DD",
+			},
+			wantErr: "failed to validate *table.DateSpec: format: Date format does not include the month.",
+		},
+		{
+			name: "format has three D run",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YYYY-MM-DDD",
+			},
+			wantErr: "failed to validate *table.DateSpec: format: Date format does not include the day of the month.",
+		},
+		{
+			// 13 chars but the chars whitelist trips before the length rule, so the
+			// foreign letter surfaces as the explicit character-class error.
+			name: "format contains foreign uppercase letter",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YYYY-HH-MM-DD",
+			},
+			wantErr: "failed to validate *table.DateSpec: format: Date format contains invalid characters.",
+		},
+		{
+			// Lowercase m is not in the whitelist, but the month regex (which runs
+			// before the char whitelist) fires first because [^M]* matches lowercase
+			// runs and never finds an uppercase M.
+			name: "format contains lowercase m instead of uppercase M",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YYYY-mm-DD",
+			},
+			wantErr: "failed to validate *table.DateSpec: format: Date format does not include the month.",
+		},
+		{
+			// Five characters: every Match rule passes but Length (6, 10) fails.
+			name: "format shorter than minimum length",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YYMMD",
+			},
+			wantErr: "failed to validate *table.DateSpec: format: the length must be between 6 and 10.",
+		},
+		{
+			// Eleven characters: every Match rule passes but Length (6, 10) fails.
+			// Also covers the "trailing separator" footgun from earlier probing.
+			name: "format longer than maximum length",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YYYY-MM-DD.",
+			},
+			wantErr: "failed to validate *table.DateSpec: format: the length must be between 6 and 10.",
+		},
+		{
+			name: "format shortest valid",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YY-M-D",
+			},
+			wantErr: "",
+		},
+		{
+			// All three separator classes (period, slash, dash) mixed in a single
+			// format; accepted because the char whitelist allows any combination of
+			// them.
+			name: "format with mixed separators",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YY.MM/DD",
+			},
+			wantErr: "",
+		},
+		{
+			// Space is in the separator whitelist, so space-separated formats
+			// validate even though they're unusual.
+			name: "format with space separator",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YY MM DD",
+			},
+			wantErr: "",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.spec.Validate(ctx)
+			if tc.wantErr == "" {
+				assert.NoError(t, err, "DateSpec must be accepted")
+			} else {
+				assert.EqualError(t, err, tc.wantErr, "DateSpec must be rejected with the expected message")
+			}
+		})
+	}
+}

--- a/server/datasources/table/doc.go
+++ b/server/datasources/table/doc.go
@@ -1,0 +1,3 @@
+// Package table contains helpers necessary for taking generic table imports
+// such as CSV or XLSX files and importing that data into monetr.
+package table

--- a/server/datasources/table/field.go
+++ b/server/datasources/table/field.go
@@ -1,0 +1,73 @@
+package table
+
+import (
+	"context"
+
+	"github.com/monetr/monetr/server/validators"
+	"github.com/monetr/validation"
+	"github.com/monetr/validation/is"
+)
+
+type DerivedKind string
+
+const (
+	// DerivedKindRowNumber is used to generate a 0 indexed row number starting
+	// from the bottom of the file to the top of the file. This row number isn't
+	// exactly stable since new rows are added and old rows are eventually
+	// removed.
+	DerivedKindRowNumber DerivedKind = "rowNumber"
+	// DerivedKindRowNumberPerDay is the 0 indexed count of rows per date value.
+	// This is from the bottom to the top of the file.
+	DerivedKindRowNumberPerDay DerivedKind = "rowNumberPerDay"
+	// DerivedKindRowNumberPerDayPerAmount is the 0 indexed count of rows per date
+	// value per amount value. This way if days have all unique transaction
+	// amounts then deduplication is easy. If days have duplicate transaction
+	// amounts then they are deduplicated in order they are observed.
+	DerivedKindRowNumberPerDayPerAmount DerivedKind = "rowNumberPerDayPerAmount"
+)
+
+// FieldRef references a field within the document, or it references a derived
+// field. Not both. Derived fields are generated at processing time and can't be
+// previewed.
+type FieldRef struct {
+	// Name just tells us the name of the field to derive the value from. This can
+	// be blank if we are deriving a value instead.
+	Name string `json:"name,omitempty"`
+	// DerivedKind specifies that this value should come from a calculated field
+	// instead of from a named field.
+	DerivedKind DerivedKind `json:"derivedKind,omitempty"`
+}
+
+func (s *FieldRef) Validate(ctx context.Context) error {
+	return validators.OneOfStruct(
+		ctx,
+		s,
+		[]*validation.FieldRules{
+			validation.Field(
+				&s.Name,
+				validators.In(getColumns(ctx)...),
+				validation.Required,
+				is.PrintableASCII,
+			),
+			validation.Field(
+				&s.DerivedKind,
+				validation.Empty,
+			),
+		},
+		[]*validation.FieldRules{
+			validation.Field(
+				&s.Name,
+				validation.Empty,
+			),
+			validation.Field(
+				&s.DerivedKind,
+				validators.In(
+					DerivedKindRowNumber,
+					DerivedKindRowNumberPerDay,
+					DerivedKindRowNumberPerDayPerAmount,
+				),
+				validation.Required,
+			),
+		},
+	)
+}

--- a/server/datasources/table/field_test.go
+++ b/server/datasources/table/field_test.go
@@ -1,0 +1,103 @@
+package table_test
+
+import (
+	"testing"
+
+	"github.com/monetr/monetr/server/datasources/table"
+	"github.com/monetr/monetr/server/validators"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFieldRef_Validate(t *testing.T) {
+	// A FieldRef must reference exactly one of: a named column (via Name, and
+	// the name must appear in the columns attached to the context), or a derived
+	// value (via DerivedKind restricted to the known constants). Setting both or
+	// neither is rejected, and an unknown DerivedKind value is rejected.
+	ctx := table.WithColumns(
+		t.Context(),
+		[]string{"Date", "Description", "Amount", "Id"},
+	)
+	cases := []struct {
+		name    string
+		ref     table.FieldRef
+		wantErr string
+	}{
+		{
+			name:    "name only",
+			ref:     table.FieldRef{Name: "Date"},
+			wantErr: "",
+		},
+		{
+			name:    "derived row number",
+			ref:     table.FieldRef{DerivedKind: table.DerivedKindRowNumber},
+			wantErr: "",
+		},
+		{
+			name:    "derived row number per day",
+			ref:     table.FieldRef{DerivedKind: table.DerivedKindRowNumberPerDay},
+			wantErr: "",
+		},
+		{
+			name:    "derived row number per day per amount",
+			ref:     table.FieldRef{DerivedKind: table.DerivedKindRowNumberPerDayPerAmount},
+			wantErr: "",
+		},
+		{
+			name:    "name not in headers",
+			ref:     table.FieldRef{Name: "NotPresent"},
+			wantErr: "input must be considered valid by: name: must be one of: [\"Date\", \"Description\", \"Amount\", \"Id\"]. or derivedKind: cannot be blank; name: must be blank.",
+		},
+		{
+			name:    "empty",
+			ref:     table.FieldRef{},
+			wantErr: "input must be considered valid by: name: cannot be blank. or derivedKind: cannot be blank.",
+		},
+		{
+			name:    "both name and derived kind",
+			ref:     table.FieldRef{Name: "Date", DerivedKind: table.DerivedKindRowNumber},
+			wantErr: "input must be considered valid by: derivedKind: must be blank. or name: must be blank.",
+		},
+		{
+			name:    "unknown derived kind",
+			ref:     table.FieldRef{DerivedKind: table.DerivedKind("bogus")},
+			wantErr: "input must be considered valid by: derivedKind: must be blank; name: cannot be blank. or derivedKind: must be one of: [\"rowNumber\", \"rowNumberPerDay\", \"rowNumberPerDayPerAmount\"].",
+		},
+		{
+			name:    "name set with unknown derived kind",
+			ref:     table.FieldRef{Name: "Date", DerivedKind: table.DerivedKind("bogus")},
+			wantErr: "input must be considered valid by: derivedKind: must be blank. or derivedKind: must be one of: [\"rowNumber\", \"rowNumberPerDay\", \"rowNumberPerDayPerAmount\"]; name: must be blank.",
+		},
+		{
+			// is.PrintableASCII fires before In(columns), so a Name containing tab or
+			// other control characters is rejected regardless of whether a column
+			// with that exact name is present in the context.
+			name:    "name with tab character",
+			ref:     table.FieldRef{Name: "Dat\te"},
+			wantErr: "input must be considered valid by: name: must be one of: [\"Date\", \"Description\", \"Amount\", \"Id\"]. or derivedKind: cannot be blank; name: must be blank.",
+		},
+		{
+			name:    "name with newline character",
+			ref:     table.FieldRef{Name: "Dat\ne"},
+			wantErr: "input must be considered valid by: name: must be one of: [\"Date\", \"Description\", \"Amount\", \"Id\"]. or derivedKind: cannot be blank; name: must be blank.",
+		},
+		{
+			// Non-ASCII codepoint also fails printable ASCII.
+			name:    "name with non-ASCII character",
+			ref:     table.FieldRef{Name: "Café"},
+			wantErr: "input must be considered valid by: name: must be one of: [\"Date\", \"Description\", \"Amount\", \"Id\"]. or derivedKind: cannot be blank; name: must be blank.",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := validators.FlattenValidationError(tc.ref.Validate(ctx))
+
+			if tc.wantErr == "" {
+				assert.NoError(t, err, "FieldRef must be accepted")
+			} else {
+				assert.EqualError(t, err, tc.wantErr, "FieldRef must be rejected with the expected message")
+			}
+		})
+	}
+}

--- a/server/datasources/table/id.go
+++ b/server/datasources/table/id.go
@@ -1,0 +1,64 @@
+package table
+
+import (
+	"context"
+
+	"github.com/monetr/monetr/server/validators"
+	"github.com/monetr/validation"
+	"github.com/pkg/errors"
+)
+
+// IDSpecKind represents the method of uniquly identifying transactions in the
+// provided CSV file.
+type IDSpecKind string
+
+const (
+	// IDSpecKindNative means that a single field within the file represents the
+	// unique identifier, and it can be trusted entirely for de-duplication.
+	IDSpecKindNative IDSpecKind = "native"
+	// IDSpecKindHashed means that a combination of multiple fields within the
+	// file represent the unique identifier.
+	IDSpecKindHashed IDSpecKind = "hashed"
+)
+
+// IDSpec is used to derive the unique identifier for a given transaction row.
+// This generates a hash of the fields provided (including derived fields) in
+// order to determine a unique identifier. This ultimately is fed into the
+// [models.Transaction.UploadIdentifier] field. The [IDSpec.Kind] field
+// indicates whether an existing field should be used plainly, or whether all of
+// the specified fields (or derivatives) should be hashed.
+type IDSpec struct {
+	Kind   IDSpecKind `json:"kind"`
+	Fields []FieldRef `json:"fields"`
+}
+
+func (s *IDSpec) Validate(ctx context.Context) error {
+	return errors.Wrapf(
+		validation.ValidateStructWithContext(
+			ctx,
+			s,
+			validation.Field(
+				&s.Kind,
+				validators.In(
+					IDSpecKindNative,
+					IDSpecKindHashed,
+				),
+				validation.Required,
+			),
+			validation.Field(
+				&s.Fields,
+				validation.Each(
+					validators.By(func(ctx context.Context, field FieldRef) error {
+						return field.Validate(ctx)
+					}),
+				),
+				// Reasonable upper bounds on number of fields.
+				validation.Length(1, 20),
+				validators.Unique[FieldRef](),
+				validation.Required,
+			),
+		),
+		"failed to validate %T",
+		s,
+	)
+}

--- a/server/datasources/table/id_test.go
+++ b/server/datasources/table/id_test.go
@@ -1,0 +1,135 @@
+package table_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/monetr/monetr/server/datasources/table"
+	"github.com/stretchr/testify/assert"
+)
+
+// makeNamedFields builds a slice of n unique FieldRefs whose Name values are
+// formatted from pattern (e.g. "F%02d"). Used to drive length-cap and bulk
+// validation cases.
+func makeNamedFields(pattern string, n int) []table.FieldRef {
+	fields := make([]table.FieldRef, n)
+	for i := range fields {
+		fields[i] = table.FieldRef{Name: fmt.Sprintf(pattern, i)}
+	}
+	return fields
+}
+
+func TestIDSpec_Validate(t *testing.T) {
+	// An IDSpec must have a recognized Kind (native or hashed) and at least one
+	// FieldRef. Each FieldRef inside Fields is validated against the same column
+	// set attached to the context; invalid children surface via validation.Each
+	// wrapped as "fields: (<index>: ...)". The column list is padded to 21 unique
+	// names so the 20-field length cap and duplicate-field cases below have
+	// enough columns to reference.
+	columns := []string{"Date", "Description", "Amount", "Id"}
+	for i := 0; i < 21; i++ {
+		columns = append(columns, fmt.Sprintf("F%02d", i))
+	}
+	ctx := table.WithColumns(t.Context(), columns)
+	cases := []struct {
+		name    string
+		spec    table.IDSpec
+		wantErr string
+	}{
+		{
+			name:    "native with single named field",
+			spec:    table.IDSpec{Kind: table.IDSpecKindNative, Fields: []table.FieldRef{{Name: "Id"}}},
+			wantErr: "",
+		},
+		{
+			name:    "hashed with multiple named fields",
+			spec:    table.IDSpec{Kind: table.IDSpecKindHashed, Fields: []table.FieldRef{{Name: "Date"}, {Name: "Amount"}}},
+			wantErr: "",
+		},
+		{
+			name:    "hashed with mix of named and derived fields",
+			spec:    table.IDSpec{Kind: table.IDSpecKindHashed, Fields: []table.FieldRef{{Name: "Date"}, {DerivedKind: table.DerivedKindRowNumber}}},
+			wantErr: "",
+		},
+		{
+			name:    "empty",
+			spec:    table.IDSpec{},
+			wantErr: "failed to validate *table.IDSpec: fields: cannot be blank; kind: cannot be blank.",
+		},
+		{
+			name:    "unknown kind",
+			spec:    table.IDSpec{Kind: table.IDSpecKind("bogus"), Fields: []table.FieldRef{{Name: "Id"}}},
+			wantErr: "failed to validate *table.IDSpec: kind: must be one of: [\"native\", \"hashed\"].",
+		},
+		{
+			name:    "valid kind with empty fields",
+			spec:    table.IDSpec{Kind: table.IDSpecKindNative, Fields: []table.FieldRef{}},
+			wantErr: "failed to validate *table.IDSpec: fields: cannot be blank.",
+		},
+		{
+			name:    "valid kind with blank child field",
+			spec:    table.IDSpec{Kind: table.IDSpecKindNative, Fields: []table.FieldRef{{}}},
+			wantErr: "failed to validate *table.IDSpec: fields: (0: input must be considered valid by: name: cannot be blank. or derivedKind: cannot be blank..).",
+		},
+		{
+			name:    "valid kind with child field that sets both name and derived kind",
+			spec:    table.IDSpec{Kind: table.IDSpecKindNative, Fields: []table.FieldRef{{Name: "Id", DerivedKind: table.DerivedKindRowNumber}}},
+			wantErr: "failed to validate *table.IDSpec: fields: (0: input must be considered valid by: derivedKind: must be blank. or name: must be blank..).",
+		},
+		{
+			name:    "valid kind with child name not in headers",
+			spec:    table.IDSpec{Kind: table.IDSpecKindNative, Fields: []table.FieldRef{{Name: "NotPresent"}}},
+			wantErr: "failed to validate *table.IDSpec: fields: (0: input must be considered valid by: name: must be one of: [\"Date\", \"Description\", \"Amount\", \"Id\", \"F00\", \"F01\", \"F02\", \"F03\", \"F04\", \"F05\", \"F06\", \"F07\", \"F08\", \"F09\", \"F10\", \"F11\", \"F12\", \"F13\", \"F14\", \"F15\", \"F16\", \"F17\", \"F18\", \"F19\", \"F20\"]. or derivedKind: cannot be blank; name: must be blank..).",
+		},
+		{
+			// 20 unique fields; exactly at the Length(1, 20) upper bound.
+			name: "hashed with 20 unique named fields at upper bound",
+			spec: table.IDSpec{
+				Kind:   table.IDSpecKindHashed,
+				Fields: makeNamedFields("F%02d", 20),
+			},
+			wantErr: "",
+		},
+		{
+			// 21 unique fields; exceeds the cap.
+			name: "hashed with 21 unique named fields exceeds upper bound",
+			spec: table.IDSpec{
+				Kind:   table.IDSpecKindHashed,
+				Fields: makeNamedFields("F%02d", 21),
+			},
+			wantErr: "failed to validate *table.IDSpec: fields: the length must be between 1 and 20.",
+		},
+		{
+			// Two identical FieldRefs pass Length (2 is in [1, 20]) so Unique is what
+			// rejects them. This path isn't reachable from any other IDSpec case
+			// today because length was previously unbounded.
+			name: "hashed with duplicate fields",
+			spec: table.IDSpec{
+				Kind:   table.IDSpecKindHashed,
+				Fields: []table.FieldRef{{Name: "Id"}, {Name: "Id"}},
+			},
+			wantErr: "failed to validate *table.IDSpec: fields: fields[1] is a duplicate of an earlier entry.",
+		},
+		{
+			// Two identical derived FieldRefs fail Unique the same way.
+			name: "hashed with duplicate derived fields",
+			spec: table.IDSpec{
+				Kind:   table.IDSpecKindHashed,
+				Fields: []table.FieldRef{{DerivedKind: table.DerivedKindRowNumber}, {DerivedKind: table.DerivedKindRowNumber}},
+			},
+			wantErr: "failed to validate *table.IDSpec: fields: fields[1] is a duplicate of an earlier entry.",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.spec.Validate(ctx)
+			if tc.wantErr == "" {
+				assert.NoError(t, err, "IDSpec must be accepted")
+			} else {
+				assert.EqualError(t, err, tc.wantErr, "IDSpec must be rejected with the expected message")
+			}
+		})
+	}
+}

--- a/server/datasources/table/mapping.go
+++ b/server/datasources/table/mapping.go
@@ -1,0 +1,121 @@
+package table
+
+import (
+	"context"
+
+	"github.com/monetr/monetr/server/validators"
+	"github.com/monetr/validation"
+	"github.com/monetr/validation/is"
+	"github.com/pkg/errors"
+)
+
+// TODO FOR LATER: Row number per date must be in descending order. That is the
+// row at the top of the file for a given date must be 0. this way as rows fall
+// off the bottom of the file the row number for that date and transaction that
+// remains is not affected. This will also need to be per amount
+// OR Do it from the bottom up, but then after the first import you might need
+// to throw away the oldest date as it could be partial data. So always go to
+// the next date in the file to ensure uniqueness can be preserved.
+
+// Mapping stores the actual mapping data that we will both persist to the
+// database as well as receive from a client's request. Validating this is going
+// to be a pain in the ass.
+type Mapping struct {
+	ID       IDSpec      `json:"id"`
+	Amount   AmountSpec  `json:"amount"`
+	Memo     FieldRef    `json:"memo"`
+	Merchant *FieldRef   `json:"merchant,omitempty"`
+	Date     DateSpec    `json:"date"`
+	Posted   *PostedSpec `json:"posted,omitempty"`
+	Balance  BalanceSpec `json:"balance"`
+	Headers  []string    `json:"headers"`
+}
+
+func (m *Mapping) Validate(ctx context.Context) error {
+	innerCtx := WithColumns(ctx, m.Headers)
+	return errors.Wrapf(
+		validation.ValidateStructWithContext(
+			innerCtx,
+			m,
+			validation.Field(
+				&m.ID,
+				validators.By(func(ctx context.Context, field IDSpec) error {
+					return field.Validate(ctx)
+				}),
+				validation.Required,
+			),
+			validation.Field(
+				&m.Amount,
+				validators.By(func(ctx context.Context, field AmountSpec) error {
+					return field.Validate(ctx)
+				}),
+				validation.Required,
+			),
+			validation.Field(
+				&m.Memo,
+				validators.By(func(ctx context.Context, field FieldRef) error {
+					return field.Validate(ctx)
+				}),
+				validation.Required,
+			),
+			validation.Field(
+				&m.Merchant,
+				validators.By(func(ctx context.Context, field *FieldRef) error {
+					if field == nil {
+						return nil
+					}
+					return field.Validate(ctx)
+				}),
+			),
+			validation.Field(
+				&m.Date,
+				validators.By(func(ctx context.Context, field DateSpec) error {
+					return field.Validate(ctx)
+				}),
+				validation.Required,
+			),
+			validation.Field(
+				&m.Posted,
+				validators.By(func(ctx context.Context, field *PostedSpec) error {
+					if field == nil {
+						return nil
+					}
+					return field.Validate(ctx)
+				}),
+			),
+			validation.Field(
+				&m.Balance,
+				validators.By(func(ctx context.Context, field BalanceSpec) error {
+					return field.Validate(ctx)
+				}),
+				validation.Required,
+			),
+			validation.Field(
+				&m.Headers,
+				validation.Length(1, 20),
+				validators.Unique[string](),
+				validation.Each(
+					is.PrintableASCII,
+					validation.Length(1, 100),
+					validation.Required,
+				),
+				validation.Required,
+			),
+		),
+		"failed to validate %T",
+		m,
+	)
+}
+
+func WithColumns(ctx context.Context, columns []string) context.Context {
+	return context.WithValue(ctx, FieldRef{}, columns)
+}
+
+func getColumns(ctx context.Context) []string {
+	columns, ok := ctx.Value(FieldRef{}).([]string)
+	if ok {
+		return columns
+	}
+
+	return []string{}
+}

--- a/server/datasources/table/mapping_test.go
+++ b/server/datasources/table/mapping_test.go
@@ -1,0 +1,360 @@
+package table_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/monetr/monetr/server/datasources/table"
+	"github.com/monetr/monetr/server/validators"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapping_Validate(t *testing.T) {
+	// Mapping.Validate composes the per-sub-spec validators and injects the
+	// mapping's own Headers into the context. Each sub-spec's error is nested
+	// under its JSON tag (id, amount, memo, merchant, date, posted, balance)
+	// and keys are emitted alphabetically. Merchant and Posted short-circuit
+	// to no error when nil; non-nil values must satisfy their respective
+	// validators.
+
+	// Build a fresh fully-valid Mapping per case so a single test's mutation
+	// cannot leak into other cases through shared slices or pointers.
+	validMapping := func() table.Mapping {
+		return table.Mapping{
+			ID: table.IDSpec{
+				Kind:   table.IDSpecKindNative,
+				Fields: []table.FieldRef{{Name: "Id"}},
+			},
+			Amount: table.AmountSpec{
+				Kind:   table.AmountKindSign,
+				Fields: []table.FieldRef{{Name: "Amount"}},
+			},
+			Memo: table.FieldRef{Name: "Description"},
+			Date: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YYYY-MM-DD",
+			},
+			Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+			Headers: []string{
+				"Date",
+				"Description",
+				"Amount",
+				"Id",
+				"TransType",
+				"DebitAmt",
+				"CreditAmt",
+				"Merchant",
+				"Status",
+				"RunningBalance",
+			},
+		}
+	}
+
+	cases := []struct {
+		name    string
+		mutate  func(m *table.Mapping)
+		wantErr string
+	}{
+		{
+			name:   "minimal valid mapping without optional fields",
+			mutate: func(*table.Mapping) {},
+		},
+		{
+			name: "valid mapping with Merchant set",
+			mutate: func(m *table.Mapping) {
+				m.Merchant = &table.FieldRef{Name: "Merchant"}
+			},
+		},
+		{
+			name: "valid mapping with Posted set",
+			mutate: func(m *table.Mapping) {
+				m.Posted = &table.PostedSpec{
+					Fields: []table.FieldRef{{Name: "Status"}},
+					Posted: "POSTED",
+				}
+			},
+		},
+		{
+			name: "valid mapping with Merchant and Posted both set",
+			mutate: func(m *table.Mapping) {
+				m.Merchant = &table.FieldRef{Name: "Merchant"}
+				m.Posted = &table.PostedSpec{
+					Fields: []table.FieldRef{{Name: "Status"}},
+					Posted: "POSTED",
+				}
+			},
+		},
+		{
+			name: "valid mapping with derived id field",
+			mutate: func(m *table.Mapping) {
+				m.ID = table.IDSpec{
+					Kind:   table.IDSpecKindHashed,
+					Fields: []table.FieldRef{{Name: "Date"}, {DerivedKind: table.DerivedKindRowNumberPerDay}},
+				}
+			},
+		},
+		{
+			name: "valid mapping with AmountKindType",
+			mutate: func(m *table.Mapping) {
+				m.Amount = table.AmountSpec{
+					Kind:   table.AmountKindType,
+					Fields: []table.FieldRef{{Name: "Amount"}, {Name: "TransType"}},
+					Credit: "CREDIT",
+					Debit:  "DEBIT",
+				}
+			},
+		},
+		{
+			name: "valid mapping with AmountKindColumn",
+			mutate: func(m *table.Mapping) {
+				m.Amount = table.AmountSpec{
+					Kind:   table.AmountKindColumn,
+					Fields: []table.FieldRef{{Name: "DebitAmt"}, {Name: "CreditAmt"}},
+				}
+			},
+		},
+		{
+			name: "valid mapping with Balance derived from a field",
+			mutate: func(m *table.Mapping) {
+				m.Balance = table.BalanceSpec{
+					Kind:   table.BalanceKindField,
+					Fields: []table.FieldRef{{Name: "RunningBalance"}},
+				}
+			},
+		},
+		{
+			name:    "empty mapping surfaces every required sub-spec error",
+			mutate:  func(m *table.Mapping) { *m = table.Mapping{} },
+			wantErr: "failed to validate *table.Mapping: amount: input must be considered valid by: fields: cannot be blank; kind: must equal \"sign\". or credit: cannot be blank; debit: cannot be blank; fields: cannot be blank; kind: must equal \"type\". or fields: cannot be blank; kind: must equal \"column\".; balance: input must be considered valid by: kind: cannot be blank. or fields: cannot be blank; kind: must equal \"field\".; date: failed to validate *table.DateSpec: fields: cannot be blank; format: cannot be blank.; headers: cannot be blank; id: failed to validate *table.IDSpec: fields: cannot be blank; kind: cannot be blank.; memo: input must be considered valid by: name: cannot be blank. or derivedKind: cannot be blank..",
+		},
+		{
+			name: "invalid ID kind",
+			mutate: func(m *table.Mapping) {
+				m.ID = table.IDSpec{
+					Kind:   table.IDSpecKind("bogus"),
+					Fields: []table.FieldRef{{Name: "Id"}},
+				}
+			},
+			wantErr: "failed to validate *table.Mapping: id: failed to validate *table.IDSpec: kind: must be one of: [\"native\", \"hashed\"]..",
+		},
+		{
+			name: "invalid Amount kind",
+			mutate: func(m *table.Mapping) {
+				m.Amount = table.AmountSpec{
+					Kind:   table.AmountKind("bogus"),
+					Fields: []table.FieldRef{{Name: "Amount"}},
+				}
+			},
+			wantErr: "failed to validate *table.Mapping: amount: input must be considered valid by: kind: must equal \"sign\". or credit: cannot be blank; debit: cannot be blank; fields: the length must be exactly 2; kind: must equal \"type\". or fields: the length must be exactly 2; kind: must equal \"column\"..",
+		},
+		{
+			name: "Memo name not in columns",
+			mutate: func(m *table.Mapping) {
+				m.Memo = table.FieldRef{Name: "NotPresent"}
+			},
+			wantErr: "failed to validate *table.Mapping: memo: input must be considered valid by: name: must be one of: [\"Date\", \"Description\", \"Amount\", \"Id\", \"TransType\", \"DebitAmt\", \"CreditAmt\", \"Merchant\", \"Status\", \"RunningBalance\"]. or derivedKind: cannot be blank; name: must be blank..",
+		},
+		{
+			name: "Merchant name not in columns",
+			mutate: func(m *table.Mapping) {
+				m.Merchant = &table.FieldRef{Name: "NotPresent"}
+			},
+			wantErr: "failed to validate *table.Mapping: merchant: input must be considered valid by: name: must be one of: [\"Date\", \"Description\", \"Amount\", \"Id\", \"TransType\", \"DebitAmt\", \"CreditAmt\", \"Merchant\", \"Status\", \"RunningBalance\"]. or derivedKind: cannot be blank; name: must be blank..",
+		},
+		{
+			name: "invalid Date format",
+			mutate: func(m *table.Mapping) {
+				m.Date = table.DateSpec{
+					Fields: []table.FieldRef{{Name: "Date"}},
+					Format: "nope",
+				}
+			},
+			wantErr: "failed to validate *table.Mapping: date: failed to validate *table.DateSpec: format: Date format does not include the year..",
+		},
+		{
+			name: "invalid Posted (empty PostedSpec)",
+			mutate: func(m *table.Mapping) {
+				m.Posted = &table.PostedSpec{}
+			},
+			wantErr: "failed to validate *table.Mapping: posted: failed to validate *table.PostedSpec: fields: cannot be blank..",
+		},
+		{
+			name: "invalid Balance kind",
+			mutate: func(m *table.Mapping) {
+				m.Balance = table.BalanceSpec{Kind: table.BalanceKind("bogus")}
+			},
+			wantErr: "failed to validate *table.Mapping: balance: input must be considered valid by: kind: must be one of: [\"none\", \"sum\"]. or fields: cannot be blank; kind: must equal \"field\"..",
+		},
+		{
+			name: "invalid ID combined with invalid Balance",
+			mutate: func(m *table.Mapping) {
+				m.ID = table.IDSpec{
+					Kind:   table.IDSpecKind("bogus"),
+					Fields: []table.FieldRef{{Name: "Id"}},
+				}
+				m.Balance = table.BalanceSpec{Kind: table.BalanceKind("bogus")}
+			},
+			wantErr: "failed to validate *table.Mapping: balance: input must be considered valid by: kind: must be one of: [\"none\", \"sum\"]. or fields: cannot be blank; kind: must equal \"field\".; id: failed to validate *table.IDSpec: kind: must be one of: [\"native\", \"hashed\"]..",
+		},
+		{
+			name: "Merchant is invalid but Posted nil is still accepted",
+			mutate: func(m *table.Mapping) {
+				m.Merchant = &table.FieldRef{}
+			},
+			wantErr: "failed to validate *table.Mapping: merchant: input must be considered valid by: name: cannot be blank. or derivedKind: cannot be blank..",
+		},
+		{
+			name: "Posted is invalid but Merchant nil is still accepted",
+			mutate: func(m *table.Mapping) {
+				m.Posted = &table.PostedSpec{
+					Fields: []table.FieldRef{{Name: "Status"}},
+					Posted: "Pösted",
+				}
+			},
+			wantErr: "failed to validate *table.Mapping: posted: failed to validate *table.PostedSpec: posted: must contain printable ASCII characters only..",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			m := validMapping()
+			tc.mutate(&m)
+			err := m.Validate(t.Context())
+			if tc.wantErr == "" {
+				assert.NoError(t, err, "Mapping must be accepted")
+			} else {
+				assert.EqualError(t, err, tc.wantErr, "Mapping must be rejected with the expected message")
+			}
+		})
+	}
+}
+
+func TestMapping_Validate_JSONShape(t *testing.T) {
+	// MarshalErrorTree plus the OneOfError / validation.Errors MarshalJSON
+	// methods should produce a nested JSON tree that mirrors the structure of
+	// the failures: per-field maps for non-union sub-specs, a {"oneOf": [...]}
+	// envelope for union sub-specs, and recursion through nested unions.
+	validMapping := func() table.Mapping {
+		return table.Mapping{
+			ID: table.IDSpec{
+				Kind:   table.IDSpecKindNative,
+				Fields: []table.FieldRef{{Name: "Id"}},
+			},
+			Amount: table.AmountSpec{
+				Kind:   table.AmountKindSign,
+				Fields: []table.FieldRef{{Name: "Amount"}},
+			},
+			Memo: table.FieldRef{Name: "Description"},
+			Date: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YYYY-MM-DD",
+			},
+			Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+			Headers: []string{"Date", "Description", "Amount", "Id"},
+		}
+	}
+
+	t.Run("empty mapping surfaces oneOf for union sub-specs and flat objects for the rest", func(t *testing.T) {
+		m := table.Mapping{}
+		err := m.Validate(t.Context())
+		require.Error(t, err)
+
+		raw, jerr := json.Marshal(validators.MarshalErrorTree(err))
+		require.NoError(t, jerr)
+
+		var decoded struct {
+			Amount struct {
+				OneOf []map[string]string `json:"oneOf"`
+			} `json:"amount"`
+			Balance struct {
+				OneOf []map[string]string `json:"oneOf"`
+			} `json:"balance"`
+			Date map[string]string `json:"date"`
+			ID   map[string]string `json:"id"`
+			Memo struct {
+				OneOf []map[string]string `json:"oneOf"`
+			} `json:"memo"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &decoded))
+
+		assert.Len(t, decoded.Amount.OneOf, 3, "amount has three union variants")
+		assert.Len(t, decoded.Balance.OneOf, 2, "balance has two union variants")
+		assert.Len(t, decoded.Memo.OneOf, 2, "memo (FieldRef) has two union variants")
+		assert.Equal(t, map[string]string{
+			"fields": "cannot be blank",
+			"format": "cannot be blank",
+		}, decoded.Date, "date is not a union, serializes as a flat object")
+		assert.Equal(t, map[string]string{
+			"fields": "cannot be blank",
+			"kind":   "cannot be blank",
+		}, decoded.ID, "id is not a union, serializes as a flat object")
+	})
+
+	t.Run("partial amount: only the sign variant has fields-only error, type and column flag the kind constraint", func(t *testing.T) {
+		// User submits kind=sign with two fields. Variant 1 (sign) only fails
+		// the length-1 check; variants 2 and 3 fail their kind constraint. The
+		// per-variant errors implicitly identify which one was being attempted.
+		m := validMapping()
+		m.Amount = table.AmountSpec{
+			Kind:   table.AmountKindSign,
+			Fields: []table.FieldRef{{Name: "Date"}, {Name: "Amount"}},
+		}
+		err := m.Validate(t.Context())
+		require.Error(t, err)
+
+		raw, jerr := json.Marshal(validators.MarshalErrorTree(err))
+		require.NoError(t, jerr)
+
+		var decoded struct {
+			Amount struct {
+				OneOf []map[string]string `json:"oneOf"`
+			} `json:"amount"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &decoded))
+		require.Len(t, decoded.Amount.OneOf, 3)
+
+		assert.NotContains(t, decoded.Amount.OneOf[0], "kind", "sign variant: kind passes")
+		assert.Equal(t, "the length must be exactly 1", decoded.Amount.OneOf[0]["fields"])
+		assert.Equal(t, `must equal "type"`, decoded.Amount.OneOf[1]["kind"], "type variant: kind fails")
+		assert.Equal(t, `must equal "column"`, decoded.Amount.OneOf[2]["kind"], "column variant: kind fails")
+	})
+
+	t.Run("nested union: a FieldRef union nested inside an AmountSpec union recurses correctly", func(t *testing.T) {
+		// A FieldRef with neither name nor derivedKind sits inside the sign
+		// variant's fields[0]. The inner FieldRef.Validate returns its own
+		// OneOfError, which must serialize as a nested {"oneOf": [...]} under
+		// the outer amount.oneOf[0].fields path.
+		m := validMapping()
+		m.Amount = table.AmountSpec{
+			Kind:   table.AmountKindSign,
+			Fields: []table.FieldRef{{}},
+		}
+		err := m.Validate(t.Context())
+		require.Error(t, err)
+
+		raw, jerr := json.Marshal(validators.MarshalErrorTree(err))
+		require.NoError(t, jerr)
+
+		// fields key here can be either a string (top-level error) or a nested
+		// object describing the per-element FieldRef failure. Decode loosely.
+		var decoded struct {
+			Amount struct {
+				OneOf []map[string]json.RawMessage `json:"oneOf"`
+			} `json:"amount"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &decoded))
+		require.Len(t, decoded.Amount.OneOf, 3)
+
+		signFields, ok := decoded.Amount.OneOf[0]["fields"]
+		require.True(t, ok, "sign variant should report a fields error")
+
+		var indexed map[string]struct {
+			OneOf []map[string]string `json:"oneOf"`
+		}
+		require.NoError(t, json.Unmarshal(signFields, &indexed))
+		require.Contains(t, indexed, "0", "fields[0] must surface as the '0' key")
+		assert.Len(t, indexed["0"].OneOf, 2, "inner FieldRef has two union variants")
+	})
+}

--- a/server/datasources/table/posted.go
+++ b/server/datasources/table/posted.go
@@ -1,0 +1,49 @@
+package table
+
+import (
+	"context"
+
+	"github.com/monetr/monetr/server/validators"
+	"github.com/monetr/validation"
+	"github.com/monetr/validation/is"
+	"github.com/pkg/errors"
+)
+
+// PostedSpec determines whether the current transaction is in a posted or
+// pending status. It does this by making a case-insensitive comparison against
+// the field specified. When the field matches the posted value provided it is
+// considered posted, any other value is considered pending. When this struct is
+// nil on the [Mapping] then all transactions are considered posted.
+type PostedSpec struct {
+	Fields []FieldRef `json:"fields"`
+	// Posted is the strong we look for in the field specified to know if the
+	// transaction is posted. Any other value is considered pending.
+	Posted string `json:"posted,omitempty"`
+}
+
+func (s *PostedSpec) Validate(ctx context.Context) error {
+	return errors.Wrapf(
+		validation.ValidateStructWithContext(
+			ctx,
+			s,
+			validation.Field(
+				&s.Fields,
+				validation.Each(
+					validators.By(func(ctx context.Context, field FieldRef) error {
+						return field.Validate(ctx)
+					}),
+				),
+				validation.Length(1, 1),
+				validators.Unique[FieldRef](),
+				validation.Required,
+			),
+			validation.Field(
+				&s.Posted,
+				is.PrintableASCII,
+				validation.Length(0, 100),
+			),
+		),
+		"failed to validate %T",
+		s,
+	)
+}

--- a/server/datasources/table/posted_test.go
+++ b/server/datasources/table/posted_test.go
@@ -1,0 +1,244 @@
+package table_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/monetr/monetr/server/datasources/table"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPostedSpec_Validate(t *testing.T) {
+	// PostedSpec requires exactly one FieldRef (valid against the column set in
+	// context). Posted is optional; when set it must contain ASCII characters
+	// only and be no longer than 50 characters. An empty Posted string is
+	// accepted because Length(0, 50) treats empty as valid.
+	ctx := table.WithColumns(
+		t.Context(),
+		[]string{"Date", "Status", "Description", "Amount"},
+	)
+	cases := []struct {
+		name    string
+		spec    table.PostedSpec
+		wantErr string
+	}{
+		{
+			name: "named field with empty Posted",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{Name: "Status"}},
+			},
+			wantErr: "",
+		},
+		{
+			name: "named field with short ASCII Posted",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{Name: "Status"}},
+				Posted: "Posted",
+			},
+			wantErr: "",
+		},
+		{
+			name: "named field with mid-range ASCII Posted",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{Name: "Status"}},
+				Posted: strings.Repeat("A", 50),
+			},
+			wantErr: "",
+		},
+		{
+			name: "named field with Posted at min non-empty length",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{Name: "Status"}},
+				Posted: "A",
+			},
+			wantErr: "",
+		},
+		{
+			name: "named field with ASCII punctuation Posted",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{Name: "Status"}},
+				Posted: "posted! @#$%^&*()_+-=",
+			},
+			wantErr: "",
+		},
+		{
+			name: "derived row number field with empty Posted",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{DerivedKind: table.DerivedKindRowNumber}},
+			},
+			wantErr: "",
+		},
+		{
+			name: "derived row number per day field with ASCII Posted",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{DerivedKind: table.DerivedKindRowNumberPerDay}},
+				Posted: "POSTED",
+			},
+			wantErr: "",
+		},
+		{
+			name: "derived row number per day per amount field with ASCII Posted",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{DerivedKind: table.DerivedKindRowNumberPerDayPerAmount}},
+				Posted: "Y",
+			},
+			wantErr: "",
+		},
+		{
+			name:    "empty",
+			spec:    table.PostedSpec{},
+			wantErr: "failed to validate *table.PostedSpec: fields: cannot be blank.",
+		},
+		{
+			name: "nil Fields with valid Posted",
+			spec: table.PostedSpec{
+				Posted: "POSTED",
+			},
+			wantErr: "failed to validate *table.PostedSpec: fields: cannot be blank.",
+		},
+		{
+			name: "empty slice Fields with valid Posted",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{},
+				Posted: "POSTED",
+			},
+			wantErr: "failed to validate *table.PostedSpec: fields: cannot be blank.",
+		},
+		{
+			name: "two named fields violates length",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{Name: "Status"}, {Name: "Date"}},
+			},
+			wantErr: "failed to validate *table.PostedSpec: fields: the length must be exactly 1.",
+		},
+		{
+			name: "three fields violates length",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{Name: "Status"}, {Name: "Date"}, {Name: "Amount"}},
+			},
+			wantErr: "failed to validate *table.PostedSpec: fields: the length must be exactly 1.",
+		},
+		{
+			// Length(1,1) fails before the Unique rule runs, so the message reports
+			// the length error rather than "duplicate".
+			name: "duplicate fields are caught by length check first",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{Name: "Status"}, {Name: "Status"}},
+			},
+			wantErr: "failed to validate *table.PostedSpec: fields: the length must be exactly 1.",
+		},
+		{
+			name: "child field is empty",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{}},
+			},
+			wantErr: "failed to validate *table.PostedSpec: fields: (0: input must be considered valid by: name: cannot be blank. or derivedKind: cannot be blank..).",
+		},
+		{
+			name: "child field name not in headers",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{Name: "NotPresent"}},
+			},
+			wantErr: "failed to validate *table.PostedSpec: fields: (0: input must be considered valid by: name: must be one of: [\"Date\", \"Status\", \"Description\", \"Amount\"]. or derivedKind: cannot be blank; name: must be blank..).",
+		},
+		{
+			name: "child field has both name and derived kind",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{Name: "Status", DerivedKind: table.DerivedKindRowNumber}},
+			},
+			wantErr: "failed to validate *table.PostedSpec: fields: (0: input must be considered valid by: derivedKind: must be blank. or name: must be blank..).",
+		},
+		{
+			name: "child field has unknown derived kind",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{DerivedKind: table.DerivedKind("bogus")}},
+			},
+			wantErr: "failed to validate *table.PostedSpec: fields: (0: input must be considered valid by: derivedKind: must be blank; name: cannot be blank. or derivedKind: must be one of: [\"rowNumber\", \"rowNumberPerDay\", \"rowNumberPerDayPerAmount\"]..).",
+		},
+		{
+			name: "non-ASCII Posted",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{Name: "Status"}},
+				Posted: "Pösted",
+			},
+			wantErr: "failed to validate *table.PostedSpec: posted: must contain printable ASCII characters only.",
+		},
+		{
+			// Tab is ASCII (0x09) but not *printable* ASCII (0x20-0x7E). The switch
+			// from is.ASCII to is.PrintableASCII is what rejects it.
+			name: "Posted with tab character",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{Name: "Status"}},
+				Posted: "POS\tTED",
+			},
+			wantErr: "failed to validate *table.PostedSpec: posted: must contain printable ASCII characters only.",
+		},
+		{
+			name: "Posted with newline character",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{Name: "Status"}},
+				Posted: "POS\nTED",
+			},
+			wantErr: "failed to validate *table.PostedSpec: posted: must contain printable ASCII characters only.",
+		},
+		{
+			// DEL (0x7F) is still ASCII but sits outside the printable range.
+			name: "Posted with DEL character",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{Name: "Status"}},
+				Posted: "POSTED\x7f",
+			},
+			wantErr: "failed to validate *table.PostedSpec: posted: must contain printable ASCII characters only.",
+		},
+		{
+			name: "Posted at 100-char max length boundary",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{Name: "Status"}},
+				Posted: strings.Repeat("A", 100),
+			},
+			wantErr: "",
+		},
+		{
+			name: "Posted exceeds max length",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{Name: "Status"}},
+				Posted: strings.Repeat("A", 101),
+			},
+			wantErr: "failed to validate *table.PostedSpec: posted: the length must be no more than 100.",
+		},
+		{
+			name: "empty Fields with non-ASCII Posted",
+			spec: table.PostedSpec{
+				Posted: "Pösted",
+			},
+			wantErr: "failed to validate *table.PostedSpec: fields: cannot be blank; posted: must contain printable ASCII characters only.",
+		},
+		{
+			name: "empty Fields with over-length Posted",
+			spec: table.PostedSpec{
+				Posted: strings.Repeat("A", 101),
+			},
+			wantErr: "failed to validate *table.PostedSpec: fields: cannot be blank; posted: the length must be no more than 100.",
+		},
+		{
+			name: "invalid child field with non-ASCII Posted",
+			spec: table.PostedSpec{
+				Fields: []table.FieldRef{{}},
+				Posted: "Pösted",
+			},
+			wantErr: "failed to validate *table.PostedSpec: fields: (0: input must be considered valid by: name: cannot be blank. or derivedKind: cannot be blank..); posted: must contain printable ASCII characters only.",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.spec.Validate(ctx)
+			if tc.wantErr == "" {
+				assert.NoError(t, err, "PostedSpec must be accepted")
+			} else {
+				assert.EqualError(t, err, tc.wantErr, "PostedSpec must be rejected with the expected message")
+			}
+		})
+	}
+}

--- a/server/internal/myownsanity/first.go
+++ b/server/internal/myownsanity/first.go
@@ -1,5 +1,7 @@
 package myownsanity
 
+import "errors"
+
 func FirstError(items ...error) error {
 	for _, item := range items {
 		if item != nil {
@@ -7,4 +9,17 @@ func FirstError(items ...error) error {
 		}
 	}
 	return nil
+}
+
+// JoinErrorMaybe takes an array of errors, if any of the errors are nil then
+// nil is returned. If all of the errors are actually errors then the joined
+// version of the errors is returned.
+func JoinErrorMaybe(items ...error) error {
+	for _, item := range items {
+		if item == nil {
+			return nil
+		}
+	}
+
+	return errors.Join(items...)
 }

--- a/server/internal/testutils/log.go
+++ b/server/internal/testutils/log.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/monetr/monetr/server/config"
 	"github.com/monetr/monetr/server/logging"
 )
 
@@ -115,7 +116,10 @@ func GetTestLog(t *testing.T) (*slog.Logger, *TestLogHook) {
 	}
 
 	hook := &TestLogHook{}
-	base := logging.NewLoggerWithLevel("trace")
+	base := logging.NewLoggerWithConfig(config.Logging{
+		Level:  "trace",
+		Format: "pretty",
+	})
 
 	combined := slog.New(&multiHandler{
 		handlers: []slog.Handler{

--- a/server/logging/logger.go
+++ b/server/logging/logger.go
@@ -4,7 +4,9 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"time"
 
+	"github.com/monetr/devslog"
 	"github.com/monetr/monetr/server/config"
 )
 
@@ -20,6 +22,19 @@ func NewLoggerWithConfig(configuration config.Logging) *slog.Logger {
 	switch strings.ToLower(configuration.Format) {
 	case "json":
 		inner = slog.NewJSONHandler(os.Stderr, opts)
+	case "pretty":
+		inner = devslog.NewHandler(os.Stderr, &devslog.Options{
+			DedupAttributes:     true,
+			HandlerOptions:      opts,
+			MaxSlicePrintSize:   0,
+			SortKeys:            true,
+			TimeFormat:          time.RFC3339,
+			NewLineAfterLog:     false,
+			StringIndentation:   true,
+			StringerFormatter:   true,
+			NoColor:             false,
+			SameSourceInfoColor: false,
+		})
 	default: // "text"
 		inner = slog.NewTextHandler(os.Stderr, opts)
 	}

--- a/server/migrations/schema/2026042800_TransactionImportMappings.tx.up.sql
+++ b/server/migrations/schema/2026042800_TransactionImportMappings.tx.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "transaction_import_mappings" (
+  "transaction_import_mapping_id" VARCHAR(32) NOT NULL,
+  "account_id"                    VARCHAR(32) NOT NULL,
+  "signature"                     TEXT        NOT NULL, -- No unique enforcement!
+  "mapping"                       JSONB       NOT NULL,
+  "created_by"                    VARCHAR(32) NOT NULL,
+  "created_at"                    TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+  "updated_at"                    TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+  CONSTRAINT "pk_transaction_import_mappings"            PRIMARY KEY ("transaction_import_mapping_id", "account_id"),
+  CONSTRAINT "fk_transaction_import_mappings_account"    FOREIGN KEY ("account_id") REFERENCES "accounts" ("account_id") ON DELETE CASCADE,
+  CONSTRAINT "fk_transaction_import_mappings_created_by" FOREIGN KEY ("created_by") REFERENCES "users" ("user_id") ON DELETE CASCADE
+);

--- a/server/models/transaction_import_mapping.go
+++ b/server/models/transaction_import_mapping.go
@@ -1,0 +1,65 @@
+package models
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/go-pg/pg/v10"
+	"github.com/monetr/monetr/server/datasources/table"
+)
+
+var (
+	_ pg.BeforeInsertHook = (*TransactionImportMapping)(nil)
+	_ Identifiable        = TransactionImportMapping{}
+)
+
+type TransactionImportMapping struct {
+	tableName string `pg:"transaction_import_mappings"`
+
+	TransactionImportMappingId ID[TransactionImportMapping] `json:"transactionImportMapping" pg:"transaction_import_mapping_id,notnull,pk"`
+	AccountId                  ID[Account]                  `json:"-" pg:"account_id,notnull,pk"`
+	Account                    *Account                     `json:"-" pg:"rel:has-one"`
+	Signature                  string                       `json:"signature" pg:"signature,notnull"`
+	Mapping                    table.Mapping                `json:"mapping" pg:"mapping,notnull,jsonb"`
+	CreatedAt                  time.Time                    `json:"createdAt" pg:"created_at,notnull"`
+	UpdatedAt                  time.Time                    `json:"updatedAt" pg:"updated_at,notnull"`
+	CreatedBy                  ID[User]                     `json:"createdBy" pg:"created_by,notnull"`
+	CreatedByUser              *User                        `json:"-" pg:"rel:has-one,fk:created_by"`
+}
+
+func (TransactionImportMapping) IdentityPrefix() string {
+	return "txix"
+}
+
+func (o *TransactionImportMapping) BeforeInsert(ctx context.Context) (context.Context, error) {
+	if o.TransactionImportMappingId.IsZero() {
+		o.TransactionImportMappingId = NewID[TransactionImportMapping]()
+	}
+
+	now := time.Now()
+	if o.CreatedAt.IsZero() {
+		o.CreatedAt = now
+	}
+	if o.UpdatedAt.IsZero() {
+		o.UpdatedAt = now
+	}
+	if o.Signature == "" {
+		o.Signature = signMappingHeaders(o.Mapping.Headers)
+	}
+
+	return ctx, nil
+}
+
+func signMappingHeaders(headers []string) string {
+	normalized := make([]string, len(headers))
+	for i, h := range headers {
+		normalized[i] = strings.ToLower(h)
+	}
+	sort.Strings(normalized)
+	sum := sha256.Sum256([]byte(strings.Join(normalized, ",")))
+	return hex.EncodeToString(sum[:])
+}

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -136,6 +136,24 @@ type BaseRepository interface {
 		transactionUpload *TransactionUpload,
 	) error
 
+	CreateTransactionImportMapping(
+		ctx context.Context,
+		mapping *TransactionImportMapping,
+	) error
+	GetTransactionImportMapping(
+		ctx context.Context,
+		mappingId ID[TransactionImportMapping],
+	) (*TransactionImportMapping, error)
+	GetTransactionImportMappings(
+		ctx context.Context,
+		limit, offset int,
+	) ([]TransactionImportMapping, error)
+	GetTransactionImportMappingsBySignature(
+		ctx context.Context,
+		signature string,
+		limit, offset int,
+	) ([]TransactionImportMapping, error)
+
 	CreateLunchFlowLink(ctx context.Context, link *LunchFlowLink) error
 	UpdateLunchFlowLink(ctx context.Context, link *LunchFlowLink) error
 	RemoveLunchFlowLink(ctx context.Context, id ID[LunchFlowLink]) error

--- a/server/repository/spending.go
+++ b/server/repository/spending.go
@@ -107,8 +107,8 @@ func (r *repositoryBase) CreateSpending(ctx context.Context, spending *Spending)
 	return nil
 }
 
-// UpdateSpending should only be called with complete expense  Do not use partial models with missing data for
-// this action.
+// UpdateSpending should only be called with complete expense  Do not use
+// partial models with missing data for this action.
 func (r *repositoryBase) UpdateSpending(ctx context.Context, bankAccountId ID[BankAccount], updates []Spending) error {
 	span := crumbs.StartFnTrace(ctx)
 	defer span.Finish()
@@ -127,6 +127,7 @@ func (r *repositoryBase) UpdateSpending(ctx context.Context, bankAccountId ID[Ba
 	}
 
 	_, err := r.txn.ModelContext(span.Context(), &updates).
+		WherePK().
 		Update(&updates)
 	if err != nil {
 		span.Status = sentry.SpanStatusInternalError

--- a/server/repository/transaction_import_mappings.go
+++ b/server/repository/transaction_import_mappings.go
@@ -1,0 +1,108 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/monetr/monetr/server/crumbs"
+	. "github.com/monetr/monetr/server/models"
+	"github.com/pkg/errors"
+)
+
+func (r *repositoryBase) CreateTransactionImportMapping(
+	ctx context.Context,
+	mapping *TransactionImportMapping,
+) error {
+	span := crumbs.StartFnTrace(ctx)
+	defer span.Finish()
+
+	mapping.AccountId = r.AccountId()
+	mapping.CreatedBy = r.UserId()
+	mapping.CreatedAt = r.clock.Now().UTC()
+	mapping.UpdatedAt = r.clock.Now().UTC()
+
+	_, err := r.txn.ModelContext(span.Context(), mapping).
+		Insert(mapping)
+	if err != nil {
+		span.Status = sentry.SpanStatusInternalError
+		return errors.Wrap(err, "failed to create transaction import mapping")
+	}
+
+	span.SetData("transactionImportMappingId", mapping.TransactionImportMappingId.String())
+	span.Status = sentry.SpanStatusOK
+
+	return nil
+}
+
+func (r *repositoryBase) GetTransactionImportMapping(
+	ctx context.Context,
+	mappingId ID[TransactionImportMapping],
+) (*TransactionImportMapping, error) {
+	span := crumbs.StartFnTrace(ctx)
+	defer span.Finish()
+
+	var item TransactionImportMapping
+	err := r.txn.ModelContext(span.Context(), &item).
+		Where(`"account_id" = ?`, r.AccountId()).
+		Where(`"transaction_import_mapping_id" = ?`, mappingId).
+		Limit(1).
+		Select(&item)
+	if err != nil {
+		span.Status = sentry.SpanStatusInternalError
+		return nil, errors.Wrap(err, "failed to retrieve transaction import mapping")
+	}
+
+	span.Status = sentry.SpanStatusOK
+
+	return &item, nil
+}
+
+func (r *repositoryBase) GetTransactionImportMappings(
+	ctx context.Context,
+	limit, offset int,
+) ([]TransactionImportMapping, error) {
+	span := crumbs.StartFnTrace(ctx)
+	defer span.Finish()
+
+	result := make([]TransactionImportMapping, 0)
+	err := r.txn.ModelContext(span.Context(), &result).
+		Where(`"account_id" = ?`, r.AccountId()).
+		Limit(limit).
+		Offset(offset).
+		Order("created_at DESC").
+		Select(&result)
+	if err != nil {
+		span.Status = sentry.SpanStatusInternalError
+		return nil, errors.Wrap(err, "failed to retrieve transaction import mappings")
+	}
+
+	span.Status = sentry.SpanStatusOK
+
+	return result, nil
+}
+
+func (r *repositoryBase) GetTransactionImportMappingsBySignature(
+	ctx context.Context,
+	signature string,
+	limit, offset int,
+) ([]TransactionImportMapping, error) {
+	span := crumbs.StartFnTrace(ctx)
+	defer span.Finish()
+
+	result := make([]TransactionImportMapping, 0)
+	err := r.txn.ModelContext(span.Context(), &result).
+		Where(`"account_id" = ?`, r.AccountId()).
+		Where(`"signature" = ?`, signature).
+		Limit(limit).
+		Offset(offset).
+		Order("created_at DESC").
+		Select(&result)
+	if err != nil {
+		span.Status = sentry.SpanStatusInternalError
+		return nil, errors.Wrap(err, "failed to retrieve transaction import mappings by signature")
+	}
+
+	span.Status = sentry.SpanStatusOK
+
+	return result, nil
+}

--- a/server/repository/transaction_import_mappings_test.go
+++ b/server/repository/transaction_import_mappings_test.go
@@ -1,0 +1,310 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/go-pg/pg/v10"
+	"github.com/monetr/monetr/server/datasources/table"
+	"github.com/monetr/monetr/server/internal/fixtures"
+	"github.com/monetr/monetr/server/internal/testutils"
+	"github.com/monetr/monetr/server/models"
+	"github.com/monetr/monetr/server/repository"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validMapping(headers []string) table.Mapping {
+	return table.Mapping{
+		ID: table.IDSpec{
+			Kind:   table.IDSpecKindNative,
+			Fields: []table.FieldRef{{Name: "Id"}},
+		},
+		Amount: table.AmountSpec{
+			Kind:   table.AmountKindSign,
+			Fields: []table.FieldRef{{Name: "Amount"}},
+		},
+		Memo: table.FieldRef{Name: "Description"},
+		Date: table.DateSpec{
+			Fields: []table.FieldRef{{Name: "Date"}},
+			Format: "YYYY-MM-DD",
+		},
+		Balance: table.BalanceSpec{
+			Kind: table.BalanceKindNone,
+		},
+		Headers: headers,
+	}
+}
+
+func TestRepositoryBase_CreateTransactionImportMapping(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		mock := clock.NewMock()
+		log := testutils.GetLog(t)
+		user, _ := fixtures.GivenIHaveABasicAccount(t, mock)
+
+		repo := repository.NewRepositoryFromSession(
+			mock,
+			user.UserId,
+			user.AccountId,
+			testutils.GetPgDatabase(t),
+			log,
+		)
+
+		headers := []string{"Date", "Description", "Amount", "Id"}
+		mapping := models.TransactionImportMapping{
+			Mapping: validMapping(headers),
+		}
+
+		err := repo.CreateTransactionImportMapping(context.Background(), &mapping)
+		require.NoError(t, err, "must be able to create transaction import mapping")
+
+		assert.False(t, mapping.TransactionImportMappingId.IsZero(), "id must be assigned")
+		assert.Equal(t, user.AccountId, mapping.AccountId, "account id must be set from session")
+		assert.Equal(t, user.UserId, mapping.CreatedBy, "created by must be set from session")
+		assert.False(t, mapping.CreatedAt.IsZero(), "created at must be set")
+		assert.False(t, mapping.UpdatedAt.IsZero(), "updated at must be set")
+		assert.NotEmpty(t, mapping.Signature, "signature must be derived in BeforeInsert")
+
+		stored := testutils.MustDBRead(t, mapping)
+		assert.Equal(t, mapping.Signature, stored.Signature, "stored signature must match")
+		assert.Equal(t, mapping.Mapping.Headers, stored.Mapping.Headers, "stored mapping headers must match")
+	})
+}
+
+func TestRepositoryBase_GetTransactionImportMapping(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		mock := clock.NewMock()
+		log := testutils.GetLog(t)
+		user, _ := fixtures.GivenIHaveABasicAccount(t, mock)
+
+		repo := repository.NewRepositoryFromSession(
+			mock,
+			user.UserId,
+			user.AccountId,
+			testutils.GetPgDatabase(t),
+			log,
+		)
+
+		mapping := models.TransactionImportMapping{
+			Mapping: validMapping([]string{"Date", "Description", "Amount", "Id"}),
+		}
+		require.NoError(t, repo.CreateTransactionImportMapping(context.Background(), &mapping))
+
+		got, err := repo.GetTransactionImportMapping(context.Background(), mapping.TransactionImportMappingId)
+		require.NoError(t, err, "must be able to retrieve mapping by id")
+		assert.Equal(t, mapping.TransactionImportMappingId, got.TransactionImportMappingId)
+		assert.Equal(t, mapping.Signature, got.Signature)
+		assert.Equal(t, mapping.Mapping.Headers, got.Mapping.Headers)
+	})
+
+	t.Run("isolates by account", func(t *testing.T) {
+		mock := clock.NewMock()
+		log := testutils.GetLog(t)
+		userA, _ := fixtures.GivenIHaveABasicAccount(t, mock)
+		userB, _ := fixtures.GivenIHaveABasicAccount(t, mock)
+
+		repoA := repository.NewRepositoryFromSession(
+			mock, userA.UserId, userA.AccountId, testutils.GetPgDatabase(t), log,
+		)
+		repoB := repository.NewRepositoryFromSession(
+			mock, userB.UserId, userB.AccountId, testutils.GetPgDatabase(t), log,
+		)
+
+		mapping := models.TransactionImportMapping{
+			Mapping: validMapping([]string{"Date", "Description", "Amount", "Id"}),
+		}
+		require.NoError(t, repoA.CreateTransactionImportMapping(context.Background(), &mapping))
+
+		got, err := repoB.GetTransactionImportMapping(context.Background(), mapping.TransactionImportMappingId)
+		require.Error(t, err, "must not return another account's mapping")
+		assert.True(t, errors.Is(err, pg.ErrNoRows), "must surface a not-found error")
+		assert.Nil(t, got, "must not return a record across accounts")
+	})
+}
+
+func TestRepositoryBase_GetTransactionImportMappings(t *testing.T) {
+	t.Run("lists all for account ordered by created_at desc", func(t *testing.T) {
+		mock := clock.NewMock()
+		log := testutils.GetLog(t)
+		user, _ := fixtures.GivenIHaveABasicAccount(t, mock)
+
+		repo := repository.NewRepositoryFromSession(
+			mock, user.UserId, user.AccountId, testutils.GetPgDatabase(t), log,
+		)
+
+		first := models.TransactionImportMapping{
+			Mapping: validMapping([]string{"Date", "Description", "Amount", "Id"}),
+		}
+		require.NoError(t, repo.CreateTransactionImportMapping(context.Background(), &first))
+
+		mock.Add(1 * time.Minute)
+
+		second := models.TransactionImportMapping{
+			Mapping: validMapping([]string{"Posted", "Memo", "Value", "Reference"}),
+		}
+		require.NoError(t, repo.CreateTransactionImportMapping(context.Background(), &second))
+
+		got, err := repo.GetTransactionImportMappings(context.Background(), 10, 0)
+		require.NoError(t, err, "must be able to list mappings")
+		require.Len(t, got, 2, "must return both mappings")
+		assert.Equal(t, second.TransactionImportMappingId, got[0].TransactionImportMappingId, "most recent must be first")
+		assert.Equal(t, first.TransactionImportMappingId, got[1].TransactionImportMappingId)
+	})
+
+	t.Run("paginates results", func(t *testing.T) {
+		mock := clock.NewMock()
+		log := testutils.GetLog(t)
+		user, _ := fixtures.GivenIHaveABasicAccount(t, mock)
+
+		repo := repository.NewRepositoryFromSession(
+			mock, user.UserId, user.AccountId, testutils.GetPgDatabase(t), log,
+		)
+
+		created := make([]models.ID[models.TransactionImportMapping], 0, 3)
+		for i := 0; i < 3; i++ {
+			mapping := models.TransactionImportMapping{
+				Mapping: validMapping([]string{"Date", "Description", "Amount", "Id"}),
+			}
+			require.NoError(t, repo.CreateTransactionImportMapping(context.Background(), &mapping))
+			created = append(created, mapping.TransactionImportMappingId)
+			mock.Add(1 * time.Minute)
+		}
+
+		page1, err := repo.GetTransactionImportMappings(context.Background(), 2, 0)
+		require.NoError(t, err)
+		require.Len(t, page1, 2, "first page must return limit-many mappings")
+
+		page2, err := repo.GetTransactionImportMappings(context.Background(), 2, 2)
+		require.NoError(t, err)
+		require.Len(t, page2, 1, "second page must return remaining mappings")
+
+		assert.NotContains(t, []models.ID[models.TransactionImportMapping]{
+			page1[0].TransactionImportMappingId,
+			page1[1].TransactionImportMappingId,
+		}, page2[0].TransactionImportMappingId, "pages must not overlap")
+	})
+
+	t.Run("isolates by account", func(t *testing.T) {
+		mock := clock.NewMock()
+		log := testutils.GetLog(t)
+		userA, _ := fixtures.GivenIHaveABasicAccount(t, mock)
+		userB, _ := fixtures.GivenIHaveABasicAccount(t, mock)
+
+		repoA := repository.NewRepositoryFromSession(
+			mock, userA.UserId, userA.AccountId, testutils.GetPgDatabase(t), log,
+		)
+		repoB := repository.NewRepositoryFromSession(
+			mock, userB.UserId, userB.AccountId, testutils.GetPgDatabase(t), log,
+		)
+
+		mappingA := models.TransactionImportMapping{
+			Mapping: validMapping([]string{"Date", "Description", "Amount", "Id"}),
+		}
+		require.NoError(t, repoA.CreateTransactionImportMapping(context.Background(), &mappingA))
+
+		mappingB := models.TransactionImportMapping{
+			Mapping: validMapping([]string{"Posted", "Memo", "Value", "Reference"}),
+		}
+		require.NoError(t, repoB.CreateTransactionImportMapping(context.Background(), &mappingB))
+
+		got, err := repoA.GetTransactionImportMappings(context.Background(), 10, 0)
+		require.NoError(t, err)
+		require.Len(t, got, 1, "account A must only see its own mapping")
+		assert.Equal(t, mappingA.TransactionImportMappingId, got[0].TransactionImportMappingId)
+	})
+}
+
+func TestRepositoryBase_GetTransactionImportMappingsBySignature(t *testing.T) {
+	t.Run("matches by signature", func(t *testing.T) {
+		mock := clock.NewMock()
+		log := testutils.GetLog(t)
+		user, _ := fixtures.GivenIHaveABasicAccount(t, mock)
+
+		repo := repository.NewRepositoryFromSession(
+			mock, user.UserId, user.AccountId, testutils.GetPgDatabase(t), log,
+		)
+
+		matching1 := models.TransactionImportMapping{
+			Mapping: validMapping([]string{"Date", "Description", "Amount", "Id"}),
+		}
+		require.NoError(t, repo.CreateTransactionImportMapping(context.Background(), &matching1))
+
+		mock.Add(1 * time.Minute)
+
+		matching2 := models.TransactionImportMapping{
+			Mapping: validMapping([]string{"Date", "Description", "Amount", "Id"}),
+		}
+		require.NoError(t, repo.CreateTransactionImportMapping(context.Background(), &matching2))
+
+		other := models.TransactionImportMapping{
+			Mapping: validMapping([]string{"Posted", "Memo", "Value", "Reference"}),
+		}
+		require.NoError(t, repo.CreateTransactionImportMapping(context.Background(), &other))
+
+		assert.Equal(t, matching1.Signature, matching2.Signature, "same headers must produce same signature")
+		assert.NotEqual(t, matching1.Signature, other.Signature, "different headers must produce different signatures")
+
+		got, err := repo.GetTransactionImportMappingsBySignature(context.Background(), matching1.Signature, 10, 0)
+		require.NoError(t, err)
+		require.Len(t, got, 2, "must return only the two matching mappings")
+		assert.Equal(t, matching2.TransactionImportMappingId, got[0].TransactionImportMappingId, "most recent must be first")
+		assert.Equal(t, matching1.TransactionImportMappingId, got[1].TransactionImportMappingId)
+	})
+
+	t.Run("signature is case insensitive", func(t *testing.T) {
+		mock := clock.NewMock()
+		log := testutils.GetLog(t)
+		user, _ := fixtures.GivenIHaveABasicAccount(t, mock)
+
+		repo := repository.NewRepositoryFromSession(
+			mock, user.UserId, user.AccountId, testutils.GetPgDatabase(t), log,
+		)
+
+		mixedCase := models.TransactionImportMapping{
+			Mapping: validMapping([]string{"Date", "Description", "Amount", "Id"}),
+		}
+		require.NoError(t, repo.CreateTransactionImportMapping(context.Background(), &mixedCase))
+
+		variant := models.TransactionImportMapping{
+			Mapping: validMapping([]string{"DATE", "description", "Amount", "id"}),
+		}
+		require.NoError(t, repo.CreateTransactionImportMapping(context.Background(), &variant))
+
+		assert.Equal(t, mixedCase.Signature, variant.Signature, "signature must ignore case differences in headers")
+	})
+
+	t.Run("isolates by account", func(t *testing.T) {
+		mock := clock.NewMock()
+		log := testutils.GetLog(t)
+		userA, _ := fixtures.GivenIHaveABasicAccount(t, mock)
+		userB, _ := fixtures.GivenIHaveABasicAccount(t, mock)
+
+		repoA := repository.NewRepositoryFromSession(
+			mock, userA.UserId, userA.AccountId, testutils.GetPgDatabase(t), log,
+		)
+		repoB := repository.NewRepositoryFromSession(
+			mock, userB.UserId, userB.AccountId, testutils.GetPgDatabase(t), log,
+		)
+
+		headers := []string{"Date", "Description", "Amount", "Id"}
+		mappingA := models.TransactionImportMapping{
+			Mapping: validMapping(headers),
+		}
+		require.NoError(t, repoA.CreateTransactionImportMapping(context.Background(), &mappingA))
+
+		mappingB := models.TransactionImportMapping{
+			Mapping: validMapping(headers),
+		}
+		require.NoError(t, repoB.CreateTransactionImportMapping(context.Background(), &mappingB))
+
+		require.Equal(t, mappingA.Signature, mappingB.Signature, "same headers across accounts must share signature")
+
+		got, err := repoA.GetTransactionImportMappingsBySignature(context.Background(), mappingA.Signature, 10, 0)
+		require.NoError(t, err)
+		require.Len(t, got, 1, "account A must only see its own matching mapping")
+		assert.Equal(t, mappingA.TransactionImportMappingId, got[0].TransactionImportMappingId)
+	})
+}

--- a/server/validators/custom.go
+++ b/server/validators/custom.go
@@ -1,0 +1,41 @@
+package validators
+
+import (
+	"context"
+
+	"github.com/monetr/validation"
+	"github.com/pkg/errors"
+)
+
+type inlineRule[T any] struct {
+	f func(ctx context.Context, value T) error
+}
+
+// ValidateWithContext implements [validation.Rule].
+func (i *inlineRule[T]) Validate(value any) error {
+	return i.f(context.Background(), value.(T))
+}
+
+// ValidateWithContext implements [validation.RuleWithContext].
+func (i *inlineRule[T]) ValidateWithContext(ctx context.Context, value any) error {
+	return i.f(ctx, value.(T))
+}
+
+func By[T any](callback func(ctx context.Context, value T) error) validation.Rule {
+	return &inlineRule[T]{
+		f: callback,
+	}
+}
+
+func Unique[T comparable]() validation.Rule {
+	return By(func(ctx context.Context, fields []T) error {
+		seen := make(map[T]struct{}, len(fields))
+		for i, f := range fields {
+			if _, dup := seen[f]; dup {
+				return errors.Errorf("fields[%d] is a duplicate of an earlier entry", i)
+			}
+			seen[f] = struct{}{}
+		}
+		return nil
+	})
+}

--- a/server/validators/custom_test.go
+++ b/server/validators/custom_test.go
@@ -1,0 +1,96 @@
+package validators_test
+
+import (
+	"testing"
+
+	"github.com/monetr/monetr/server/validators"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnique_Strings(t *testing.T) {
+	rule := validators.Unique[string]()
+	cases := []struct {
+		name    string
+		input   []string
+		wantErr string
+	}{
+		{
+			name:    "empty",
+			input:   []string{},
+			wantErr: "",
+		},
+		{
+			name:    "single element",
+			input:   []string{"a"},
+			wantErr: "",
+		},
+		{
+			name:    "all unique",
+			input:   []string{"a", "b", "c"},
+			wantErr: "",
+		},
+		{
+			name:    "duplicate at index 1",
+			input:   []string{"a", "a"},
+			wantErr: "fields[1] is a duplicate of an earlier entry",
+		},
+		{
+			name:    "non-adjacent duplicate surfaces at the later index",
+			input:   []string{"a", "b", "a"},
+			wantErr: "fields[2] is a duplicate of an earlier entry",
+		},
+		{
+			name:    "three identical reports the first repeat",
+			input:   []string{"x", "x", "x"},
+			wantErr: "fields[1] is a duplicate of an earlier entry",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := rule.Validate(tc.input)
+			if tc.wantErr == "" {
+				assert.NoError(t, err, "slice must be accepted")
+			} else {
+				assert.EqualError(t, err, tc.wantErr, "slice must be rejected with the expected message")
+			}
+		})
+	}
+}
+
+func TestUnique_Ints(t *testing.T) {
+	rule := validators.Unique[int]()
+
+	assert.NoError(t, rule.Validate([]int{1, 2, 3}), "unique ints accepted")
+	assert.EqualError(t, rule.Validate([]int{1, 2, 1}), "fields[2] is a duplicate of an earlier entry", "repeated int flagged")
+}
+
+func TestUnique_ComparableStruct(t *testing.T) {
+	// Unique works on any `comparable` type, including structs whose fields are
+	// all comparable. This mirrors how it's used against FieldRef in the csv
+	// package: two entries are duplicates only if every field matches.
+	type pair struct {
+		Name string
+		Kind string
+	}
+
+	rule := validators.Unique[pair]()
+
+	assert.NoError(
+		t,
+		rule.Validate([]pair{{Name: "Date"}, {Name: "Amount"}}),
+		"structurally distinct structs accepted",
+	)
+	assert.NoError(
+		t,
+		rule.Validate([]pair{{Name: "Amount"}, {Kind: "rowNumber"}}),
+		"same zero field is fine when the other differs",
+	)
+	assert.EqualError(
+		t,
+		rule.Validate([]pair{{Name: "Date"}, {Name: "Date"}}),
+		"fields[1] is a duplicate of an earlier entry",
+		"fully equal structs flagged",
+	)
+}

--- a/server/validators/equal.go
+++ b/server/validators/equal.go
@@ -1,0 +1,38 @@
+package validators
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/monetr/validation"
+)
+
+type EqRule interface {
+	validation.Rule
+	validation.RuleWithContext
+}
+
+type eqRule[T any] struct {
+	value T
+}
+
+// Validate implements [EqRule].
+func (e *eqRule[T]) Validate(value any) error {
+	return e.ValidateWithContext(context.Background(), value)
+}
+
+// ValidateWithContext implements [EqRule].
+func (e *eqRule[T]) ValidateWithContext(ctx context.Context, value any) error {
+	if reflect.DeepEqual(value, e.value) {
+		return nil
+	}
+
+	return validation.NewError("validation_eq_invalid", fmt.Sprintf("must equal \"%v\"", e.value))
+}
+
+func Eq[T any](value T) EqRule {
+	return &eqRule[T]{
+		value,
+	}
+}

--- a/server/validators/error.go
+++ b/server/validators/error.go
@@ -1,0 +1,158 @@
+package validators
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/monetr/validation"
+	"github.com/pkg/errors"
+)
+
+type Problems map[string][]error
+
+func (p Problems) Error() string {
+	if len(p) == 0 {
+		return ""
+	}
+
+	keys := make([]string, len(p))
+	i := 0
+	for key := range p {
+		keys[i] = key
+		i++
+	}
+	sort.Strings(keys)
+
+	var s strings.Builder
+	for i, key := range keys {
+		if i > 0 {
+			s.WriteString("; ")
+		}
+		_, _ = fmt.Fprintf(&s, "%v: ", key)
+		for x, item := range p[key] {
+			if x > 0 {
+				s.WriteString(", ")
+			}
+			_, _ = fmt.Fprintf(&s, "%v", item.Error())
+		}
+	}
+	s.WriteString(".")
+	return s.String()
+}
+
+// OneOfStruct validates structPtr against several alternative schemas. The
+// first schema that fully validates wins and OneOfStruct returns nil. If none
+// match, OneOfStruct returns a [OneOfError] where each element is one schema's
+// [validation.Errors] in input order. Variants are unlabeled; the per-rule
+// failures inside each variant are expected to be self-discriminating (the
+// kind-style fields will pass on exactly one variant when the input is
+// internally consistent).
+//
+// If a custom rule returns a non-validation error (anything that's not a
+// [validation.Errors]), OneOfStruct surfaces it directly so callers can
+// distinguish unexpected errors from schema-mismatch failures.
+func OneOfStruct[T any](
+	ctx context.Context,
+	structPtr *T,
+	schemas ...[]*validation.FieldRules,
+) error {
+	failures := make(OneOfError, 0, len(schemas))
+	for _, schema := range schemas {
+		err := validation.ValidateStructWithContext(
+			ctx,
+			structPtr,
+			schema...,
+		)
+		if err == nil {
+			return nil
+		}
+		verrs, ok := err.(validation.Errors)
+		if !ok {
+			return err
+		}
+		failures = append(failures, verrs)
+	}
+	return failures
+}
+
+// MarshalErrorTree prepares an error returned from a [validation.Validate]
+// chain or a [validators] helper for JSON serialization. It walks the error
+// tree, stripping pkg/errors wraps at every level (each per-spec errors.Wrapf
+// in datasources/table, plus the outermost Mapping wrap) so nested
+// [validation.Errors] and [OneOfError] values are reached by the caller's
+// encoding/json. Returns a JSON-marshalable value tree built from maps, slices,
+// and strings.
+//
+// A walker (rather than relying on [json.Marshaler] delegation in
+// [validation.Errors.MarshalJSON]) is required because that delegation only
+// fires for direct [json.Marshaler] values; pkg/errors wraps in between would
+// otherwise fall back to err.Error() and collapse a sub-tree into a flat
+// string.
+func MarshalErrorTree(err error) any {
+	if err == nil {
+		return nil
+	}
+	return walkError(err)
+}
+
+func walkError(err error) any {
+	if err == nil {
+		return nil
+	}
+	err = errors.Cause(err)
+	switch e := err.(type) {
+	case validation.Errors:
+		out := make(map[string]any, len(e))
+		for k, v := range e {
+			out[k] = walkError(v)
+		}
+		return out
+	case OneOfError:
+		if len(e) == 1 {
+			return walkError(e[0])
+		}
+		variants := make([]any, len(e))
+		for i, v := range e {
+			variants[i] = walkError(v)
+		}
+		return map[string]any{"oneOf": variants}
+	default:
+		return err.Error()
+	}
+}
+
+// FlattenValidationError walks a validation error and produces a flat
+// [Problems] map suitable for human-readable logs and string assertions. It is
+// not the JSON marshaller; for API responses use [MarshalErrorTree] which
+// preserves the nested structure (including [OneOfError] variants).
+func FlattenValidationError(err error) error {
+	switch err := errors.Cause(err).(type) {
+	case validation.Errors:
+		errs := make(Problems)
+		for key, problem := range err {
+			errs[key] = []error{FlattenValidationError(problem)}
+		}
+		return errs
+	case interface {
+		error
+		Unwrap() []error
+	}:
+		// If we get nested merged errors then join them.
+		errs := make(Problems)
+		for _, item := range err.Unwrap() {
+			switch item := errors.Cause(item).(type) {
+			case validation.Errors:
+				for key, problem := range item {
+					errs[key] = append(errs[key], FlattenValidationError(problem))
+				}
+			default:
+				return err
+			}
+		}
+		return errs
+	default:
+		return err
+	}
+}

--- a/server/validators/error_test.go
+++ b/server/validators/error_test.go
@@ -1,0 +1,188 @@
+package validators_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/monetr/monetr/server/validators"
+	"github.com/monetr/validation"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOneOfError_MarshalJSON(t *testing.T) {
+	t.Run("single schema unwraps to a flat validation.Errors object", func(t *testing.T) {
+		// When OneOf or OneOfStruct is used with a single schema (the common case
+		// for an endpoint that only ever validates against one shape), the JSON
+		// shape should be a plain {field: message} object so existing API
+		// consumers see a flat error map. This keeps the wire format compatible
+		// with non-union endpoints.
+		oe := validators.OneOfError{
+			validation.Errors{
+				"name": errors.New("Name must be between 1 and 300 characters"),
+			},
+		}
+		raw, err := json.Marshal(oe)
+		require.NoError(t, err)
+
+		var decoded map[string]string
+		require.NoError(t, json.Unmarshal(raw, &decoded))
+		assert.Equal(t, map[string]string{
+			"name": "Name must be between 1 and 300 characters",
+		}, decoded)
+	})
+
+	t.Run("multiple schemas wrap in oneOf array", func(t *testing.T) {
+		oe := validators.OneOfError{
+			validation.Errors{
+				"name": errors.New("cannot be blank"),
+			},
+			validation.Errors{
+				"derivedKind": errors.New("cannot be blank"),
+			},
+		}
+		raw, err := json.Marshal(oe)
+		require.NoError(t, err)
+
+		var decoded struct {
+			OneOf []map[string]string `json:"oneOf"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &decoded))
+		assert.Equal(t, []map[string]string{
+			{"name": "cannot be blank"},
+			{"derivedKind": "cannot be blank"},
+		}, decoded.OneOf)
+	})
+
+	t.Run("nested inside a validation.Errors recurses", func(t *testing.T) {
+		// This is the load-bearing case: a OneOfError sitting as the value of a
+		// field inside a parent validation.Errors must serialize structurally
+		// when the parent is marshalled, not collapse to a string.
+		// validation.Errors.MarshalJSON delegates to nested json.Marshaler
+		// values, which is what makes this work.
+		parent := validation.Errors{
+			"memo": validators.OneOfError{
+				validation.Errors{
+					"name":        errors.New("must be a valid value"),
+					"derivedKind": errors.New("must be blank"),
+				},
+				validation.Errors{
+					"name":        errors.New("must be blank"),
+					"derivedKind": errors.New("cannot be blank"),
+				},
+			},
+		}
+		raw, err := json.Marshal(parent)
+		require.NoError(t, err)
+
+		var decoded map[string]struct {
+			OneOf []map[string]string `json:"oneOf"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &decoded))
+		require.Contains(t, decoded, "memo")
+		assert.Equal(t, []map[string]string{
+			{"name": "must be a valid value", "derivedKind": "must be blank"},
+			{"name": "must be blank", "derivedKind": "cannot be blank"},
+		}, decoded["memo"].OneOf)
+	})
+}
+
+type sampleStruct struct {
+	Kind   string
+	Fields []string
+}
+
+func TestOneOfStruct_ReturnsOneOfError(t *testing.T) {
+	// OneOfStruct must return a typed OneOfError when no alternative validates,
+	// not an errors.Join wrapper. Returning the typed error is what lets the
+	// caller's type switch and the JSON marshaller find the union structure.
+	s := sampleStruct{Kind: "neither"}
+	err := validators.OneOfStruct(
+		context.Background(),
+		&s,
+		[]*validation.FieldRules{
+			validation.Field(&s.Kind, validation.Required, validation.In("alpha")),
+		},
+		[]*validation.FieldRules{
+			validation.Field(&s.Kind, validation.Required, validation.In("beta")),
+		},
+	)
+	require.Error(t, err)
+	oe, ok := err.(validators.OneOfError)
+	require.True(t, ok, "expected OneOfError, got %T", err)
+	assert.Len(t, oe, 2, "one entry per attempted schema")
+}
+
+func TestOneOfStruct_NilOnFirstSuccess(t *testing.T) {
+	// Short-circuit on first valid schema: subsequent schemas are not consulted.
+	s := sampleStruct{Kind: "alpha"}
+	err := validators.OneOfStruct(
+		context.Background(),
+		&s,
+		[]*validation.FieldRules{
+			validation.Field(&s.Kind, validation.Required, validation.In("alpha")),
+		},
+		[]*validation.FieldRules{
+			validation.Field(&s.Kind, validation.Required, validation.In("beta")),
+		},
+	)
+	assert.NoError(t, err)
+}
+
+func TestMarshalErrorTree(t *testing.T) {
+	t.Run("nil returns nil", func(t *testing.T) {
+		assert.Nil(t, validators.MarshalErrorTree(nil))
+	})
+
+	t.Run("strips pkg/errors wraps and produces a JSON-marshalable map", func(t *testing.T) {
+		inner := validation.Errors{"name": errors.New("cannot be blank")}
+		wrapped := errors.Wrapf(inner, "failed to validate %T", &sampleStruct{})
+		got := validators.MarshalErrorTree(wrapped)
+		assert.Equal(t, map[string]any{"name": "cannot be blank"}, got)
+	})
+
+	t.Run("walks nested validation.Errors with per-spec wraps", func(t *testing.T) {
+		// This mirrors the production case: the outer Mapping.Validate wraps a
+		// validation.Errors whose values are themselves wrapped (per-spec
+		// IDSpec / DateSpec wraps). The walker has to unwrap at every level,
+		// not just the outermost, so the inner field-level errors are reachable.
+		innerSpec := validation.Errors{"kind": errors.New("cannot be blank")}
+		wrappedInner := errors.Wrapf(innerSpec, "failed to validate inner")
+		outer := validation.Errors{"id": wrappedInner}
+		wrappedOuter := errors.Wrapf(outer, "failed to validate outer")
+
+		got := validators.MarshalErrorTree(wrappedOuter)
+		assert.Equal(t, map[string]any{
+			"id": map[string]any{
+				"kind": "cannot be blank",
+			},
+		}, got)
+	})
+
+	t.Run("OneOfError with one variant flattens to its inner errors", func(t *testing.T) {
+		oe := validators.OneOfError{validation.Errors{"name": errors.New("blank")}}
+		got := validators.MarshalErrorTree(oe)
+		assert.Equal(t, map[string]any{"name": "blank"}, got)
+	})
+
+	t.Run("OneOfError with multiple variants becomes oneOf array", func(t *testing.T) {
+		oe := validators.OneOfError{
+			validation.Errors{"name": errors.New("must be a valid value")},
+			validation.Errors{"derivedKind": errors.New("cannot be blank")},
+		}
+		got := validators.MarshalErrorTree(oe)
+		assert.Equal(t, map[string]any{
+			"oneOf": []any{
+				map[string]any{"name": "must be a valid value"},
+				map[string]any{"derivedKind": "cannot be blank"},
+			},
+		}, got)
+	})
+
+	t.Run("non-validation error becomes its string", func(t *testing.T) {
+		got := validators.MarshalErrorTree(errors.New("something else"))
+		assert.Equal(t, "something else", got)
+	})
+}

--- a/server/validators/in.go
+++ b/server/validators/in.go
@@ -1,0 +1,60 @@
+package validators
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/monetr/monetr/server/internal/myownsanity"
+	"github.com/monetr/validation"
+)
+
+type InRule interface {
+	validation.Rule
+	validation.RuleWithContext
+}
+
+type inRule[T any] struct {
+	values []T
+}
+
+// Validate implements [InRule].
+func (i *inRule[T]) Validate(value any) error {
+	return i.ValidateWithContext(context.Background(), value)
+}
+
+// ValidateWithContext implements [InRule]. Empty/nil values pass through so
+// that a sibling [validation.Required] rule controls the "missing" path with
+// "cannot be blank"; this rule speaks up only when the caller supplied a value
+// that wasn't in the allowed set.
+func (i *inRule[T]) ValidateWithContext(ctx context.Context, value any) error {
+	value, isNil := validation.Indirect(value)
+	if isNil || validation.IsEmpty(value) {
+		return nil
+	}
+	for _, v := range i.values {
+		if reflect.DeepEqual(value, v) {
+			return nil
+		}
+	}
+
+	return validation.NewError(
+		"validation_in_invalid",
+		fmt.Sprintf("must be one of: [%s]", strings.Join(
+			myownsanity.Map(i.values, func(v T) string {
+				return fmt.Sprintf("%q", any(v))
+			}),
+			", ",
+		)),
+	)
+}
+
+// In returns a rule that succeeds when the value matches one of the supplied
+// alternatives. The failure message lists the alternatives as
+// `must be one of: ["a", "b", ...]`, which is more actionable than
+// [validation.In]'s default `must be a valid value`. Empty values are passed
+// through; pair with [validation.Required] when the field is also required.
+func In[T any](values ...T) InRule {
+	return &inRule[T]{values: values}
+}

--- a/server/validators/validator.go
+++ b/server/validators/validator.go
@@ -1,0 +1,100 @@
+package validators
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/monetr/monetr/server/internal/myownsanity"
+	"github.com/monetr/monetr/server/merge"
+	"github.com/monetr/validation"
+	"github.com/pkg/errors"
+)
+
+var (
+	_ error          = OneOfError{}
+	_ json.Marshaler = OneOfError{}
+)
+
+// OneOfError is returned by [OneOf] and [OneOfStruct] when none of the
+// alternative schemas validate. Each entry is the [validation.Errors] produced
+// by one schema attempt, in the order the schemas were provided. Variants are
+// unlabeled on purpose: the per-rule errors inside each entry (in particular
+// the kind-discriminator field's failure or pass) tell the caller which
+// variant was being attempted.
+type OneOfError []validation.Errors
+
+// Error implements [error].
+func (o OneOfError) Error() string {
+	return fmt.Sprintf(
+		"input must be considered valid by: %s",
+		strings.Join(myownsanity.Map(o, func(err validation.Errors) string {
+			return err.Error()
+		}), " or "),
+	)
+}
+
+// MarshalJSON serializes a [OneOfError] for API responses. When there is a
+// single alternative (the common case for an endpoint that's only ever
+// validated against one schema, even though it goes through OneOf), the inner
+// [validation.Errors] is emitted directly so callers see a flat
+// {"field": "message"} object. When there are multiple alternatives (the
+// discriminated-union case), the output is {"oneOf": [<errs>, ...]}; nested
+// unions work because [validation.Errors.MarshalJSON] delegates to any nested
+// [json.Marshaler] values.
+func (o OneOfError) MarshalJSON() ([]byte, error) {
+	if len(o) == 1 {
+		return json.Marshal(o[0])
+	}
+	return json.Marshal(map[string]any{
+		"oneOf": []validation.Errors(o),
+	})
+}
+
+// OneOf takes multiple map rules and combines them into an "or" type schema. At
+// least one of the map rules provided must be considered valid. The first valid
+// map rule for the provided input is the one that is parsed, merged and
+// returned. If none of the rules are valid then an error is returned. If more
+// than one rule is valid, only the first valid rule is considered. Schemas
+// should be written such that they are mutually exclusive.
+// The input data is parsed over the existing data provided, but the existing
+// data is copied first such that a copy is returned with the valid and parsed
+// data returned. If the input is not valid then a simple copy of the existing
+// data is returned along with an error.
+func OneOf[T any](
+	ctx context.Context,
+	existing *T,
+	input map[string]any,
+	schemas ...validation.MapRule,
+) (T, error) {
+	if existing == nil {
+		existing = new(T)
+	}
+	errs := make(OneOfError, len(schemas))
+	for i, schema := range schemas {
+		err := validation.ValidateWithContext(
+			ctx,
+			&input,
+			schema,
+		)
+		switch err := err.(type) {
+		case validation.Errors:
+			errs[i] = err
+		case nil:
+			// On the first schema that is considered valid we return the parsed
+			// object from it.
+			output := *existing
+			if err := merge.Merge(
+				&output, input, merge.ErrorOnUnknownField,
+			); err != nil {
+				return *existing, errors.Wrap(err, "failed to merge patched data")
+			}
+			return output, nil
+		default:
+			return *existing, errors.Wrap(err, "failed to validate schema")
+		}
+	}
+
+	return *existing, errors.WithStack(errs)
+}


### PR DESCRIPTION
This PR won't be the complete CSV import feature, instead this PR is just laying the mapping and validation groundwork for the initial steps of the CSV import process.
