### PR TITLE
refactor(api): Adding transaction import groundwork

### DIFF
--- a/compose/monetr.yaml
+++ b/compose/monetr.yaml
@@ -17,6 +17,9 @@ backgroundjobs:
 redis:
   enabled: true
   address: valkey
+features:
+  # Enable transaction imports for local development.
+  transactionImports: true
 email:
   enabled: true
   domain: monetr.local

--- a/server/config/configuration.go
+++ b/server/config/configuration.go
@@ -40,6 +40,7 @@ type Configuration struct {
 	Beta          Beta          `yaml:"beta"`
 	CORS          CORS          `yaml:"cors"`
 	Email         Email         `yaml:"email"`
+	Features      Features      `yaml:"transactionImports"`
 	KeyManagement KeyManagement `yaml:"keyManagement"`
 	Links         Links         `yaml:"links"`
 	Logging       Logging       `yaml:"logging"`

--- a/server/config/features.go
+++ b/server/config/features.go
@@ -1,0 +1,9 @@
+package config
+
+type Features struct {
+	// TransactionImports is currently in development and so it is tucked behind a
+	// basic feature flag here in order to prevent its use while I'm still working
+	// on it. Transaction imports are different from transaction uploads. This
+	// flag defaults to `false`.
+	TransactionImports bool `yaml:"transactionImports"`
+}

--- a/server/controller/routes.go
+++ b/server/controller/routes.go
@@ -310,6 +310,10 @@ func (c *Controller) RegisterRoutes(app *echo.Echo) {
 	// Mappings
 	billed.GET("/mappings", c.getTransactionImportMappings)
 	billed.POST("/mappings", c.postTransactionImportMapping)
+	// Imports
+	billed.POST("/bank_accounts/:bankAccountId/transactions/import", c.postTransactionImport)
+	billed.GET("/bank_accounts/:bankAccountId/transactions/import/:transactionImportId", c.getTransactionImportById)
+	billed.PATCH("/bank_accounts/:bankAccountId/transactions/import/:transactionImportId", c.patchTransactionImport)
 	// Uploads
 	billed.GET("/files", c.getFiles)
 	// Funding schedules

--- a/server/controller/routes.go
+++ b/server/controller/routes.go
@@ -307,13 +307,17 @@ func (c *Controller) RegisterRoutes(app *echo.Echo) {
 	billed.GET("/bank_accounts/:bankAccountId/transactions/upload/:transactionUploadId/progress", c.getTransactionUploadProgress)
 	billed.PUT("/bank_accounts/:bankAccountId/transactions/:transactionId", c.putTransactions)
 	billed.DELETE("/bank_accounts/:bankAccountId/transactions/:transactionId", c.deleteTransactions)
-	// Mappings
-	billed.GET("/mappings", c.getTransactionImportMappings)
-	billed.POST("/mappings", c.postTransactionImportMapping)
-	// Imports
-	billed.POST("/bank_accounts/:bankAccountId/transactions/import", c.postTransactionImport)
-	billed.GET("/bank_accounts/:bankAccountId/transactions/import/:transactionImportId", c.getTransactionImportById)
-	billed.PATCH("/bank_accounts/:bankAccountId/transactions/import/:transactionImportId", c.patchTransactionImport)
+
+	// Mappings and transaction imports
+	if c.Configuration.Features.TransactionImports {
+		billed.GET("/mappings", c.getTransactionImportMappings)
+		billed.POST("/mappings", c.postTransactionImportMapping)
+		// Imports
+		billed.POST("/bank_accounts/:bankAccountId/transactions/import", c.postTransactionImport)
+		billed.GET("/bank_accounts/:bankAccountId/transactions/import/:transactionImportId", c.getTransactionImportById)
+		billed.PATCH("/bank_accounts/:bankAccountId/transactions/import/:transactionImportId", c.patchTransactionImport)
+	}
+
 	// Uploads
 	billed.GET("/files", c.getFiles)
 	// Funding schedules

--- a/server/controller/transaction_import_mappings_test.go
+++ b/server/controller/transaction_import_mappings_test.go
@@ -182,6 +182,8 @@ func TestPostTransactionImportMapping(t *testing.T) {
 			Expect()
 
 		response.Status(http.StatusOK)
+		response.JSON().Path("$.transactionImportMappingId").String().NotEmpty()
+		response.JSON().Path("$.signature").String().NotEmpty()
 	})
 }
 
@@ -218,7 +220,7 @@ func TestGetTransactionImportMappings(t *testing.T) {
 			}).
 			Expect()
 		first.Status(http.StatusOK)
-		firstId := first.JSON().Path("$.transactionImportMapping").String().Raw()
+		firstId := first.JSON().Path("$.transactionImportMappingId").String().Raw()
 
 		app.Clock.Add(1 * time.Minute)
 
@@ -236,7 +238,7 @@ func TestGetTransactionImportMappings(t *testing.T) {
 			}).
 			Expect()
 		second.Status(http.StatusOK)
-		secondId := second.JSON().Path("$.transactionImportMapping").String().Raw()
+		secondId := second.JSON().Path("$.transactionImportMappingId").String().Raw()
 
 		response := e.GET("/api/mappings").
 			WithCookie(TestCookieName, token).
@@ -244,8 +246,8 @@ func TestGetTransactionImportMappings(t *testing.T) {
 
 		response.Status(http.StatusOK)
 		response.JSON().Array().Length().IsEqual(2)
-		response.JSON().Path("$[0].transactionImportMapping").IsEqual(secondId)
-		response.JSON().Path("$[1].transactionImportMapping").IsEqual(firstId)
+		response.JSON().Path("$[0].transactionImportMappingId").IsEqual(secondId)
+		response.JSON().Path("$[1].transactionImportMappingId").IsEqual(firstId)
 	})
 
 	t.Run("filters by signature", func(t *testing.T) {
@@ -267,7 +269,7 @@ func TestGetTransactionImportMappings(t *testing.T) {
 			}).
 			Expect()
 		matching.Status(http.StatusOK)
-		matchingId := matching.JSON().Path("$.transactionImportMapping").String().Raw()
+		matchingId := matching.JSON().Path("$.transactionImportMappingId").String().Raw()
 		signature := matching.JSON().Path("$.signature").String().Raw()
 
 		other := e.POST("/api/mappings").
@@ -292,7 +294,7 @@ func TestGetTransactionImportMappings(t *testing.T) {
 
 		response.Status(http.StatusOK)
 		response.JSON().Array().Length().IsEqual(1)
-		response.JSON().Path("$[0].transactionImportMapping").IsEqual(matchingId)
+		response.JSON().Path("$[0].transactionImportMappingId").IsEqual(matchingId)
 		response.JSON().Path("$[0].signature").IsEqual(signature)
 	})
 

--- a/server/controller/transaction_imports.go
+++ b/server/controller/transaction_imports.go
@@ -1,0 +1,227 @@
+package controller
+
+import (
+	"net/http"
+	"path"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/monetr/monetr/server/datasources/csv"
+	"github.com/monetr/monetr/server/datasources/csv/csv_jobs"
+	. "github.com/monetr/monetr/server/models"
+)
+
+func (c *Controller) postTransactionImport(ctx echo.Context) error {
+	c.scrubSentryBody(ctx)
+
+	if !c.Configuration.Storage.Enabled {
+		return c.notFound(ctx, "File uploads are not enabled on this server")
+	}
+
+	bankAccountId, err := ParseID[BankAccount](ctx.Param("bankAccountId"))
+	if err != nil || bankAccountId.IsZero() {
+		return c.badRequest(ctx, "must specify a valid bank account Id")
+	}
+
+	log := c.getLog(ctx)
+
+	repo := c.mustGetAuthenticatedRepository(ctx)
+	transactionImport := TransactionImport{
+		BankAccountId: bankAccountId,
+		Status:        TransactionImportStatusMapping,
+	}
+
+	// Take the body and upload it as a file
+	// TODO Add ClamAV anti-virus here
+	{
+		form, err := ctx.MultipartForm()
+		if err != nil {
+			return c.badRequestError(ctx, err, "Failed to read file upload")
+		}
+		if len(form.File) != 1 || len(form.File["data"]) != 1 {
+			return c.badRequest(ctx, "exactly one file must be uploaded under field \"data\"")
+		}
+
+		reader, header, err := ctx.Request().FormFile("data")
+		if err != nil {
+			return c.badRequestError(ctx, err, "Failed to read file upload")
+		}
+		defer reader.Close()
+
+		if header.Size <= 0 {
+			return c.badRequest(ctx, "uploaded file must not be empty")
+		}
+
+		contentType := header.Header.Get("Content-Type")
+		extension := strings.ToLower(path.Ext(header.Filename))
+		log = log.With(
+			"contentType", contentType,
+			"fileName", header.Filename,
+			"extension", extension,
+		)
+
+		// TODO We only support CSV here, so we need to be able to attempt to parse
+		// the file before we store it.
+		headers, buffer, err := csv.PeekHeader(reader)
+		if err != nil {
+			return c.badRequestError(ctx, err, "Failed to parse CSV file")
+		}
+
+		file := File{
+			Name:        header.Filename,
+			Kind:        transactionImport.FileKind(),
+			ContentType: TextCSVContentType,
+			Size:        uint64(header.Size),
+			ExpiresAt:   transactionImport.FileExpiration(c.Clock),
+		}
+
+		if err := repo.CreateFile(c.getContext(ctx), &file); err != nil {
+			return c.wrapPgError(ctx, err, "Failed to create file")
+		}
+
+		err = c.FileStorage.Store(
+			c.getContext(ctx),
+			buffer,
+			file,
+		)
+		if err != nil {
+			return c.wrapAndReturnError(
+				ctx,
+				err,
+				http.StatusInternalServerError,
+				"Failed to upload file",
+			)
+		}
+
+		transactionImport.Headers = headers
+		transactionImport.FileId = file.FileId
+		transactionImport.File = &file
+	}
+
+	if err := repo.CreateTransactionImport(
+		c.getContext(ctx),
+		bankAccountId,
+		&transactionImport,
+	); err != nil {
+		return c.wrapPgError(ctx, err, "Failed to create transaction import")
+	}
+
+	return ctx.JSON(http.StatusOK, transactionImport)
+}
+
+func (c *Controller) getTransactionImportById(ctx echo.Context) error {
+	bankAccountId, err := ParseID[BankAccount](ctx.Param("bankAccountId"))
+	if err != nil || bankAccountId.IsZero() {
+		return c.badRequest(ctx, "must specify a valid bank account Id")
+	}
+
+	transactionImportId, err := ParseID[TransactionImport](ctx.Param("transactionImportId"))
+	if err != nil || transactionImportId.IsZero() {
+		return c.badRequest(ctx, "must specify a valid transaction import Id")
+	}
+
+	repo := c.mustGetAuthenticatedRepository(ctx)
+
+	existing, err := repo.GetTransactionImport(
+		c.getContext(ctx),
+		bankAccountId,
+		transactionImportId,
+	)
+	if err != nil {
+		return c.wrapPgError(ctx, err, "failed to retrieve transaction import")
+	}
+
+	return ctx.JSON(http.StatusOK, existing)
+}
+
+func (c *Controller) patchTransactionImport(ctx echo.Context) error {
+	// After the user has created their transaction import, then theyll get the
+	// header info back and need to map it. The frontend can look up mappings
+	// based on the header signature
+	// (?signature=sha256(join(sort(lower(headers)), ","))) to autofill the
+	// mappings if a similar file has been created before. The signature is
+	// case-insensitive so that "Date" and "date" match the same mapping. If the
+	// user modifies the mapping then they do a POST to the mapping endpoint, if
+	// the user uses the existing mapping then they can use that ID.
+	// The user then PATCH calls the transaction import with the mapping ID and
+	// updating the status to `preview`.
+	bankAccountId, err := ParseID[BankAccount](ctx.Param("bankAccountId"))
+	if err != nil || bankAccountId.IsZero() {
+		return c.badRequest(ctx, "must specify a valid bank account Id")
+	}
+
+	transactionImportId, err := ParseID[TransactionImport](ctx.Param("transactionImportId"))
+	if err != nil || transactionImportId.IsZero() {
+		return c.badRequest(ctx, "must specify a valid transaction import Id")
+	}
+
+	repo := c.mustGetAuthenticatedRepository(ctx)
+
+	existing, err := repo.GetTransactionImport(
+		c.getContext(ctx),
+		bankAccountId,
+		transactionImportId,
+	)
+	if err != nil {
+		return c.wrapPgError(ctx, err, "failed to retrieve transaction import")
+	}
+
+	transactionImport, err := parse(
+		c,
+		ctx,
+		existing,
+		existing.PatchSchemas()...,
+	)
+	if err != nil {
+		return err
+	}
+
+	// We only allow patching in two scenarios, when the new status is pending
+	// preview and when the new status is pending processing. And we only allow
+	// each to be specified when the current status is also in a specific state.
+	switch existing.Status {
+	case TransactionImportStatusMapping:
+		if transactionImport.Status != TransactionImportStatusPendingPreview {
+			return c.badRequest(ctx, "Cannot move a transaction import to any status other than pending preview from mapping")
+		}
+	case TransactionImportStatusPreview:
+		if transactionImport.Status != TransactionImportStatusPendingProcessing {
+			return c.badRequest(ctx, "Cannot move a transaction import to any status other than pending processing from preview")
+		}
+	}
+
+	if err = repo.UpdateTransactionImport(
+		c.getContext(ctx),
+		bankAccountId,
+		&transactionImport,
+	); err != nil {
+		return c.wrapPgError(ctx, err, "failed to update transaction import")
+	}
+
+	// TODO What about when we have other file types in the import path? Like
+	// OFX?
+	switch transactionImport.Status {
+	case TransactionImportStatusPendingPreview:
+		if err = enqueueJob(
+			c,
+			ctx,
+			csv_jobs.PreviewCSVImport,
+			csv_jobs.PreviewCSVImportArguments{
+				AccountId:           c.mustGetAccountId(ctx),
+				BankAccountId:       bankAccountId,
+				TransactionImportId: transactionImportId,
+			},
+		); err != nil {
+			return c.wrapAndReturnError(
+				ctx,
+				err,
+				http.StatusInternalServerError,
+				"failed to enqueue import preview job",
+			)
+		}
+	case TransactionImportStatusPendingProcessing:
+		// TODO Kick off processing
+	}
+
+	return ctx.JSON(http.StatusOK, transactionImport)
+}

--- a/server/controller/transaction_imports.go
+++ b/server/controller/transaction_imports.go
@@ -62,7 +62,7 @@ func (c *Controller) postTransactionImport(ctx echo.Context) error {
 
 		// TODO We only support CSV here, so we need to be able to attempt to parse
 		// the file before we store it.
-		headers, buffer, err := csv.PeekHeader(reader)
+		delimeter, headers, buffer, err := csv.PeekHeader(reader)
 		if err != nil {
 			return c.badRequestError(ctx, err, "Failed to parse CSV file")
 		}
@@ -94,6 +94,7 @@ func (c *Controller) postTransactionImport(ctx echo.Context) error {
 		}
 
 		transactionImport.Headers = headers
+		transactionImport.Delimeter = string(delimeter)
 		transactionImport.FileId = file.FileId
 		transactionImport.File = &file
 	}

--- a/server/controller/transaction_imports_test.go
+++ b/server/controller/transaction_imports_test.go
@@ -60,6 +60,7 @@ func TestPostTransactionImport(t *testing.T) {
 		response.Status(http.StatusOK)
 		response.JSON().Path("$.bankAccountId").String().IsEqual(bank.BankAccountId.String())
 		response.JSON().Path("$.fileId").String().NotEmpty()
+		response.JSON().Path("$.delimeter").IsEqual(",")
 		response.JSON().Path("$.headers").Array().IsEqual([]string{"Date", "Description", "Amount", "Balance"})
 	})
 
@@ -529,5 +530,282 @@ func TestPatchTransactionImport(t *testing.T) {
 		response.JSON().Path("$.status").String().IsEqual("pending-preview")
 	})
 
-	// TODO Add more tests for invalid paths here
+	t.Run("invalid status transition", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		var token string
+		var bank BankAccount
+
+		{ // Seed data
+			user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+			link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+			bank = fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+			token = GivenILogin(t, e, user.Login.Email, password)
+		}
+
+		csvData := []byte(
+			"Date,Description,Amount\n" +
+				"2026-01-15,COFFEE SHOP,-4.50\n" +
+				"2026-01-16,GAS STATION,-45.00\n",
+		)
+
+		// The POST upload triggers exactly one Store call. We don't care about the
+		// file contents at this layer, just that the upload path runs.
+		app.Storage.EXPECT().
+			Store(
+				gomock.Any(),
+				gomock.Any(),
+				gomock.Any(),
+			).
+			Times(1).
+			Return(nil)
+
+		var transactionImportId ID[TransactionImport]
+		{ // Upload the CSV. This creates the import in mapping status.
+			response := e.POST("/api/bank_accounts/{bankAccountId}/transactions/import").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithMultipart().
+				WithFileBytes("data", "transactions.csv", csvData).
+				WithCookie(TestCookieName, token).
+				Expect()
+
+			response.Status(http.StatusOK)
+			response.JSON().Path("$.status").String().IsEqual("mapping")
+			transactionImportId = ID[TransactionImport](response.JSON().Path("$.transactionImportId").String().Raw())
+		}
+
+		app.Queue.EXPECT().
+			EnqueueAt(
+				gomock.Any(),
+				mockqueue.EqQueue(csv_jobs.PreviewCSVImport),
+				gomock.Any(),
+				testutils.NewGenericMatcher(func(args csv_jobs.PreviewCSVImportArguments) bool {
+					return myownsanity.Every(
+						assert.EqualValues(t, bank.AccountId, args.AccountId, "Account ID should match"),
+						assert.EqualValues(t, bank.BankAccountId, args.BankAccountId, "Bank Account ID should match"),
+						assert.EqualValues(t, transactionImportId, args.TransactionImportId, "Transaction Import ID should match"),
+					)
+				}),
+			).
+			Times(0).
+			Return(nil)
+
+		response := e.PATCH("/api/bank_accounts/{bankAccountId}/transactions/import/{transactionImportId}").
+			WithPath("bankAccountId", bank.BankAccountId).
+			WithPath("transactionImportId", transactionImportId).
+			WithCookie(TestCookieName, token).
+			WithJSON(map[string]any{
+				"status": TransactionImportStatusPendingProcessing,
+			}).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.error").IsEqual("Cannot move a transaction import to any status other than pending preview from mapping")
+	})
+
+	t.Run("no cross account patching", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		var token string
+		var bank BankAccount
+
+		{ // Seed data
+			user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+			link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+			bank = fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+			token = GivenILogin(t, e, user.Login.Email, password)
+		}
+
+		csvData := []byte(
+			"Date,Description,Amount\n" +
+				"2026-01-15,COFFEE SHOP,-4.50\n" +
+				"2026-01-16,GAS STATION,-45.00\n",
+		)
+
+		// The POST upload triggers exactly one Store call. We don't care about the
+		// file contents at this layer, just that the upload path runs.
+		app.Storage.EXPECT().
+			Store(
+				gomock.Any(),
+				gomock.Any(),
+				gomock.Any(),
+			).
+			Times(1).
+			Return(nil)
+
+		var transactionImportId ID[TransactionImport]
+		{ // Upload the CSV. This creates the import in mapping status.
+			response := e.POST("/api/bank_accounts/{bankAccountId}/transactions/import").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithMultipart().
+				WithFileBytes("data", "transactions.csv", csvData).
+				WithCookie(TestCookieName, token).
+				Expect()
+
+			response.Status(http.StatusOK)
+			response.JSON().Path("$.status").String().IsEqual("mapping")
+			transactionImportId = ID[TransactionImport](response.JSON().Path("$.transactionImportId").String().Raw())
+		}
+
+		app.Queue.EXPECT().
+			EnqueueAt(
+				gomock.Any(),
+				mockqueue.EqQueue(csv_jobs.PreviewCSVImport),
+				gomock.Any(),
+				testutils.NewGenericMatcher(func(args csv_jobs.PreviewCSVImportArguments) bool {
+					return myownsanity.Every(
+						assert.EqualValues(t, bank.AccountId, args.AccountId, "Account ID should match"),
+						assert.EqualValues(t, bank.BankAccountId, args.BankAccountId, "Bank Account ID should match"),
+						assert.EqualValues(t, transactionImportId, args.TransactionImportId, "Transaction Import ID should match"),
+					)
+				}),
+			).
+			Times(0).
+			Return(nil)
+
+		{
+			// Create another use and try to patch the original import
+			user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+			token = GivenILogin(t, e, user.Login.Email, password)
+
+			// Create the mapping under the new user
+			var mappingId ID[TransactionImportMapping]
+			{
+				response := e.POST("/api/mappings").
+					WithCookie(TestCookieName, token).
+					WithJSON(map[string]any{
+						"mapping": map[string]any{
+							"id": map[string]any{
+								"kind": "hashed",
+								"fields": []any{
+									map[string]any{
+										"name": "Date",
+									},
+									map[string]any{
+										"name": "Description",
+									},
+									map[string]any{
+										"name": "Amount",
+									},
+								},
+							},
+							"amount": map[string]any{
+								"kind": "sign",
+								"fields": []any{
+									map[string]any{
+										"name": "Amount",
+									},
+								},
+							},
+							"memo": map[string]any{
+								"name": "Description",
+							},
+							"date": map[string]any{
+								"fields": []any{
+									map[string]any{
+										"name": "Date",
+									},
+								},
+								"format": "YYYY-MM-DD",
+							},
+							"balance": map[string]any{
+								"kind": "none",
+							},
+							"headers": []string{
+								"Date",
+								"Description",
+								"Amount",
+							},
+						},
+					}).
+					Expect()
+
+				response.Status(http.StatusOK)
+				mappingId = ID[TransactionImportMapping](response.JSON().Path("$.transactionImportMappingId").String().Raw())
+			}
+
+			response := e.PATCH("/api/bank_accounts/{bankAccountId}/transactions/import/{transactionImportId}").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithPath("transactionImportId", transactionImportId).
+				WithCookie(TestCookieName, token).
+				WithJSON(map[string]any{
+					"transactionImportMappingId": mappingId,
+					"status":                     TransactionImportStatusPendingPreview,
+				}).
+				Expect()
+
+			response.Status(http.StatusNotFound)
+			response.JSON().Path("$.error").IsEqual("failed to retrieve transaction import: record does not exist")
+		}
+	})
+
+	t.Run("patch invalid field", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		var token string
+		var bank BankAccount
+
+		{ // Seed data
+			user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+			link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+			bank = fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+			token = GivenILogin(t, e, user.Login.Email, password)
+		}
+
+		csvData := []byte(
+			"Date,Description,Amount\n" +
+				"2026-01-15,COFFEE SHOP,-4.50\n" +
+				"2026-01-16,GAS STATION,-45.00\n",
+		)
+
+		// The POST upload triggers exactly one Store call. We don't care about the
+		// file contents at this layer, just that the upload path runs.
+		app.Storage.EXPECT().
+			Store(
+				gomock.Any(),
+				gomock.Any(),
+				gomock.Any(),
+			).
+			Times(1).
+			Return(nil)
+
+		var transactionImportId ID[TransactionImport]
+		{ // Upload the CSV. This creates the import in mapping status.
+			response := e.POST("/api/bank_accounts/{bankAccountId}/transactions/import").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithMultipart().
+				WithFileBytes("data", "transactions.csv", csvData).
+				WithCookie(TestCookieName, token).
+				Expect()
+
+			response.Status(http.StatusOK)
+			response.JSON().Path("$.status").String().IsEqual("mapping")
+			transactionImportId = ID[TransactionImport](response.JSON().Path("$.transactionImportId").String().Raw())
+		}
+
+		app.Queue.EXPECT().
+			EnqueueAt(
+				gomock.Any(),
+				mockqueue.EqQueue(csv_jobs.PreviewCSVImport),
+				gomock.Any(),
+				testutils.NewGenericMatcher(func(args csv_jobs.PreviewCSVImportArguments) bool {
+					return myownsanity.Every(
+						assert.EqualValues(t, bank.AccountId, args.AccountId, "Account ID should match"),
+						assert.EqualValues(t, bank.BankAccountId, args.BankAccountId, "Bank Account ID should match"),
+						assert.EqualValues(t, transactionImportId, args.TransactionImportId, "Transaction Import ID should match"),
+					)
+				}),
+			).
+			Times(0).
+			Return(nil)
+
+		response := e.PATCH("/api/bank_accounts/{bankAccountId}/transactions/import/{transactionImportId}").
+			WithPath("bankAccountId", bank.BankAccountId).
+			WithPath("transactionImportId", transactionImportId).
+			WithCookie(TestCookieName, token).
+			WithJSON(map[string]any{
+				"fileId": "file_bogus",
+			}).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.error").IsEqual("Invalid request")
+	})
 }

--- a/server/controller/transaction_imports_test.go
+++ b/server/controller/transaction_imports_test.go
@@ -1,0 +1,533 @@
+package controller_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/monetr/monetr/server/datasources/csv/csv_jobs"
+	"github.com/monetr/monetr/server/internal/fixtures"
+	"github.com/monetr/monetr/server/internal/mockqueue"
+	"github.com/monetr/monetr/server/internal/myownsanity"
+	"github.com/monetr/monetr/server/internal/testutils"
+	"github.com/monetr/monetr/server/models"
+	. "github.com/monetr/monetr/server/models"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestPostTransactionImport(t *testing.T) {
+	t.Run("import CSV success", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		var token string
+		var bank BankAccount
+
+		{ // Seed data
+			user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+			link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+			bank = fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+			token = GivenILogin(t, e, user.Login.Email, password)
+		}
+
+		csvData := []byte(
+			"Date,Description,Amount,Balance\n" +
+				"2026-01-15,COFFEE SHOP,-4.50,1234.56\n" +
+				"2026-01-16,GAS STATION,-45.00,1189.56\n",
+		)
+
+		app.Storage.EXPECT().
+			Store(
+				gomock.Any(),
+				gomock.Any(),
+				testutils.NewGenericMatcher(func(file models.File) bool {
+					return myownsanity.Every(
+						assert.Equal(t, "transactions.csv", file.Name),
+						assert.Equal(t, "transactions/imports", file.Kind),
+						assert.Equal(t, bank.AccountId, file.AccountId),
+						assert.Equal(t, models.TextCSVContentType, file.ContentType),
+					)
+				}),
+			).
+			Times(1).
+			Return(nil)
+
+		response := e.POST("/api/bank_accounts/{bankAccountId}/transactions/import").
+			WithPath("bankAccountId", bank.BankAccountId).
+			WithMultipart().
+			WithFileBytes("data", "transactions.csv", csvData).
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusOK)
+		response.JSON().Path("$.bankAccountId").String().IsEqual(bank.BankAccountId.String())
+		response.JSON().Path("$.fileId").String().NotEmpty()
+		response.JSON().Path("$.headers").Array().IsEqual([]string{"Date", "Description", "Amount", "Balance"})
+	})
+
+	t.Run("rejects non-CSV input", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		var token string
+		var bank BankAccount
+
+		{ // Seed data
+			user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+			link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+			bank = fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+			token = GivenILogin(t, e, user.Login.Email, password)
+		}
+
+		app.Storage.EXPECT().
+			Store(
+				gomock.Any(),
+				gomock.Any(),
+				gomock.Any(),
+			).
+			Times(0)
+
+		response := e.POST("/api/bank_accounts/{bankAccountId}/transactions/import").
+			WithPath("bankAccountId", bank.BankAccountId).
+			WithMultipart().
+			WithFileBytes("data", "not-a-csv.txt", []byte("this is just a sentence with no delimiters whatsoever")).
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.error").String().IsEqual("Failed to parse CSV file")
+	})
+
+	t.Run("rejects multiple files in the same request", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		var token string
+		var bank BankAccount
+
+		{ // Seed data
+			user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+			link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+			bank = fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+			token = GivenILogin(t, e, user.Login.Email, password)
+		}
+
+		app.Storage.EXPECT().
+			Store(
+				gomock.Any(),
+				gomock.Any(),
+				gomock.Any(),
+			).
+			Times(0)
+
+		response := e.POST("/api/bank_accounts/{bankAccountId}/transactions/import").
+			WithPath("bankAccountId", bank.BankAccountId).
+			WithMultipart().
+			WithFileBytes("data", "first.csv", []byte("Date,Description,Amount\n2026-01-15,COFFEE,-4.50\n")).
+			WithFileBytes("data", "second.csv", []byte("Date,Description,Amount\n2026-01-16,GAS,-45.00\n")).
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.error").String().IsEqual("exactly one file must be uploaded under field \"data\"")
+	})
+
+	t.Run("storage disabled", func(t *testing.T) {
+		config := NewTestApplicationConfig(t)
+		config.Storage.Enabled = false
+		app, e := NewTestApplicationWithConfig(t, config)
+		var token string
+		var bank BankAccount
+
+		{ // Seed data
+			user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+			link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+			bank = fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+			token = GivenILogin(t, e, user.Login.Email, password)
+		}
+
+		app.Storage.EXPECT().
+			Store(
+				gomock.Any(),
+				gomock.Any(),
+				gomock.Any(),
+			).
+			Times(0)
+
+		response := e.POST("/api/bank_accounts/{bankAccountId}/transactions/import").
+			WithPath("bankAccountId", bank.BankAccountId).
+			WithMultipart().
+			WithFileBytes("data", "transactions.csv", []byte("Date,Description,Amount\n2026-01-15,COFFEE,-4.50\n")).
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusNotFound)
+		response.JSON().Path("$.error").String().IsEqual("File uploads are not enabled on this server")
+	})
+
+	t.Run("requires authentication", func(t *testing.T) {
+		_, e := NewTestApplication(t)
+
+		response := e.POST("/api/bank_accounts/{bankAccountId}/transactions/import").
+			WithPath("bankAccountId", "bac_unauthorized_test").
+			WithMultipart().
+			WithFileBytes("data", "transactions.csv", []byte("Date,Description,Amount\n2026-01-15,COFFEE,-4.50\n")).
+			Expect()
+
+		response.Status(http.StatusUnauthorized)
+	})
+}
+
+func TestGetTransactionImport(t *testing.T) {
+	t.Run("retrieve a transaction import by ID", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		app.Storage.EXPECT().
+			Store(
+				gomock.Any(),
+				gomock.Any(),
+				gomock.Any(),
+			).
+			Times(1).
+			Return(nil)
+
+		var transactionImportId ID[TransactionImport]
+		{ // Create the transaction import.
+			response := e.POST("/api/bank_accounts/{bankAccountId}/transactions/import").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithMultipart().
+				WithFileBytes("data", "transactions.csv", []byte("Date,Description,Amount\n2026-01-15,COFFEE,-4.50\n")).
+				WithCookie(TestCookieName, token).
+				Expect()
+
+			response.Status(http.StatusOK)
+			response.JSON().Path("$.transactionImportId").String().IsASCII()
+
+			// Save the ID of the created transaction import so we can use it below.
+			transactionImportId = ID[TransactionImport](response.JSON().Path("$.transactionImportId").String().Raw())
+		}
+
+		response := e.GET("/api/bank_accounts/{bankAccountId}/transactions/import/{transactionImportId}").
+			WithPath("bankAccountId", bank.BankAccountId).
+			WithPath("transactionImportId", transactionImportId).
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusOK)
+		response.JSON().Path("$.transactionImportId").IsEqual(transactionImportId)
+		response.JSON().Path("$.bankAccountId").IsEqual(bank.BankAccountId)
+		response.JSON().Path("$.fileId").String().NotEmpty()
+		response.JSON().Path("$.headers").Array().IsEqual([]string{"Date", "Description", "Amount"})
+		response.JSON().Path("$.status").IsEqual("mapping")
+	})
+
+	t.Run("invalid bank account ID", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		response := e.GET("/api/bank_accounts/{bankAccountId}/transactions/import/{transactionImportId}").
+			WithPath("bankAccountId", "bogus_bank_id").
+			WithPath("transactionImportId", "txim_anything").
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.error").String().IsEqual("must specify a valid bank account Id")
+	})
+
+	t.Run("invalid transaction import ID", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		response := e.GET("/api/bank_accounts/{bankAccountId}/transactions/import/{transactionImportId}").
+			WithPath("bankAccountId", bank.BankAccountId).
+			WithPath("transactionImportId", "bogus_import").
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.error").String().IsEqual("must specify a valid transaction import Id")
+	})
+
+	t.Run("zero transaction import ID", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		// A bare prefix parses without error but is zero, so it must be
+		// rejected before it reaches the database.
+		response := e.GET("/api/bank_accounts/{bankAccountId}/transactions/import/{transactionImportId}").
+			WithPath("bankAccountId", bank.BankAccountId).
+			WithPath("transactionImportId", "txim_").
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.error").String().IsEqual("must specify a valid transaction import Id")
+	})
+
+	t.Run("non-existant transaction import", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+		bank := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		response := e.GET("/api/bank_accounts/{bankAccountId}/transactions/import/{transactionImportId}").
+			WithPath("bankAccountId", bank.BankAccountId).
+			WithPath("transactionImportId", "txim_bogus").
+			WithCookie(TestCookieName, token).
+			Expect()
+
+		response.Status(http.StatusNotFound)
+		response.JSON().Path("$.error").String().IsEqual("failed to retrieve transaction import: record does not exist")
+	})
+
+	t.Run("cant get a transaction import from a different bank account", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+		bankOne := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+		bankTwo := fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+		token := GivenILogin(t, e, user.Login.Email, password)
+
+		app.Storage.EXPECT().
+			Store(
+				gomock.Any(),
+				gomock.Any(),
+				gomock.Any(),
+			).
+			Times(1).
+			Return(nil)
+
+		var transactionImportId ID[TransactionImport]
+		{ // Create the transaction import under the first bank account.
+			response := e.POST("/api/bank_accounts/{bankAccountId}/transactions/import").
+				WithPath("bankAccountId", bankOne.BankAccountId).
+				WithMultipart().
+				WithFileBytes("data", "transactions.csv", []byte("Date,Description,Amount\n2026-01-15,COFFEE,-4.50\n")).
+				WithCookie(TestCookieName, token).
+				Expect()
+
+			response.Status(http.StatusOK)
+			transactionImportId = ID[TransactionImport](response.JSON().Path("$.transactionImportId").String().Raw())
+		}
+
+		{ // Then try to read it under the second bank account.
+			response := e.GET("/api/bank_accounts/{bankAccountId}/transactions/import/{transactionImportId}").
+				WithPath("bankAccountId", bankTwo.BankAccountId).
+				WithPath("transactionImportId", transactionImportId).
+				WithCookie(TestCookieName, token).
+				Expect()
+
+			response.Status(http.StatusNotFound)
+			response.JSON().Path("$.error").String().IsEqual("failed to retrieve transaction import: record does not exist")
+		}
+	})
+
+	t.Run("cant get someone elses transaction import by ID", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		var token string
+		var bank BankAccount
+		var transactionImportId ID[TransactionImport]
+
+		{ // Create a bank account and transaction import under one user.
+			user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+			link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+			bank = fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+			tok := GivenILogin(t, e, user.Login.Email, password)
+
+			app.Storage.EXPECT().
+				Store(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).
+				Times(1).
+				Return(nil)
+
+			response := e.POST("/api/bank_accounts/{bankAccountId}/transactions/import").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithMultipart().
+				WithFileBytes("data", "transactions.csv", []byte("Date,Description,Amount\n2026-01-15,COFFEE,-4.50\n")).
+				WithCookie(TestCookieName, tok).
+				Expect()
+
+			response.Status(http.StatusOK)
+			transactionImportId = ID[TransactionImport](response.JSON().Path("$.transactionImportId").String().Raw())
+		}
+
+		{ // Create another user.
+			user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+			token = GivenILogin(t, e, user.Login.Email, password)
+		}
+
+		{ // Try to get the transaction import using the other user's bank account and import IDs.
+			response := e.GET("/api/bank_accounts/{bankAccountId}/transactions/import/{transactionImportId}").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithPath("transactionImportId", transactionImportId).
+				WithCookie(TestCookieName, token).
+				Expect()
+
+			response.Status(http.StatusNotFound)
+			response.JSON().Path("$.error").String().IsEqual("failed to retrieve transaction import: record does not exist")
+		}
+	})
+}
+
+func TestPatchTransactionImport(t *testing.T) {
+	t.Run("selecting a mapping kicks off the preview job", func(t *testing.T) {
+		// End-to-end happy path for the mapping -> pending-preview transition. The
+		// user uploads a CSV (which lands in the mapping status), creates a
+		// TransactionImportMapping that lines up with the file's headers, then
+		// PATCHes the import with that mapping id and status=pending-preview. The
+		// controller must persist the new status and enqueue
+		// [csv_jobs.PreviewCSVImport] inside the same transaction it used for the
+		// patch, with the right Account/BankAccount/TransactionImport ids in the
+		// args.
+		app, e := NewTestApplication(t)
+		var token string
+		var bank BankAccount
+
+		{ // Seed data
+			user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+			link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+			bank = fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+			token = GivenILogin(t, e, user.Login.Email, password)
+		}
+
+		csvData := []byte(
+			"Date,Description,Amount\n" +
+				"2026-01-15,COFFEE SHOP,-4.50\n" +
+				"2026-01-16,GAS STATION,-45.00\n",
+		)
+
+		// The POST upload triggers exactly one Store call. We don't care about the
+		// file contents at this layer, just that the upload path runs.
+		app.Storage.EXPECT().
+			Store(
+				gomock.Any(),
+				gomock.Any(),
+				gomock.Any(),
+			).
+			Times(1).
+			Return(nil)
+
+		var transactionImportId ID[TransactionImport]
+		{ // Upload the CSV. This creates the import in mapping status.
+			response := e.POST("/api/bank_accounts/{bankAccountId}/transactions/import").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithMultipart().
+				WithFileBytes("data", "transactions.csv", csvData).
+				WithCookie(TestCookieName, token).
+				Expect()
+
+			response.Status(http.StatusOK)
+			response.JSON().Path("$.status").String().IsEqual("mapping")
+			transactionImportId = ID[TransactionImport](response.JSON().Path("$.transactionImportId").String().Raw())
+		}
+
+		var mappingId ID[TransactionImportMapping]
+		{ // Create a mapping whose headers line up with the uploaded CSV. The id is
+			// hashed across all three columns since the file does not carry its own
+			// stable identifier.
+			response := e.POST("/api/mappings").
+				WithCookie(TestCookieName, token).
+				WithJSON(map[string]any{
+					"mapping": map[string]any{
+						"id": map[string]any{
+							"kind": "hashed",
+							"fields": []any{
+								map[string]any{
+									"name": "Date",
+								},
+								map[string]any{
+									"name": "Description",
+								},
+								map[string]any{
+									"name": "Amount",
+								},
+							},
+						},
+						"amount": map[string]any{
+							"kind": "sign",
+							"fields": []any{
+								map[string]any{
+									"name": "Amount",
+								},
+							},
+						},
+						"memo": map[string]any{
+							"name": "Description",
+						},
+						"date": map[string]any{
+							"fields": []any{
+								map[string]any{
+									"name": "Date",
+								},
+							},
+							"format": "YYYY-MM-DD",
+						},
+						"balance": map[string]any{
+							"kind": "none",
+						},
+						"headers": []string{
+							"Date",
+							"Description",
+							"Amount",
+						},
+					},
+				}).
+				Expect()
+
+			response.Status(http.StatusOK)
+			mappingId = ID[TransactionImportMapping](response.JSON().Path("$.transactionImportMappingId").String().Raw())
+		}
+
+		// The PATCH wraps the enqueue in the same db transaction as the status
+		// update via [controller.enqueueJob], so WithTransaction lands first and
+		// the EnqueueAt call lands on the transactional queue. Returning app.Queue
+		// from WithTransaction is the convention the OFX upload tests use too.
+		app.Queue.EXPECT().
+			WithTransaction(
+				gomock.Any(),
+			).
+			Return(app.Queue)
+		app.Queue.EXPECT().
+			EnqueueAt(
+				gomock.Any(),
+				mockqueue.EqQueue(csv_jobs.PreviewCSVImport),
+				gomock.Any(),
+				testutils.NewGenericMatcher(func(args csv_jobs.PreviewCSVImportArguments) bool {
+					return myownsanity.Every(
+						assert.EqualValues(t, bank.AccountId, args.AccountId, "Account ID should match"),
+						assert.EqualValues(t, bank.BankAccountId, args.BankAccountId, "Bank Account ID should match"),
+						assert.EqualValues(t, transactionImportId, args.TransactionImportId, "Transaction Import ID should match"),
+					)
+				}),
+			).
+			Times(1).
+			Return(nil)
+
+		response := e.PATCH("/api/bank_accounts/{bankAccountId}/transactions/import/{transactionImportId}").
+			WithPath("bankAccountId", bank.BankAccountId).
+			WithPath("transactionImportId", transactionImportId).
+			WithCookie(TestCookieName, token).
+			WithJSON(map[string]any{
+				"transactionImportMappingId": mappingId,
+				"status":                     TransactionImportStatusPendingPreview,
+			}).
+			Expect()
+
+		response.Status(http.StatusOK)
+		response.JSON().Path("$.transactionImportId").IsEqual(transactionImportId)
+		response.JSON().Path("$.transactionImportMappingId").IsEqual(mappingId)
+		response.JSON().Path("$.status").String().IsEqual("pending-preview")
+	})
+
+	// TODO Add more tests for invalid paths here
+}

--- a/server/datasources/csv/CMakeLists.txt
+++ b/server/datasources/csv/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(GolangTestUtils)
+
+provision_golang_tests(${CMAKE_CURRENT_SOURCE_DIR})

--- a/server/datasources/csv/csv_jobs/preview_csv_import.go
+++ b/server/datasources/csv/csv_jobs/preview_csv_import.go
@@ -1,0 +1,148 @@
+package csv_jobs
+
+import (
+	"encoding/csv"
+	"io"
+	"log/slog"
+	"time"
+
+	"github.com/monetr/monetr/server/crumbs"
+	"github.com/monetr/monetr/server/datasources/table"
+	"github.com/monetr/monetr/server/models"
+	"github.com/monetr/monetr/server/queue"
+	"github.com/monetr/monetr/server/repository"
+	"github.com/pkg/errors"
+)
+
+type PreviewCSVImportArguments struct {
+	AccountId           models.ID[models.Account]           `json:"accountId"`
+	BankAccountId       models.ID[models.BankAccount]       `json:"bankAccountId"`
+	TransactionImportId models.ID[models.TransactionImport] `json:"transactionImportId"`
+}
+
+type previewCSVImport struct {
+	args     PreviewCSVImportArguments
+	log      *slog.Logger
+	repo     repository.BaseRepository
+	timezone *time.Location
+
+	bankAccount          *models.BankAccount
+	transactionImport    *models.TransactionImport
+	file                 *models.File
+	currency             string
+	rows                 []table.Row
+	existingTransactions map[string]models.Transaction
+}
+
+// loadFile takes the ID of the [models.TrasactionUpload] and reads the file
+// from the storage system. If this fails due to a retryable issue then an error
+// is returned so the job can be re-attempted. If this fails due to a bad file,
+// then this function panics so that the job is not retried.
+func (j *previewCSVImport) loadFile(
+	ctx queue.Context,
+) error {
+	span := crumbs.StartFnTrace(ctx)
+	defer span.Finish()
+
+	transactionImport, err := j.repo.GetTransactionImport(
+		span.Context(),
+		j.args.BankAccountId,
+		j.args.TransactionImportId,
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to retrieve transaction import")
+	}
+	j.transactionImport = transactionImport
+
+	file, err := j.repo.GetFile(span.Context(), transactionImport.FileId)
+	if err != nil {
+		return errors.Wrap(err, "could not get file for processing")
+	}
+	j.file = file
+
+	if file.DeletedAt != nil {
+		return errors.New("cannot import transactions from a deleted file")
+	}
+
+	fileReader, err := ctx.Storage().Read(span.Context(), *file)
+	if err != nil {
+		return errors.Wrap(err, "failed to access file from storage")
+	}
+	defer fileReader.Close()
+
+	// TODO Store the delimiter on the import so we can use it here.
+	csvReader := csv.NewReader(fileReader)
+	csvReader.TrimLeadingSpace = true
+
+	tableReader := table.NewTable(
+		csvReader,
+		&j.transactionImport.TransactionImportMapping.Mapping,
+		true, // Store this too?
+	)
+	// TODO, make arbitrary max number of rows supported a const
+	for i := 0; i < 100000; i++ {
+		row, err := tableReader.Read()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return errors.Wrap(err, "failed to parse csv file")
+		}
+		j.rows = append(j.rows, *row)
+	}
+
+	return nil
+}
+
+func PreviewCSVImport(
+	ctx queue.Context,
+	args PreviewCSVImportArguments,
+) error {
+	crumbs.IncludeUserInScope(ctx, args.AccountId)
+
+	return ctx.RunInTransaction(ctx, func(ctx queue.Context) error {
+		log := ctx.Log().With(
+			"accountId", args.AccountId,
+			"transactionImportId", args.TransactionImportId,
+			"bankAccountId", args.BankAccountId,
+		)
+		j := &previewCSVImport{
+			args: args,
+			log:  log,
+			repo: repository.NewRepositoryFromSession(
+				ctx.Clock(),
+				"user_system",
+				args.AccountId,
+				ctx.DB(),
+				log,
+			),
+			existingTransactions: map[string]models.Transaction{},
+		}
+
+		account, err := j.repo.GetAccount(ctx)
+		if err != nil {
+			j.log.ErrorContext(ctx, "failed to retrieve account for job", "err", err)
+			return err
+		}
+
+		j.timezone, err = account.GetTimezone()
+		if err != nil {
+			j.log.WarnContext(ctx, "failed to get account's time zone, defaulting to UTC", "err", err)
+			j.timezone = time.UTC
+		}
+
+		// Load the bank account ahead of processing the file, we need this for
+		// currency data and will use it for balance updates later.
+		j.bankAccount, err = j.repo.GetBankAccount(ctx, args.BankAccountId)
+		if err != nil {
+			return errors.Wrap(err, "failed to retrieve bank account for file import sync")
+		}
+
+		// Load the file and its data into memory.
+		if err := j.loadFile(ctx); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}

--- a/server/datasources/csv/csv_jobs/preview_csv_import.go
+++ b/server/datasources/csv/csv_jobs/preview_csv_import.go
@@ -91,6 +91,12 @@ func (j *previewCSVImport) loadFile(
 		j.rows = append(j.rows, *row)
 	}
 
+	j.log.DebugContext(
+		ctx,
+		"parsed rows from CSV file for preview",
+		"rows", j.rows,
+	)
+
 	return nil
 }
 

--- a/server/datasources/csv/header.go
+++ b/server/datasources/csv/header.go
@@ -25,11 +25,11 @@ var testDelimeters = []rune{
 // parsed.
 func PeekHeader(
 	reader io.Reader,
-) ([]string, io.Reader, error) {
+) (delimiter rune, headers []string, output io.Reader, err error) {
 	buffer := bufio.NewReaderSize(reader, peekSize)
 	preview, err := buffer.Peek(peekSize)
 	if err != nil && err != io.EOF {
-		return nil, nil, errors.WithStack(err)
+		return ',', nil, nil, errors.WithStack(err)
 	}
 
 	for _, delimeter := range testDelimeters {
@@ -48,9 +48,9 @@ func PeekHeader(
 		// - Amount
 		// - Description
 		if len(header) >= 3 {
-			return header, buffer, nil
+			return delimeter, header, buffer, nil
 		}
 	}
 
-	return nil, nil, errors.New("failed to determine CSV headers")
+	return ',', nil, nil, errors.New("failed to determine CSV headers")
 }

--- a/server/datasources/csv/header.go
+++ b/server/datasources/csv/header.go
@@ -1,0 +1,56 @@
+package csv
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/csv"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+const peekSize = 1000
+
+var testDelimeters = []rune{
+	',',
+	'|',
+	'\t',
+}
+
+// PeekHeader reads the first [peekSize] of the provided reader, making a copy
+// of it such that an intact reader can be returned in order to facilitate file
+// uploads. If the first peek of the data contains valid CSV data then the
+// headers of the file are returned with a buffer to upload the file. If the
+// file is not valid then an error is returned indicating that it cannot be
+// parsed.
+func PeekHeader(
+	reader io.Reader,
+) ([]string, io.Reader, error) {
+	buffer := bufio.NewReaderSize(reader, peekSize)
+	preview, err := buffer.Peek(peekSize)
+	if err != nil && err != io.EOF {
+		return nil, nil, errors.WithStack(err)
+	}
+
+	for _, delimeter := range testDelimeters {
+		csvReader := csv.NewReader(bytes.NewReader(preview))
+		csvReader.Comma = delimeter
+		csvReader.TrimLeadingSpace = true
+
+		header, err := csvReader.Read()
+		if err != nil {
+			// TODO Log the error?
+			continue
+		}
+
+		// We must have at least:
+		// - Date
+		// - Amount
+		// - Description
+		if len(header) >= 3 {
+			return header, buffer, nil
+		}
+	}
+
+	return nil, nil, errors.New("failed to determine CSV headers")
+}

--- a/server/datasources/csv/header_test.go
+++ b/server/datasources/csv/header_test.go
@@ -17,8 +17,9 @@ func TestPeekHeader(t *testing.T) {
 			"2026-01-15,COFFEE SHOP,-4.50,1234.56\n" +
 			"2026-01-16,GAS STATION,-45.00,1189.56\n"
 
-		headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
+		delimeter, headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
 		require.NoError(t, err, "must parse a comma-delimited CSV")
+		assert.Equal(t, ',', delimeter)
 		assert.Equal(t, []string{"Date", "Description", "Amount", "Balance"}, headers, "must extract all four headers")
 
 		contents, err := io.ReadAll(reader)
@@ -31,8 +32,9 @@ func TestPeekHeader(t *testing.T) {
 			"2026-01-15|GROCERY|-42.10\n" +
 			"2026-01-16|RESTAURANT|-23.45\n"
 
-		headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
+		delimeter, headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
 		require.NoError(t, err, "must parse a pipe-delimited CSV")
+		assert.Equal(t, '|', delimeter)
 		assert.Equal(t, []string{"Date", "Description", "Amount"}, headers, "must extract pipe-delimited headers")
 
 		contents, err := io.ReadAll(reader)
@@ -45,7 +47,8 @@ func TestPeekHeader(t *testing.T) {
 			"2026-01-15\tUTIL\t-99.00\tBills\n" +
 			"2026-01-16\tPAYCHECK\t2000.00\tIncome\n"
 
-		headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
+		delimeter, headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
+		assert.Equal(t, '\t', delimeter)
 		require.NoError(t, err, "must parse a tab-delimited CSV")
 		assert.Equal(t, []string{"Date", "Description", "Amount", "Category"}, headers, "must extract tab-delimited headers")
 
@@ -58,7 +61,8 @@ func TestPeekHeader(t *testing.T) {
 		input := "Date, Description, Amount\n" +
 			"2026-01-15, COFFEE, -4.50\n"
 
-		headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
+		delimeter, headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
+		assert.Equal(t, ',', delimeter)
 		require.NoError(t, err, "must parse CSV with leading spaces")
 		assert.Equal(t, []string{"Date", "Description", "Amount"}, headers, "leading spaces must be trimmed from headers")
 
@@ -71,7 +75,8 @@ func TestPeekHeader(t *testing.T) {
 		input := "Date,Description,Amount,Balance\n" +
 			"2026-01-15,\"PAYROLL, INC\",\"1,234.56\",\"10,000.00\"\n"
 
-		headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
+		delimeter, headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
+		assert.Equal(t, ',', delimeter)
 		require.NoError(t, err, "must parse CSV with quoted comma fields")
 		assert.Equal(t, []string{"Date", "Description", "Amount", "Balance"}, headers, "headers must be extracted despite quoted commas in body rows")
 
@@ -86,7 +91,8 @@ func TestPeekHeader(t *testing.T) {
 		// parses into a valid header row.
 		input := "Date,Description,Amount\n2026-01-15,COFFEE,-4.50\n"
 
-		headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
+		delimeter, headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
+		assert.Equal(t, ',', delimeter)
 		require.NoError(t, err, "short CSV must still parse")
 		assert.Equal(t, []string{"Date", "Description", "Amount"}, headers, "short-input headers must be extracted")
 
@@ -108,7 +114,8 @@ func TestPeekHeader(t *testing.T) {
 		input := b.String()
 		require.Greater(t, len(input), 1000, "test setup: input must exceed the 1000-byte peek window")
 
-		headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
+		delimeter, headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
+		assert.Equal(t, ',', delimeter)
 		require.NoError(t, err, "large CSV must parse")
 		assert.Equal(t, []string{"Date", "Description", "Amount"}, headers, "headers must be read from the first peek window")
 
@@ -135,7 +142,8 @@ func TestPeekHeader(t *testing.T) {
 		for _, tc := range invalidCases {
 			tc := tc
 			t.Run("invalid/"+tc.name, func(t *testing.T) {
-				headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(tc.input)))
+				delimeter, headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(tc.input)))
+				assert.Equal(t, ',', delimeter)
 				assert.Error(t, err, "must reject %q as non-CSV", tc.name)
 				assert.Nil(t, headers, "headers must be nil on failure")
 				assert.Nil(t, reader, "reader must be nil on failure")

--- a/server/datasources/csv/header_test.go
+++ b/server/datasources/csv/header_test.go
@@ -1,0 +1,145 @@
+package csv_test
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/monetr/monetr/server/datasources/csv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPeekHeader(t *testing.T) {
+	t.Run("comma-delimited bank export", func(t *testing.T) {
+		input := "Date,Description,Amount,Balance\n" +
+			"2026-01-15,COFFEE SHOP,-4.50,1234.56\n" +
+			"2026-01-16,GAS STATION,-45.00,1189.56\n"
+
+		headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
+		require.NoError(t, err, "must parse a comma-delimited CSV")
+		assert.Equal(t, []string{"Date", "Description", "Amount", "Balance"}, headers, "must extract all four headers")
+
+		contents, err := io.ReadAll(reader)
+		require.NoError(t, err, "must read the returned reader to completion")
+		assert.Equal(t, input, string(contents), "returned reader must preserve original content")
+	})
+
+	t.Run("pipe-delimited export", func(t *testing.T) {
+		input := "Date|Description|Amount\n" +
+			"2026-01-15|GROCERY|-42.10\n" +
+			"2026-01-16|RESTAURANT|-23.45\n"
+
+		headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
+		require.NoError(t, err, "must parse a pipe-delimited CSV")
+		assert.Equal(t, []string{"Date", "Description", "Amount"}, headers, "must extract pipe-delimited headers")
+
+		contents, err := io.ReadAll(reader)
+		require.NoError(t, err, "must read returned reader")
+		assert.Equal(t, input, string(contents), "returned reader must preserve pipe content")
+	})
+
+	t.Run("tab-delimited export", func(t *testing.T) {
+		input := "Date\tDescription\tAmount\tCategory\n" +
+			"2026-01-15\tUTIL\t-99.00\tBills\n" +
+			"2026-01-16\tPAYCHECK\t2000.00\tIncome\n"
+
+		headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
+		require.NoError(t, err, "must parse a tab-delimited CSV")
+		assert.Equal(t, []string{"Date", "Description", "Amount", "Category"}, headers, "must extract tab-delimited headers")
+
+		contents, err := io.ReadAll(reader)
+		require.NoError(t, err, "must read returned reader")
+		assert.Equal(t, input, string(contents), "returned reader must preserve tab content")
+	})
+
+	t.Run("headers with leading whitespace are trimmed", func(t *testing.T) {
+		input := "Date, Description, Amount\n" +
+			"2026-01-15, COFFEE, -4.50\n"
+
+		headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
+		require.NoError(t, err, "must parse CSV with leading spaces")
+		assert.Equal(t, []string{"Date", "Description", "Amount"}, headers, "leading spaces must be trimmed from headers")
+
+		contents, err := io.ReadAll(reader)
+		require.NoError(t, err, "must read returned reader")
+		assert.Equal(t, input, string(contents), "returned reader must preserve original bytes including interior spaces")
+	})
+
+	t.Run("quoted fields containing commas", func(t *testing.T) {
+		input := "Date,Description,Amount,Balance\n" +
+			"2026-01-15,\"PAYROLL, INC\",\"1,234.56\",\"10,000.00\"\n"
+
+		headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
+		require.NoError(t, err, "must parse CSV with quoted comma fields")
+		assert.Equal(t, []string{"Date", "Description", "Amount", "Balance"}, headers, "headers must be extracted despite quoted commas in body rows")
+
+		contents, err := io.ReadAll(reader)
+		require.NoError(t, err, "must read returned reader")
+		assert.Equal(t, input, string(contents), "returned reader must preserve quoted content verbatim")
+	})
+
+	t.Run("input smaller than peek size", func(t *testing.T) {
+		// bufio.Reader.Peek returns io.EOF for inputs shorter than the 1000-byte
+		// peek window. The function tolerates EOF as long as the available preview
+		// parses into a valid header row.
+		input := "Date,Description,Amount\n2026-01-15,COFFEE,-4.50\n"
+
+		headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
+		require.NoError(t, err, "short CSV must still parse")
+		assert.Equal(t, []string{"Date", "Description", "Amount"}, headers, "short-input headers must be extracted")
+
+		contents, err := io.ReadAll(reader)
+		require.NoError(t, err, "must read returned reader")
+		assert.Equal(t, input, string(contents), "short-input reader must preserve content")
+	})
+
+	t.Run("input larger than peek size", func(t *testing.T) {
+		// Build a CSV whose body exceeds the 1000-byte peek window so we exercise
+		// the non-EOF peek path and prove the returned reader yields the full
+		// original payload, not just the peeked prefix. This is the load-bearing
+		// contract for FileStorage.Store.
+		var b strings.Builder
+		b.WriteString("Date,Description,Amount\n")
+		for i := 0; i < 100; i++ {
+			b.WriteString("2026-01-15,SOME TRANSACTION DESCRIPTION STRING,-12.34\n")
+		}
+		input := b.String()
+		require.Greater(t, len(input), 1000, "test setup: input must exceed the 1000-byte peek window")
+
+		headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(input)))
+		require.NoError(t, err, "large CSV must parse")
+		assert.Equal(t, []string{"Date", "Description", "Amount"}, headers, "headers must be read from the first peek window")
+
+		contents, err := io.ReadAll(reader)
+		require.NoError(t, err, "must read returned reader to completion")
+		assert.Equal(t, input, string(contents), "returned reader must yield the entire original payload, not just the peeked window")
+	})
+
+	t.Run("invalid cases", func(t *testing.T) {
+		// Invalid inputs: fewer than 3 columns under every candidate delimiter, or
+		// data that does not parse as CSV at all. Each case must produce an error and
+		// nil outputs.
+		invalidCases := []struct {
+			name  string
+			input string
+		}{
+			{"single column", "Date\n2026-01-15\n2026-01-16\n"},
+			{"two columns", "Date,Amount\n2026-01-15,-4.50\n"},
+			{"empty input", ""},
+			{"binary noise", "\x00\x01\x02\xff\xfe garbage \x00"},
+			{"prose without delimiters", "this is just a sentence with no structure whatsoever"},
+			{"html document", "<html><body>Not a CSV</body></html>"},
+		}
+		for _, tc := range invalidCases {
+			tc := tc
+			t.Run("invalid/"+tc.name, func(t *testing.T) {
+				headers, reader, err := csv.PeekHeader(bytes.NewReader([]byte(tc.input)))
+				assert.Error(t, err, "must reject %q as non-CSV", tc.name)
+				assert.Nil(t, headers, "headers must be nil on failure")
+				assert.Nil(t, reader, "reader must be nil on failure")
+			})
+		}
+	})
+}

--- a/server/datasources/table/amount.go
+++ b/server/datasources/table/amount.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/monetr/monetr/server/validators"
 	"github.com/monetr/validation"
-	"github.com/monetr/validation/is"
 )
 
 type AmountKind string
@@ -117,13 +116,15 @@ func (s *AmountSpec) Validate(ctx context.Context) error {
 			validation.Field(
 				&s.Credit,
 				validation.Required,
-				is.PrintableASCII,
+				validators.PrintableUnicode,
+				validation.NotIn(s.Debit),
 				validation.Length(1, 100),
 			),
 			validation.Field(
 				&s.Debit,
 				validation.Required,
-				is.PrintableASCII,
+				validators.PrintableUnicode,
+				validation.NotIn(s.Credit),
 				validation.Length(1, 100),
 			),
 		},

--- a/server/datasources/table/amount_test.go
+++ b/server/datasources/table/amount_test.go
@@ -158,6 +158,19 @@ func TestAmountSpec_Validate(t *testing.T) {
 			wantErr: "input must be considered valid by: credit: when kind is \"sign\" credit cannot be specified; debit: when kind is \"sign\" debit cannot be specified; fields: the length must be exactly 1; kind: must equal \"sign\". or fields: fields[1] is a duplicate of an earlier entry. or credit: when kind is \"column\" credit cannot be specified; debit: when kind is \"column\" debit cannot be specified; fields: fields[1] is a duplicate of an earlier entry; kind: must equal \"column\".",
 		},
 		{
+			// Credit and Debit must be distinct under Type. The NotIn rule on
+			// each side fires when the two strings are equal so that the same
+			// label can't represent both directions.
+			name: "type with credit equals debit",
+			spec: table.AmountSpec{
+				Kind:   table.AmountKindType,
+				Fields: []table.FieldRef{{Name: "Amount"}, {Name: "TransType"}},
+				Credit: "DEBIT",
+				Debit:  "DEBIT",
+			},
+			wantErr: "input must be considered valid by: credit: when kind is \"sign\" credit cannot be specified; debit: when kind is \"sign\" debit cannot be specified; fields: the length must be exactly 1; kind: must equal \"sign\". or credit: must not be in list; debit: must not be in list. or credit: when kind is \"column\" credit cannot be specified; debit: when kind is \"column\" debit cannot be specified; kind: must equal \"column\".",
+		},
+		{
 			name: "column with duplicate fields",
 			spec: table.AmountSpec{
 				Kind:   table.AmountKindColumn,
@@ -220,8 +233,9 @@ func TestAmountSpec_Validate(t *testing.T) {
 			wantErr: "input must be considered valid by: credit: when kind is \"sign\" credit cannot be specified; debit: when kind is \"sign\" debit cannot be specified; fields: the length must be exactly 1; kind: must equal \"sign\". or debit: the length must be between 1 and 100. or credit: when kind is \"column\" credit cannot be specified; debit: when kind is \"column\" debit cannot be specified; kind: must equal \"column\".",
 		},
 		{
-			// Tab is ASCII but not printable ASCII; the recent switch from is.ASCII
-			// to is.PrintableASCII on Credit is what catches this.
+			// Tab still gets caught after the swap to [validators.PrintableUnicode]
+			// because [unicode.IsPrint] only considers the regular ASCII space
+			// printable, never the C0 controls.
 			name: "type credit with tab",
 			spec: table.AmountSpec{
 				Kind:   table.AmountKindType,
@@ -229,17 +243,21 @@ func TestAmountSpec_Validate(t *testing.T) {
 				Credit: "CR\tEDIT",
 				Debit:  "DEBIT",
 			},
-			wantErr: "input must be considered valid by: credit: when kind is \"sign\" credit cannot be specified; debit: when kind is \"sign\" debit cannot be specified; fields: the length must be exactly 1; kind: must equal \"sign\". or credit: must contain printable ASCII characters only. or credit: when kind is \"column\" credit cannot be specified; debit: when kind is \"column\" debit cannot be specified; kind: must equal \"column\".",
+			wantErr: "input must be considered valid by: credit: when kind is \"sign\" credit cannot be specified; debit: when kind is \"sign\" debit cannot be specified; fields: the length must be exactly 1; kind: must equal \"sign\". or credit: must contain printable characters only. or credit: when kind is \"column\" credit cannot be specified; debit: when kind is \"column\" debit cannot be specified; kind: must equal \"column\".",
 		},
 		{
-			name: "type debit with non-ASCII",
+			// "Débit" used to be rejected because the rule was ASCII-only. After the
+			// swap to [validators.PrintableUnicode] it goes through, which is the
+			// whole point of the swap — bank exports happen in plenty of languages
+			// and we shouldn't be the reason they break.
+			name: "type debit with accented vowel",
 			spec: table.AmountSpec{
 				Kind:   table.AmountKindType,
 				Fields: []table.FieldRef{{Name: "Amount"}, {Name: "TransType"}},
 				Credit: "CREDIT",
 				Debit:  "Débit",
 			},
-			wantErr: "input must be considered valid by: credit: when kind is \"sign\" credit cannot be specified; debit: when kind is \"sign\" debit cannot be specified; fields: the length must be exactly 1; kind: must equal \"sign\". or debit: must contain printable ASCII characters only. or credit: when kind is \"column\" credit cannot be specified; debit: when kind is \"column\" debit cannot be specified; kind: must equal \"column\".",
+			wantErr: "",
 		},
 		{
 			// Type-branch Each coverage: second field is a blank FieldRef (first is

--- a/server/datasources/table/balance_test.go
+++ b/server/datasources/table/balance_test.go
@@ -72,22 +72,6 @@ func TestBalanceSpec_Validate(t *testing.T) {
 			},
 			wantErr: "",
 		},
-		{
-			name: "field with row per day",
-			spec: table.BalanceSpec{
-				Kind:   table.BalanceKindField,
-				Fields: []table.FieldRef{{DerivedKind: table.DerivedKindRowNumberPerDay}},
-			},
-			wantErr: "",
-		},
-		{
-			name: "field with row per day per amount",
-			spec: table.BalanceSpec{
-				Kind:   table.BalanceKindField,
-				Fields: []table.FieldRef{{DerivedKind: table.DerivedKindRowNumberPerDayPerAmount}},
-			},
-			wantErr: "",
-		},
 
 		// --- Cross-validation: Kind and Fields must agree ---
 		{
@@ -228,7 +212,7 @@ func TestBalanceSpec_Validate(t *testing.T) {
 				Kind:   table.BalanceKindField,
 				Fields: []table.FieldRef{{DerivedKind: table.DerivedKind("bogus")}},
 			},
-			wantErr: "input must be considered valid by: fields: must be blank; kind: must be one of: [\"none\", \"sum\"]. or fields: (0: input must be considered valid by: derivedKind: must be blank; name: cannot be blank. or derivedKind: must be one of: [\"rowNumber\", \"rowNumberPerDay\", \"rowNumberPerDayPerAmount\"]..).",
+			wantErr: "input must be considered valid by: fields: must be blank; kind: must be one of: [\"none\", \"sum\"]. or fields: (0: input must be considered valid by: derivedKind: must be blank; name: cannot be blank. or derivedKind: must be one of: [\"rowNumber\"]..).",
 		},
 
 		// --- Combined (both kind and fields misbehaving) ---

--- a/server/datasources/table/date.go
+++ b/server/datasources/table/date.go
@@ -3,6 +3,7 @@ package table
 import (
 	"context"
 	"regexp"
+	"strings"
 
 	"github.com/monetr/monetr/server/validators"
 	"github.com/monetr/validation"
@@ -60,4 +61,32 @@ func (s *DateSpec) Validate(ctx context.Context) error {
 		"failed to validate %T",
 		s,
 	)
+}
+
+func (s *DateSpec) GetTimeFormat() string {
+	replacements := [][2]string{
+		{
+			"YYYY", "2006",
+		},
+		{
+			"YY", "06",
+		},
+		{
+			"MM", "01",
+		},
+		{
+			"M", "1",
+		},
+		{
+			"DD", "02",
+		},
+		{
+			"D", "2",
+		},
+	}
+	format := s.Format
+	for _, replacement := range replacements {
+		format = strings.Replace(format, replacement[0], replacement[1], 1)
+	}
+	return format
 }

--- a/server/datasources/table/date_test.go
+++ b/server/datasources/table/date_test.go
@@ -273,3 +273,92 @@ func TestDateSpec_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestDateSpec_GetTimeFormat(t *testing.T) {
+	cases := []struct {
+		name     string
+		spec     table.DateSpec
+		expected string
+	}{
+		{
+			name: "YY-MM-DD",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YY-MM-DD",
+			},
+			expected: "06-01-02",
+		},
+		{
+			name: "YYYY-MM-DD",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YYYY-MM-DD",
+			},
+			expected: "2006-01-02",
+		},
+		{
+			name: "YY-M-D",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YY-M-D",
+			},
+			expected: "06-1-2",
+		},
+		{
+			name: "MM/DD/YYYY",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "MM/DD/YYYY",
+			},
+			expected: "01/02/2006",
+		},
+		{
+			name: "DD-MM-YYYY",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "DD-MM-YYYY",
+			},
+			expected: "02-01-2006",
+		},
+		{
+			name: "DD.MM.YYYY",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "DD.MM.YYYY",
+			},
+			expected: "02.01.2006",
+		},
+		{
+			name: "YYYY/MM/DD",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YYYY/MM/DD",
+			},
+			expected: "2006/01/02",
+		},
+		{
+			name: "M/D/YY",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "M/D/YY",
+			},
+			expected: "1/2/06",
+		},
+		{
+			name: "YYYY-M-D",
+			spec: table.DateSpec{
+				Fields: []table.FieldRef{{Name: "Date"}},
+				Format: "YYYY-M-D",
+			},
+			expected: "2006-1-2",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.spec.GetTimeFormat()
+			assert.EqualValues(t, tc.expected, result, "Expected time format to match expeced")
+		})
+	}
+}

--- a/server/datasources/table/field.go
+++ b/server/datasources/table/field.go
@@ -2,10 +2,10 @@ package table
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/monetr/monetr/server/validators"
 	"github.com/monetr/validation"
-	"github.com/monetr/validation/is"
 )
 
 type DerivedKind string
@@ -16,14 +16,14 @@ const (
 	// exactly stable since new rows are added and old rows are eventually
 	// removed.
 	DerivedKindRowNumber DerivedKind = "rowNumber"
-	// DerivedKindRowNumberPerDay is the 0 indexed count of rows per date value.
-	// This is from the bottom to the top of the file.
-	DerivedKindRowNumberPerDay DerivedKind = "rowNumberPerDay"
-	// DerivedKindRowNumberPerDayPerAmount is the 0 indexed count of rows per date
-	// value per amount value. This way if days have all unique transaction
-	// amounts then deduplication is easy. If days have duplicate transaction
-	// amounts then they are deduplicated in order they are observed.
-	DerivedKindRowNumberPerDayPerAmount DerivedKind = "rowNumberPerDayPerAmount"
+	// // DerivedKindRowNumberPerDay is the 0 indexed count of rows per date value.
+	// // This is from the bottom to the top of the file.
+	// DerivedKindRowNumberPerDay DerivedKind = "rowNumberPerDay"
+	// // DerivedKindRowNumberPerDayPerAmount is the 0 indexed count of rows per date
+	// // value per amount value. This way if days have all unique transaction
+	// // amounts then deduplication is easy. If days have duplicate transaction
+	// // amounts then they are deduplicated in order they are observed.
+	// DerivedKindRowNumberPerDayPerAmount DerivedKind = "rowNumberPerDayPerAmount"
 )
 
 // FieldRef references a field within the document, or it references a derived
@@ -46,8 +46,8 @@ func (s *FieldRef) Validate(ctx context.Context) error {
 			validation.Field(
 				&s.Name,
 				validators.In(getColumns(ctx)...),
+				validators.PrintableUnicode,
 				validation.Required,
-				is.PrintableASCII,
 			),
 			validation.Field(
 				&s.DerivedKind,
@@ -63,11 +63,19 @@ func (s *FieldRef) Validate(ctx context.Context) error {
 				&s.DerivedKind,
 				validators.In(
 					DerivedKindRowNumber,
-					DerivedKindRowNumberPerDay,
-					DerivedKindRowNumberPerDayPerAmount,
+					// DerivedKindRowNumberPerDay,
+					// DerivedKindRowNumberPerDayPerAmount,
 				),
 				validation.Required,
 			),
 		},
 	)
+}
+
+func (s FieldRef) String() string {
+	if s.DerivedKind != "" {
+		return fmt.Sprintf("derived::%s", s.DerivedKind)
+	}
+
+	return s.Name
 }

--- a/server/datasources/table/field_test.go
+++ b/server/datasources/table/field_test.go
@@ -33,16 +33,6 @@ func TestFieldRef_Validate(t *testing.T) {
 			wantErr: "",
 		},
 		{
-			name:    "derived row per day",
-			ref:     table.FieldRef{DerivedKind: table.DerivedKindRowNumberPerDay},
-			wantErr: "",
-		},
-		{
-			name:    "derived row per day per amount",
-			ref:     table.FieldRef{DerivedKind: table.DerivedKindRowNumberPerDayPerAmount},
-			wantErr: "",
-		},
-		{
 			name:    "name not in headers",
 			ref:     table.FieldRef{Name: "NotPresent"},
 			wantErr: "input must be considered valid by: name: must be one of: [\"Date\", \"Description\", \"Amount\", \"Id\"]. or derivedKind: cannot be blank; name: must be blank.",
@@ -60,17 +50,18 @@ func TestFieldRef_Validate(t *testing.T) {
 		{
 			name:    "unknown derived kind",
 			ref:     table.FieldRef{DerivedKind: table.DerivedKind("bogus")},
-			wantErr: "input must be considered valid by: derivedKind: must be blank; name: cannot be blank. or derivedKind: must be one of: [\"rowNumber\", \"rowNumberPerDay\", \"rowNumberPerDayPerAmount\"].",
+			wantErr: "input must be considered valid by: derivedKind: must be blank; name: cannot be blank. or derivedKind: must be one of: [\"rowNumber\"].",
 		},
 		{
 			name:    "name with unknown derived",
 			ref:     table.FieldRef{Name: "Date", DerivedKind: table.DerivedKind("bogus")},
-			wantErr: "input must be considered valid by: derivedKind: must be blank. or derivedKind: must be one of: [\"rowNumber\", \"rowNumberPerDay\", \"rowNumberPerDayPerAmount\"]; name: must be blank.",
+			wantErr: "input must be considered valid by: derivedKind: must be blank. or derivedKind: must be one of: [\"rowNumber\"]; name: must be blank.",
 		},
 		{
-			// is.PrintableASCII fires before In(columns), so a Name containing tab or
-			// other control characters is rejected regardless of whether a column
-			// with that exact name is present in the context.
+			// A Name with a tab in it can't ever match a real column because the
+			// Headers themselves are validated through [validators.PrintableUnicode]
+			// upstream in [Mapping]. So the In check is what surfaces here, the print
+			// rule on Name is more or less defense-in-depth.
 			name:    "name with tab",
 			ref:     table.FieldRef{Name: "Dat\te"},
 			wantErr: "input must be considered valid by: name: must be one of: [\"Date\", \"Description\", \"Amount\", \"Id\"]. or derivedKind: cannot be blank; name: must be blank.",
@@ -81,8 +72,10 @@ func TestFieldRef_Validate(t *testing.T) {
 			wantErr: "input must be considered valid by: name: must be one of: [\"Date\", \"Description\", \"Amount\", \"Id\"]. or derivedKind: cannot be blank; name: must be blank.",
 		},
 		{
-			// Non-ASCII codepoint also fails printable ASCII.
-			name:    "name with non-ASCII",
+			// "Café" used to fail the print rule, but [validators.PrintableUnicode]
+			// is fine with it. The case still fails here because "Café" isn't in this
+			// context's column list, which is the more meaningful thing to test now.
+			name:    "name not in columns, with non-ASCII",
 			ref:     table.FieldRef{Name: "Café"},
 			wantErr: "input must be considered valid by: name: must be one of: [\"Date\", \"Description\", \"Amount\", \"Id\"]. or derivedKind: cannot be blank; name: must be blank.",
 		},

--- a/server/datasources/table/mapping.go
+++ b/server/datasources/table/mapping.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/monetr/monetr/server/validators"
 	"github.com/monetr/validation"
-	"github.com/monetr/validation/is"
 	"github.com/pkg/errors"
 )
 
@@ -95,7 +94,7 @@ func (m *Mapping) Validate(ctx context.Context) error {
 				validation.Length(1, 20),
 				validators.Unique[string](),
 				validation.Each(
-					is.PrintableASCII,
+					validators.PrintableUnicode,
 					validation.Length(1, 100),
 					validation.Required,
 				),

--- a/server/datasources/table/mapping_test.go
+++ b/server/datasources/table/mapping_test.go
@@ -90,7 +90,7 @@ func TestMapping_Validate(t *testing.T) {
 			mutate: func(m *table.Mapping) {
 				m.ID = table.IDSpec{
 					Kind:   table.IDSpecKindHashed,
-					Fields: []table.FieldRef{{Name: "Date"}, {DerivedKind: table.DerivedKindRowNumberPerDay}},
+					Fields: []table.FieldRef{{Name: "Date"}, {DerivedKind: table.DerivedKindRowNumber}},
 				}
 			},
 		},
@@ -205,14 +205,19 @@ func TestMapping_Validate(t *testing.T) {
 			wantErr: "failed to validate *table.Mapping: merchant: input must be considered valid by: name: cannot be blank. or derivedKind: cannot be blank..",
 		},
 		{
+			// Pösted used to be the canonical "invalid posted needle" here because
+			// the rule was ASCII-only; after the swap to
+			// [validators.PrintableUnicode] it's a perfectly fine value. To keep the
+			// "PostedSpec error bubbles up under the posted key" coverage we use a
+			// tab now, which the new rule still rejects.
 			name: "invalid posted, merchant nil ok",
 			mutate: func(m *table.Mapping) {
 				m.Posted = &table.PostedSpec{
 					Fields: []table.FieldRef{{Name: "Status"}},
-					Posted: "Pösted",
+					Posted: "POS\tTED",
 				}
 			},
-			wantErr: "failed to validate *table.Mapping: posted: failed to validate *table.PostedSpec: posted: must contain printable ASCII characters only..",
+			wantErr: "failed to validate *table.Mapping: posted: failed to validate *table.PostedSpec: posted: must contain printable characters only..",
 		},
 	}
 

--- a/server/datasources/table/posted.go
+++ b/server/datasources/table/posted.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/monetr/monetr/server/validators"
 	"github.com/monetr/validation"
-	"github.com/monetr/validation/is"
 	"github.com/pkg/errors"
 )
 
@@ -16,7 +15,7 @@ import (
 // nil on the [Mapping] then all transactions are considered posted.
 type PostedSpec struct {
 	Fields []FieldRef `json:"fields"`
-	// Posted is the strong we look for in the field specified to know if the
+	// Posted is the string we look for in the field specified to know if the
 	// transaction is posted. Any other value is considered pending.
 	Posted string `json:"posted,omitempty"`
 }
@@ -39,8 +38,8 @@ func (s *PostedSpec) Validate(ctx context.Context) error {
 			),
 			validation.Field(
 				&s.Posted,
-				is.PrintableASCII,
-				validation.Length(0, 100),
+				validators.PrintableUnicode,
+				validation.Length(1, 100),
 			),
 		),
 		"failed to validate %T",

--- a/server/datasources/table/posted_test.go
+++ b/server/datasources/table/posted_test.go
@@ -10,9 +10,12 @@ import (
 
 func TestPostedSpec_Validate(t *testing.T) {
 	// PostedSpec requires exactly one FieldRef (valid against the column set in
-	// context). Posted is optional; when set it must contain ASCII characters
-	// only and be no longer than 50 characters. An empty Posted string is
-	// accepted because Length(0, 50) treats empty as valid.
+	// context). Posted is optional; when set it must contain printable
+	// characters only (per [validators.PrintableUnicode], so umlauts and the
+	// like are fine but tabs and zero-width joiners are not) and be 1 to 100
+	// characters long. An empty Posted string is still accepted because
+	// Length(1, 100) treats empty as valid (the rule only fires once the value
+	// is non-empty).
 	ctx := table.WithColumns(
 		t.Context(),
 		[]string{"Date", "Status", "Description", "Amount"},
@@ -65,22 +68,6 @@ func TestPostedSpec_Validate(t *testing.T) {
 			name: "row number field, empty posted",
 			spec: table.PostedSpec{
 				Fields: []table.FieldRef{{DerivedKind: table.DerivedKindRowNumber}},
-			},
-			wantErr: "",
-		},
-		{
-			name: "row per day field, ascii",
-			spec: table.PostedSpec{
-				Fields: []table.FieldRef{{DerivedKind: table.DerivedKindRowNumberPerDay}},
-				Posted: "POSTED",
-			},
-			wantErr: "",
-		},
-		{
-			name: "row per day per amount field, ascii",
-			spec: table.PostedSpec{
-				Fields: []table.FieldRef{{DerivedKind: table.DerivedKindRowNumberPerDayPerAmount}},
-				Posted: "Y",
 			},
 			wantErr: "",
 		},
@@ -153,25 +140,28 @@ func TestPostedSpec_Validate(t *testing.T) {
 			spec: table.PostedSpec{
 				Fields: []table.FieldRef{{DerivedKind: table.DerivedKind("bogus")}},
 			},
-			wantErr: "failed to validate *table.PostedSpec: fields: (0: input must be considered valid by: derivedKind: must be blank; name: cannot be blank. or derivedKind: must be one of: [\"rowNumber\", \"rowNumberPerDay\", \"rowNumberPerDayPerAmount\"]..).",
+			wantErr: "failed to validate *table.PostedSpec: fields: (0: input must be considered valid by: derivedKind: must be blank; name: cannot be blank. or derivedKind: must be one of: [\"rowNumber\"]..).",
 		},
 		{
-			name: "non-ascii posted",
+			// "Pösted" is the canonical reason monetr swapped from
+			// is.PrintableASCII to [validators.PrintableUnicode]. It used to
+			// fail here, now it's a perfectly fine Posted needle.
+			name: "posted with umlauts",
 			spec: table.PostedSpec{
 				Fields: []table.FieldRef{{Name: "Status"}},
 				Posted: "Pösted",
 			},
-			wantErr: "failed to validate *table.PostedSpec: posted: must contain printable ASCII characters only.",
+			wantErr: "",
 		},
 		{
-			// Tab is ASCII (0x09) but not *printable* ASCII (0x20-0x7E). The switch
-			// from is.ASCII to is.PrintableASCII is what rejects it.
+			// Tab still gets caught because [unicode.IsPrint] only treats
+			// the regular ASCII space as printable, not the C0 controls.
 			name: "posted with tab",
 			spec: table.PostedSpec{
 				Fields: []table.FieldRef{{Name: "Status"}},
 				Posted: "POS\tTED",
 			},
-			wantErr: "failed to validate *table.PostedSpec: posted: must contain printable ASCII characters only.",
+			wantErr: "failed to validate *table.PostedSpec: posted: must contain printable characters only.",
 		},
 		{
 			name: "posted with newline",
@@ -179,16 +169,17 @@ func TestPostedSpec_Validate(t *testing.T) {
 				Fields: []table.FieldRef{{Name: "Status"}},
 				Posted: "POS\nTED",
 			},
-			wantErr: "failed to validate *table.PostedSpec: posted: must contain printable ASCII characters only.",
+			wantErr: "failed to validate *table.PostedSpec: posted: must contain printable characters only.",
 		},
 		{
-			// DEL (0x7F) is still ASCII but sits outside the printable range.
+			// DEL (0x7F) is still ASCII but it's outside the printable range
+			// so the new rule rejects it the same way the old one did.
 			name: "posted with DEL",
 			spec: table.PostedSpec{
 				Fields: []table.FieldRef{{Name: "Status"}},
 				Posted: "POSTED\x7f",
 			},
-			wantErr: "failed to validate *table.PostedSpec: posted: must contain printable ASCII characters only.",
+			wantErr: "failed to validate *table.PostedSpec: posted: must contain printable characters only.",
 		},
 		{
 			name: "posted at max length",
@@ -204,29 +195,36 @@ func TestPostedSpec_Validate(t *testing.T) {
 				Fields: []table.FieldRef{{Name: "Status"}},
 				Posted: strings.Repeat("A", 101),
 			},
-			wantErr: "failed to validate *table.PostedSpec: posted: the length must be no more than 100.",
+			wantErr: "failed to validate *table.PostedSpec: posted: the length must be between 1 and 100.",
 		},
 		{
-			name: "empty fields, non-ascii posted",
+			// Pösted is now fine on its own, so the only problem left here is
+			// that fields is blank. The case stays around to make sure the
+			// fields error still surfaces when the Posted needle happens to
+			// contain non-ASCII content.
+			name: "empty fields, posted with umlauts",
 			spec: table.PostedSpec{
 				Posted: "Pösted",
 			},
-			wantErr: "failed to validate *table.PostedSpec: fields: cannot be blank; posted: must contain printable ASCII characters only.",
+			wantErr: "failed to validate *table.PostedSpec: fields: cannot be blank.",
 		},
 		{
 			name: "empty fields, over-length posted",
 			spec: table.PostedSpec{
 				Posted: strings.Repeat("A", 101),
 			},
-			wantErr: "failed to validate *table.PostedSpec: fields: cannot be blank; posted: the length must be no more than 100.",
+			wantErr: "failed to validate *table.PostedSpec: fields: cannot be blank; posted: the length must be between 1 and 100.",
 		},
 		{
-			name: "invalid child, non-ascii posted",
+			// Same idea as the previous case but with the child FieldRef
+			// also broken. Since Pösted itself is fine now, only the fields
+			// error makes it through.
+			name: "invalid child, posted with umlauts",
 			spec: table.PostedSpec{
 				Fields: []table.FieldRef{{}},
 				Posted: "Pösted",
 			},
-			wantErr: "failed to validate *table.PostedSpec: fields: (0: input must be considered valid by: name: cannot be blank. or derivedKind: cannot be blank..); posted: must contain printable ASCII characters only.",
+			wantErr: "failed to validate *table.PostedSpec: fields: (0: input must be considered valid by: name: cannot be blank. or derivedKind: cannot be blank..).",
 		},
 	}
 

--- a/server/datasources/table/table.go
+++ b/server/datasources/table/table.go
@@ -1,0 +1,292 @@
+package table
+
+import (
+	"context"
+	"encoding/base32"
+	"encoding/csv"
+	"hash/fnv"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/monetr/monetr/server/currency"
+	"github.com/pkg/errors"
+)
+
+type Row struct {
+	RowNumber int       `json:"rowNumber"`
+	ID        string    `json:"id"`
+	Amount    int64     `json:"amount"`
+	Memo      string    `json:"memo"`
+	Merchant  *string   `json:"merchant,omitempty"`
+	Date      time.Time `json:"date"`
+	Posted    bool      `json:"posted"`
+	Balance   int64     `json:"balance"`
+}
+
+var (
+	_ TableReader = &csv.Reader{}
+)
+
+type TableReader interface {
+	Read() (record []string, err error)
+}
+
+type Table struct {
+	currency        string
+	timezone        *time.Location
+	index           int
+	firstRowHeaders bool
+	headers         []string
+	mapping         *Mapping
+	reader          TableReader
+}
+
+func NewTable(
+	reader TableReader,
+	mapping *Mapping,
+	firstRowHeaders bool,
+) *Table {
+	return &Table{
+		currency:        "USD",    // TODO!!!
+		timezone:        time.UTC, // TODO!!!
+		firstRowHeaders: firstRowHeaders,
+		reader:          reader,
+		mapping:         mapping,
+	}
+}
+
+func (t *Table) Read() (*Row, error) {
+	if t.firstRowHeaders && t.index == 0 {
+		if err := t.mapping.Validate(context.TODO()); err != nil {
+			return nil, err
+		}
+
+		data, err := t.reader.Read()
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		t.headers = data
+		if !slices.Equal(t.headers, t.mapping.Headers) {
+			return nil, errors.New("headers in file do not match headers in mapping!")
+		}
+		t.index++
+	} else if !t.firstRowHeaders && len(t.headers) == 0 {
+		if err := t.mapping.Validate(context.TODO()); err != nil {
+			return nil, err
+		}
+
+		t.headers = t.mapping.Headers
+	}
+
+	defer func() {
+		t.index++
+	}()
+
+	data, err := t.reader.Read()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	id, err := t.getID(data)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"failed to derive ID from table for row %d",
+			t.index,
+		)
+	}
+
+	amount, err := t.getAmount(data)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"failed to derive amount from table for row %d",
+			t.index,
+		)
+	}
+
+	date, err := t.getDate(data)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"failed to derive date from table for row %d",
+			t.index,
+		)
+	}
+
+	balance, err := t.getBalance(data)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"failed to derive balance from table for row %d",
+			t.index,
+		)
+	}
+
+	row := Row{
+		RowNumber: t.index,
+		ID:        id,
+		Amount:    amount,
+		Memo:      t.getField(data, t.mapping.Memo),
+		Merchant:  t.getMerchant(data),
+		Date:      date,
+		Posted:    t.getPosted(data),
+		Balance:   balance,
+	}
+
+	return &row, nil
+}
+
+func (t *Table) getID(data []string) (string, error) {
+	switch t.mapping.ID.Kind {
+	case IDSpecKindNative:
+		values := make([]string, len(t.mapping.ID.Fields))
+		for i, field := range t.mapping.ID.Fields {
+			values[i] = t.getField(data, field)
+		}
+		return strings.Join(values, "::"), nil
+	case IDSpecKindHashed:
+		hash := fnv.New64()
+		for _, field := range t.mapping.ID.Fields {
+			_, err := hash.Write([]byte(t.getField(data, field)))
+			if err != nil {
+				return "", errors.WithStack(err)
+			}
+		}
+
+		return base32.StdEncoding.EncodeToString(hash.Sum(nil)), nil
+	default:
+		panic("invalid id spec")
+	}
+}
+
+func (t *Table) getAmount(data []string) (int64, error) {
+	var amount int64
+	var err error
+	switch t.mapping.Amount.Kind {
+	case AmountKindSign:
+		// Assumes that the mapping struct is 100% valid!
+		field := t.mapping.Amount.Fields[0]
+		value := t.getField(data, field)
+		amount, err = currency.ParseFriendlyToAmount(value, t.currency)
+	case AmountKindType:
+		value := t.getField(data, t.mapping.Amount.Fields[0])
+		direction := t.getField(data, t.mapping.Amount.Fields[1])
+		// err is handled, just not right here!
+		amount, err = currency.ParseFriendlyToAmount(value, t.currency)
+
+		switch direction {
+		case t.mapping.Amount.Credit:
+			// Amounts should be negative if they are credits, this might need to be
+			// reversed but I need real data to play with first.
+			amount *= -1
+		case t.mapping.Amount.Debit:
+			// No-op?
+		default:
+			panic("invalid amount direction mapping")
+		}
+	case AmountKindColumn:
+		debit := t.getField(data, t.mapping.Amount.Fields[0])
+		credit := t.getField(data, t.mapping.Amount.Fields[1])
+
+		switch {
+		case debit != "" && credit == "":
+			amount, err = currency.ParseFriendlyToAmount(debit, t.currency)
+		case debit == "" && credit != "":
+			amount, err = currency.ParseFriendlyToAmount(credit, t.currency)
+		case debit == "" && credit == "":
+			return 0, errors.Errorf("invalid amount row %d, both debit and credit columns are empty", t.index)
+		default:
+			return 0, errors.Errorf("invalid amount row %d, both debit and credit columns are populated", t.index)
+		}
+	default:
+		panic("invalid amount spec")
+	}
+
+	// handle the error from the parse amount.
+	if err != nil {
+		return 0, err
+	}
+
+	// If the user wants to invert the value then do that here before we return
+	// it. Do this after everything!
+	if t.mapping.Amount.Invert {
+		amount *= -1
+	}
+
+	return amount, nil
+}
+
+func (t *Table) getMerchant(data []string) *string {
+	if t.mapping.Merchant != nil {
+		// TODO Simplify to new(t.getField(data, *t.mapping.Merchant)) once golang
+		// pulls its head out of its ass.
+		value := t.getField(data, *t.mapping.Merchant)
+		return &value
+	}
+
+	return nil
+}
+
+func (t *Table) getDate(data []string) (time.Time, error) {
+	value := t.getField(data, t.mapping.Date.Fields[0])
+	format := t.mapping.Date.GetTimeFormat()
+	date, err := time.ParseInLocation(format, value, t.timezone)
+	if err != nil {
+		return date, errors.WithStack(err)
+	}
+
+	return date, nil
+}
+
+func (t *Table) getPosted(data []string) bool {
+	// If we don't have a posted spec then we always assume that the transaction
+	// is infact posted and not pending. This seems to be the default behavior
+	// with all of the CSV exports I've been able to find with banks?
+	if t.mapping.Posted == nil {
+		return true
+	}
+	value := t.getField(data, t.mapping.Posted.Fields[0])
+	return value == t.mapping.Posted.Posted
+}
+
+func (t *Table) getBalance(data []string) (int64, error) {
+	switch t.mapping.Balance.Kind {
+	case BalanceKindNone:
+		return 0, nil
+	case BalanceKindField:
+		// Assumes that the mapping struct is 100% valid!
+		field := t.mapping.Balance.Fields[0]
+		value := t.getField(data, field)
+		amount, err := currency.ParseFriendlyToAmount(value, t.currency)
+		if err != nil {
+			return 0, err
+		}
+		return amount, nil
+	case BalanceKindSum:
+		// TODO I'm not sure how to implement this and it might need to be a post
+		// processing stage?
+		// Essentially what I would need to do this is a balance at a specific point
+		// in time. Like end of day balance of a specific date, and then take the sum
+		// of all the rows that have come after that date to calculate the current
+		// running balance. But none of that exists yet so this might just be a no-op
+		// for the mean time.
+		return 0, nil
+	default:
+		panic("invalid balance spec")
+	}
+}
+
+func (t *Table) getField(data []string, field FieldRef) string {
+	switch field.DerivedKind {
+	case DerivedKindRowNumber:
+		// TODO IS this the right order? This would be top of file = 0
+		return strconv.Itoa(t.index)
+	default:
+		index := slices.Index(t.headers, field.Name)
+		return strings.TrimSpace(data[index])
+	}
+}

--- a/server/datasources/table/table.go
+++ b/server/datasources/table/table.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/monetr/monetr/server/currency"
+	"github.com/monetr/monetr/server/validators"
+	"github.com/monetr/validation"
 	"github.com/pkg/errors"
 )
 
@@ -23,6 +25,42 @@ type Row struct {
 	Date      time.Time `json:"date"`
 	Posted    bool      `json:"posted"`
 	Balance   int64     `json:"balance"`
+}
+
+func (r *Row) Validate() error {
+	return errors.Wrap(
+		validation.ValidateStruct(
+			r,
+			validation.Field(
+				&r.ID,
+				validators.PrintableUnicode,
+				validation.Length(1, 100),
+				validation.Required,
+			),
+			validation.Field(
+				&r.Amount,
+				validation.NotIn(0).Error("amount cannot be zero"),
+				validation.Required,
+			),
+			validation.Field(
+				&r.Memo,
+				validators.PrintableUnicode,
+				validation.Length(1, 300),
+				validation.Required,
+			),
+			validation.Field(
+				&r.Merchant,
+				validators.PrintableUnicode,
+				validation.Length(1, 300),
+			),
+			validation.Field(
+				&r.Date,
+				validation.NotIn(time.Time{}).Error("date cannot be empty"),
+				validation.Required,
+			),
+		),
+		"row is invalid",
+	)
 }
 
 var (

--- a/server/datasources/table/table_test.go
+++ b/server/datasources/table/table_test.go
@@ -1,0 +1,1502 @@
+package table_test
+
+import (
+	"encoding/csv"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/monetr/monetr/server/datasources/table"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTable_Read(t *testing.T) {
+	// Each case feeds a CSV string and a Mapping into NewTable, drains Read()
+	// until an error, and asserts the produced rows + the terminal error. Full
+	// table.Row equality is intentional: every field is part of expected so
+	// unrelated wiring changes break these tests on purpose. Posted defaults to
+	// true when the mapping omits a PostedSpec (every CSV monetr has seen in the
+	// wild reports only posted rows), and Balance defaults to 0 when the
+	// BalanceSpec is BalanceKindNone or BalanceKindSum. Cases that exercise the
+	// wired paths set Posted/Balance explicitly.
+	cases := []struct {
+		name            string
+		csv             string
+		mapping         *table.Mapping
+		firstRowHeaders bool
+		want            []table.Row
+		wantErr         string // substring; empty == expect io.EOF
+	}{
+		{
+			name: "native id, sign amount, date, no headers",
+			csv:  "1,12.34,2026-05-02,coffee\n2,-5.67,2026-05-02,refund\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Amount", "Date", "Memo"},
+			},
+			firstRowHeaders: false,
+			want: []table.Row{
+				{
+					RowNumber: 0,
+					ID:        "1",
+					Amount:    1234,
+					Memo:      "coffee",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+				{
+					RowNumber: 1,
+					ID:        "2",
+					Amount:    -567,
+					Memo:      "refund",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "native id with two fields joins on '::'",
+			csv:  "1,checking,12.34,coffee,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+						{
+							Name: "Account",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Account", "Amount", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want: []table.Row{
+				{
+					RowNumber: 0,
+					ID:        "1::checking",
+					Amount:    1234,
+					Memo:      "coffee",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			// Hash precomputed: fnv.New64() over "1" then base32.StdEncoding. The
+			// literal value is locked in so a regression that quietly changed the
+			// hashing or encoding strategy would surface here.
+			name: "hashed id over single field",
+			csv:  "1,12.34,coffee,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindHashed,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Amount", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want: []table.Row{
+				{
+					RowNumber: 0,
+					ID:        "V5R32TEGAG364===",
+					Amount:    1234,
+					Memo:      "coffee",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "id derived from row number",
+			csv:  "12.34,coffee,2026-05-02\n-5.67,refund,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							DerivedKind: table.DerivedKindRowNumber,
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"Amount", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want: []table.Row{
+				{
+					RowNumber: 0,
+					ID:        "0",
+					Amount:    1234,
+					Memo:      "coffee",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+				{
+					RowNumber: 1,
+					ID:        "1",
+					Amount:    -567,
+					Memo:      "refund",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "sign amount with invert flips sign",
+			csv:  "1,12.34,coffee,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind:   table.AmountKindSign,
+					Invert: true,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Amount", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want: []table.Row{
+				{
+					RowNumber: 0,
+					ID:        "1",
+					Amount:    -1234,
+					Memo:      "coffee",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "type amount, debit row keeps sign",
+			csv:  "1,12.34,DEBIT,coffee,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindType,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+						{
+							Name: "Type",
+						},
+					},
+					Credit: "CREDIT",
+					Debit:  "DEBIT",
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Amount", "Type", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want: []table.Row{
+				{
+					RowNumber: 0,
+					ID:        "1",
+					Amount:    1234,
+					Memo:      "coffee",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "type amount, credit row negates",
+			csv:  "1,12.34,CREDIT,refund,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindType,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+						{
+							Name: "Type",
+						},
+					},
+					Credit: "CREDIT",
+					Debit:  "DEBIT",
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Amount", "Type", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want: []table.Row{
+				{
+					RowNumber: 0,
+					ID:        "1",
+					Amount:    -1234,
+					Memo:      "refund",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			// Invert composes after credit handling: CREDIT row gets *= -1, then
+			// Invert flips it again. Net effect is the original positive value.
+			name: "type amount, credit row with invert double-flips",
+			csv:  "1,12.34,CREDIT,refund,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind:   table.AmountKindType,
+					Invert: true,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+						{
+							Name: "Type",
+						},
+					},
+					Credit: "CREDIT",
+					Debit:  "DEBIT",
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Amount", "Type", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want: []table.Row{
+				{
+					RowNumber: 0,
+					ID:        "1",
+					Amount:    1234,
+					Memo:      "refund",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			// Column kind: first field is the debit column, second is the credit
+			// column. With debit populated and credit empty the debit value is
+			// parsed as the amount.
+			name: "column amount, debit column populated",
+			csv:  "1,12.34,,coffee,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindColumn,
+					Fields: []table.FieldRef{
+						{
+							Name: "Debit",
+						},
+						{
+							Name: "Credit",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Debit", "Credit", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want: []table.Row{
+				{
+					RowNumber: 0,
+					ID:        "1",
+					Amount:    1234,
+					Memo:      "coffee",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			// Mirror of the previous case with the credit cell populated instead.
+			name: "column amount, credit column populated",
+			csv:  "1,,12.34,refund,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindColumn,
+					Fields: []table.FieldRef{
+						{
+							Name: "Debit",
+						},
+						{
+							Name: "Credit",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Debit", "Credit", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want: []table.Row{
+				{
+					RowNumber: 0,
+					ID:        "1",
+					Amount:    1234,
+					Memo:      "refund",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			// The headers row consumes index 0 today: t.index increments after the
+			// headers check passes, so the first body row is RowNumber 1.
+			name: "first row headers consumed and matched",
+			csv:  "ID,Amount,Memo,Date\n1,12.34,coffee,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Amount", "Memo", "Date"},
+			},
+			firstRowHeaders: true,
+			want: []table.Row{
+				{
+					RowNumber: 1,
+					ID:        "1",
+					Amount:    1234,
+					Memo:      "coffee",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "memo from derived row number",
+			csv:  "1,12.34,2026-05-02\n2,-5.67,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{DerivedKind: table.DerivedKindRowNumber},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Amount", "Date"},
+			},
+			firstRowHeaders: false,
+			want: []table.Row{
+				{
+					RowNumber: 0,
+					ID:        "1",
+					Amount:    1234,
+					Memo:      "0",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+				{
+					RowNumber: 1,
+					ID:        "2",
+					Amount:    -567,
+					Memo:      "1",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "empty csv terminates with EOF",
+			csv:  "",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Amount", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want:            nil,
+			wantErr:         "",
+		},
+		{
+			name: "first row headers do not match mapping",
+			csv:  "X,Y,Z\n1,12.34,coffee\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Amount", "Memo", "Date"},
+			},
+			firstRowHeaders: true,
+			want:            nil,
+			wantErr:         "headers in file do not match",
+		},
+		{
+			name: "column amount with both columns empty",
+			csv:  "1,,,coffee,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindColumn,
+					Fields: []table.FieldRef{
+						{
+							Name: "Debit",
+						},
+						{
+							Name: "Credit",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Debit", "Credit", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want:            nil,
+			wantErr:         "both debit and credit columns are empty",
+		},
+		{
+			name: "column amount with both columns populated",
+			csv:  "1,5.00,3.00,coffee,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindColumn,
+					Fields: []table.FieldRef{
+						{
+							Name: "Debit",
+						},
+						{
+							Name: "Credit",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Debit", "Credit", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want:            nil,
+			wantErr:         "both debit and credit columns are populated",
+		},
+		{
+			name: "amount parse failure surfaces as wrapped row error",
+			csv:  "1,not-a-number,coffee,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Amount", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want:            nil,
+			wantErr:         "failed to derive amount from table for row",
+		},
+		{
+			// Format variation: slashes with year last. [DateSpec.GetTimeFormat]
+			// rewrites MM/DD/YYYY into Go's 01/02/2006 reference layout.
+			name: "date format MM/DD/YYYY",
+			csv:  "1,12.34,coffee,05/02/2026\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "MM/DD/YYYY",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Amount", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want: []table.Row{
+				{
+					RowNumber: 0,
+					ID:        "1",
+					Amount:    1234,
+					Memo:      "coffee",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			// Format variation: dashes with day first.
+			name: "date format DD-MM-YYYY",
+			csv:  "1,12.34,coffee,02-05-2026\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "DD-MM-YYYY",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Amount", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want: []table.Row{
+				{
+					RowNumber: 0,
+					ID:        "1",
+					Amount:    1234,
+					Memo:      "coffee",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			// Format variation: single-digit month/day plus two-digit year. Maps
+			// to Go's 1/2/06 reference layout, which accepts both single- and
+			// double-digit components when parsing.
+			name: "date format M/D/YY",
+			csv:  "1,12.34,coffee,5/2/26\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "M/D/YY",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Amount", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want: []table.Row{
+				{
+					RowNumber: 0,
+					ID:        "1",
+					Amount:    1234,
+					Memo:      "coffee",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			// Format variation: dotted European style.
+			name: "date format DD.MM.YYYY",
+			csv:  "1,12.34,coffee,02.05.2026\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "DD.MM.YYYY",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Amount", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want: []table.Row{
+				{
+					RowNumber: 0,
+					ID:        "1",
+					Amount:    1234,
+					Memo:      "coffee",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			// Date value does not match the declared format. [Table.getDate]
+			// surfaces the time.Parse error wrapped with the row prefix.
+			name: "date parse failure surfaces as wrapped row error",
+			csv:  "1,12.34,coffee,not-a-date\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Amount", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want:            nil,
+			wantErr:         "failed to derive date from table for row",
+		},
+		{
+			// [Table.Read] validates the mapping on the first call. An invalid
+			// mapping (here, Date is omitted entirely) must surface that error
+			// before any rows are produced.
+			name: "invalid mapping is rejected on first read",
+			csv:  "1,12.34,coffee,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo:    table.FieldRef{Name: "Memo"},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Amount", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want:            nil,
+			wantErr:         "failed to validate",
+		},
+		{
+			// [Table.getPosted] returns true when the configured field matches
+			// PostedSpec.Posted exactly. Any other status (including the empty
+			// string) is treated as pending. Both rows here are posted.
+			name: "posted spec, both rows match posted value",
+			csv:  "1,12.34,POSTED,coffee,2026-05-02\n2,-5.67,POSTED,refund,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Posted: &table.PostedSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Status",
+						},
+					},
+					Posted: "POSTED",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Amount", "Status", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want: []table.Row{
+				{
+					RowNumber: 0,
+					ID:        "1",
+					Amount:    1234,
+					Memo:      "coffee",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+				{
+					RowNumber: 1,
+					ID:        "2",
+					Amount:    -567,
+					Memo:      "refund",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			// First row is PENDING which doesn't match POSTED, so it surfaces as
+			// Posted=false. Second row matches and surfaces as true. The comparison
+			// is exact, so case differences would also fall to pending.
+			name: "posted spec, mixed posted and pending rows",
+			csv:  "1,12.34,PENDING,coffee,2026-05-02\n2,-5.67,POSTED,refund,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Posted: &table.PostedSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Status",
+						},
+					},
+					Posted: "POSTED",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Amount", "Status", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want: []table.Row{
+				{
+					RowNumber: 0,
+					ID:        "1",
+					Amount:    1234,
+					Memo:      "coffee",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    false,
+					Balance:   0,
+				},
+				{
+					RowNumber: 1,
+					ID:        "2",
+					Amount:    -567,
+					Memo:      "refund",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			// Comparison is exact, not case-insensitive, so a "posted" row against a
+			// "POSTED" needle is treated as pending. Worth pinning since the godoc on
+			// [PostedSpec] still describes it as case- insensitive but the
+			// implementation is not.
+			name: "posted spec, case mismatch falls to pending",
+			csv:  "1,12.34,posted,coffee,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Posted: &table.PostedSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Status",
+						},
+					},
+					Posted: "POSTED",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindNone},
+				Headers: []string{"ID", "Amount", "Status", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want: []table.Row{
+				{
+					RowNumber: 0,
+					ID:        "1",
+					Amount:    1234,
+					Memo:      "coffee",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    false,
+					Balance:   0,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			// Balance pulled from a column on each row. The first row is 100.00 USD =
+			// 10000 minor units, the second is -25.50 = -2550. monetr does not
+			// currently invert balances; the value passes through whatever sign the
+			// source provided.
+			name: "balance spec, field per row",
+			csv:  "1,12.34,100.00,coffee,2026-05-02\n2,-5.67,-25.50,refund,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{
+					Kind: table.BalanceKindField,
+					Fields: []table.FieldRef{
+						{
+							Name: "Balance",
+						},
+					},
+				},
+				Headers: []string{"ID", "Amount", "Balance", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want: []table.Row{
+				{
+					RowNumber: 0,
+					ID:        "1",
+					Amount:    1234,
+					Memo:      "coffee",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   10000,
+				},
+				{
+					RowNumber: 1,
+					ID:        "2",
+					Amount:    -567,
+					Memo:      "refund",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   -2550,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			// BalanceKindSum is currently a documented no-op pending the
+			// post-processing pass that would actually walk the rows. Pinning it as 0
+			// here so the day that gets implemented this case fails loudly and
+			// reminds us to update the test.
+			name: "balance spec, sum kind is a no-op",
+			csv:  "1,12.34,coffee,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{Kind: table.BalanceKindSum},
+				Headers: []string{"ID", "Amount", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want: []table.Row{
+				{
+					RowNumber: 0,
+					ID:        "1",
+					Amount:    1234,
+					Memo:      "coffee",
+					Merchant:  nil,
+					Date:      time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+					Posted:    true,
+					Balance:   0,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			// A non-numeric balance cell surfaces from [Table.getBalance] and is
+			// wrapped with the row prefix the same way the amount path does.
+			name: "balance parse failure surfaces as wrapped row error",
+			csv:  "1,12.34,not-a-number,coffee,2026-05-02\n",
+			mapping: &table.Mapping{
+				ID: table.IDSpec{
+					Kind: table.IDSpecKindNative,
+					Fields: []table.FieldRef{
+						{
+							Name: "ID",
+						},
+					},
+				},
+				Amount: table.AmountSpec{
+					Kind: table.AmountKindSign,
+					Fields: []table.FieldRef{
+						{
+							Name: "Amount",
+						},
+					},
+				},
+				Memo: table.FieldRef{Name: "Memo"},
+				Date: table.DateSpec{
+					Fields: []table.FieldRef{
+						{
+							Name: "Date",
+						},
+					},
+					Format: "YYYY-MM-DD",
+				},
+				Balance: table.BalanceSpec{
+					Kind: table.BalanceKindField,
+					Fields: []table.FieldRef{
+						{
+							Name: "Balance",
+						},
+					},
+				},
+				Headers: []string{"ID", "Amount", "Balance", "Memo", "Date"},
+			},
+			firstRowHeaders: false,
+			want:            nil,
+			wantErr:         "failed to derive balance from table for row",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			reader := csv.NewReader(strings.NewReader(tc.csv))
+			tbl := table.NewTable(reader, tc.mapping, tc.firstRowHeaders)
+
+			var got []table.Row
+			var lastErr error
+			for {
+				row, err := tbl.Read()
+				if err != nil {
+					lastErr = err
+					break
+				}
+				got = append(got, *row)
+			}
+
+			require.Len(t, got, len(tc.want), "row count must match expected")
+			for i := range tc.want {
+				assert.Equal(t, tc.want[i], got[i], "row %d", i)
+			}
+			if tc.wantErr == "" {
+				assert.ErrorIs(t, lastErr, io.EOF, "last error should be io.EOF")
+			} else {
+				assert.ErrorContains(t, lastErr, tc.wantErr, "terminal error must match")
+			}
+		})
+	}
+}

--- a/server/internal/mockgen/storage.go
+++ b/server/internal/mockgen/storage.go
@@ -72,7 +72,7 @@ func (mr *MockStorageMockRecorder) Remove(ctx, file any) *gomock.Call {
 }
 
 // Store mocks base method.
-func (m *MockStorage) Store(ctx context.Context, buf io.ReadSeekCloser, file models.File) error {
+func (m *MockStorage) Store(ctx context.Context, buf io.Reader, file models.File) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Store", ctx, buf, file)
 	ret0, _ := ret[0].(error)

--- a/server/internal/testutils/configuration.go
+++ b/server/internal/testutils/configuration.go
@@ -16,6 +16,10 @@ const (
 func GetConfig(t *testing.T) config.Configuration {
 	return config.Configuration{
 		AllowSignUp: true,
+		Features: config.Features{
+			// Enabled for test suites and local dev
+			TransactionImports: true,
+		},
 		Server: config.Server{
 			ExternalURL: "https://monetr.local",
 			Cookies: config.Cookies{

--- a/server/jobs/jobs.go
+++ b/server/jobs/jobs.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/monetr/monetr/server/billing/billing_jobs"
 	"github.com/monetr/monetr/server/config"
+	"github.com/monetr/monetr/server/datasources/csv/csv_jobs"
 	"github.com/monetr/monetr/server/datasources/lunch_flow/lunch_flow_jobs"
 	"github.com/monetr/monetr/server/datasources/ofx/ofx_jobs"
 	"github.com/monetr/monetr/server/datasources/plaid/plaid_jobs"
@@ -48,6 +49,7 @@ func RegisterJobs(
 	}
 
 	return myownsanity.FirstError(
+		queue.Register(ctx, processor, csv_jobs.PreviewCSVImport),
 		queue.Register(ctx, processor, funding_jobs.ProcessFundingSchedule),
 		queue.Register(ctx, processor, link_jobs.RemoveLink),
 		queue.Register(ctx, processor, ofx_jobs.ProcessOFXUpload),

--- a/server/migrations/schema/2026042801_TransactionImports.tx.up.sql
+++ b/server/migrations/schema/2026042801_TransactionImports.tx.up.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "transaction_imports" (
+  "transaction_import_id"         VARCHAR(32) NOT NULL,
+  "account_id"                    VARCHAR(32) NOT NULL,
+  "bank_account_id"               VARCHAR(32) NOT NULL,
+  "file_id"                       VARCHAR(32) NOT NULL,
+  "transaction_import_mapping_id" VARCHAR(32),
+  "headers"                       TEXT[]      NOT NULL,
+  "status"                        TEXT        NOT NULL,
+  "created_by"                    VARCHAR(32) NOT NULL,
+  "created_at"                    TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+  "updated_at"                    TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+  "completed_at"                  TIMESTAMP WITHOUT TIME ZONE,
+  CONSTRAINT "pk_transaction_imports"              PRIMARY KEY ("transaction_import_id", "account_id", "bank_account_id"),
+  CONSTRAINT "fk_transaction_imports_account"      FOREIGN KEY ("account_id") REFERENCES "accounts" ("account_id") ON DELETE CASCADE,
+  CONSTRAINT "fk_transaction_imports_bank_account" FOREIGN KEY ("bank_account_id", "account_id") REFERENCES "bank_accounts" ("bank_account_id", "account_id") ON DELETE CASCADE,
+  CONSTRAINT "fk_transaction_imports_file"         FOREIGN KEY ("file_id", "account_id") REFERENCES "files" ("file_id", "account_id") ON DELETE CASCADE,
+  CONSTRAINT "fk_transaction_imports_mapping"      FOREIGN KEY ("transaction_import_mapping_id", "account_id") REFERENCES "transaction_import_mappings" ("transaction_import_mapping_id", "account_id") ON DELETE CASCADE,
+  CONSTRAINT "fk_transaction_imports_created_by"   FOREIGN KEY ("created_by") REFERENCES "users" ("user_id") ON DELETE CASCADE
+);

--- a/server/migrations/schema/2026050400_TransactionImports.tx.up.sql
+++ b/server/migrations/schema/2026050400_TransactionImports.tx.up.sql
@@ -1,9 +1,15 @@
+-- Since this API was exposed but wasn't used for anything we should just drop
+-- everything from this table during this migration. We will likely do this
+-- again for the final release.
+DELETE FROM "transaction_import_mappings";
+
 CREATE TABLE "transaction_imports" (
   "transaction_import_id"         VARCHAR(32) NOT NULL,
   "account_id"                    VARCHAR(32) NOT NULL,
   "bank_account_id"               VARCHAR(32) NOT NULL,
   "file_id"                       VARCHAR(32) NOT NULL,
   "transaction_import_mapping_id" VARCHAR(32),
+  "delimeter"                     VARCHAR(1)  NOT NULL,
   "headers"                       TEXT[]      NOT NULL,
   "status"                        TEXT        NOT NULL,
   "created_by"                    VARCHAR(32) NOT NULL,

--- a/server/models/transaction_import_mapping.go
+++ b/server/models/transaction_import_mapping.go
@@ -20,7 +20,7 @@ var (
 type TransactionImportMapping struct {
 	tableName string `pg:"transaction_import_mappings"`
 
-	TransactionImportMappingId ID[TransactionImportMapping] `json:"transactionImportMapping" pg:"transaction_import_mapping_id,notnull,pk"`
+	TransactionImportMappingId ID[TransactionImportMapping] `json:"transactionImportMappingId" pg:"transaction_import_mapping_id,notnull,pk"`
 	AccountId                  ID[Account]                  `json:"-" pg:"account_id,notnull,pk"`
 	Account                    *Account                     `json:"-" pg:"rel:has-one"`
 	Signature                  string                       `json:"signature" pg:"signature,notnull"`

--- a/server/models/transaction_imports.go
+++ b/server/models/transaction_imports.go
@@ -48,6 +48,7 @@ type TransactionImport struct {
 	TransactionImportMappingId *ID[TransactionImportMapping] `json:"transactionImportMappingId" pg:"transaction_import_mapping_id"`
 	TransactionImportMapping   *TransactionImportMapping     `json:"transactionImportMapping,omitempty" pg:"rel:has-one"`
 	Headers                    []string                      `json:"headers" pg:"headers,notnull,type:'text[]'"`
+	Delimeter                  string                        `json:"delimeter" pg:"delimeter,notnull"`
 	Status                     TransactionImportStatus       `json:"status" pg:"status,notnull"`
 	CreatedAt                  time.Time                     `json:"createdAt" pg:"created_at,notnull"`
 	UpdatedAt                  time.Time                     `json:"updatedAt" pg:"updated_at,notnull"`

--- a/server/models/transaction_imports.go
+++ b/server/models/transaction_imports.go
@@ -95,18 +95,21 @@ func (TransactionImport) PatchSchemas() []validation.MapRule {
 			validation.Key(
 				"transactionImportMappingId",
 				ValidID[TransactionImportMapping]().Error("Transaction import mapping ID must be valid if provided"),
-			).Required(validators.Require),
+				validation.Required,
+			),
 			validation.Key(
 				"status",
 				validators.In(string(TransactionImportStatusPendingPreview)),
-			).Required(validators.Require),
+				validation.Required,
+			),
 		),
 		// Otherwise the user can only progress the import to pending processing.
 		validation.Map(
 			validation.Key(
 				"status",
 				validators.In(string(TransactionImportStatusPendingProcessing)),
-			).Required(validators.Require),
+				validation.Required,
+			),
 		),
 	}
 }

--- a/server/models/transaction_imports.go
+++ b/server/models/transaction_imports.go
@@ -1,0 +1,111 @@
+package models
+
+import (
+	"context"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/monetr/monetr/server/validators"
+	"github.com/monetr/validation"
+)
+
+// TransactionImportStatus covers all of the different states of a transaction
+// import. When it is initially created it will be in a `mapping` status.
+// 1. `mapping`
+// 2. `pending-preview` (user)
+// 3. `preview`
+// 4. `pending-processing` (user)
+// 5. `processing`
+// 6. `complete` | `failed`
+// 0. `expired`
+// Imports move to expired if they remain in a mapping, preview, or processing
+// status longer than the file is available in storage.
+// Imports are moved to pending preview or pending processing by the user when
+// they want to proceed with the import after mapping and confirmation.
+type TransactionImportStatus string
+
+const (
+	TransactionImportStatusMapping           TransactionImportStatus = "mapping"
+	TransactionImportStatusPendingPreview    TransactionImportStatus = "pending-preview"
+	TransactionImportStatusPreview           TransactionImportStatus = "preview"
+	TransactionImportStatusPendingProcessing TransactionImportStatus = "pending-processing"
+	TransactionImportStatusProcessing        TransactionImportStatus = "processing"
+	TransactionImportStatusFailed            TransactionImportStatus = "failed"
+	TransactionImportStatusComplete          TransactionImportStatus = "complete"
+	TransactionImportStatusExpired           TransactionImportStatus = "expired"
+)
+
+type TransactionImport struct {
+	tableName string `pg:"transaction_imports"`
+
+	TransactionImportId        ID[TransactionImport]         `json:"transactionImportId" pg:"transaction_import_id,notnull,pk"`
+	AccountId                  ID[Account]                   `json:"-" pg:"account_id,notnull,pk"`
+	Account                    *Account                      `json:"-" pg:"rel:has-one"`
+	BankAccountId              ID[BankAccount]               `json:"bankAccountId" pg:"bank_account_id,notnull,pk"`
+	BankAccount                *BankAccount                  `json:"-" pg:"rel:has-one"`
+	FileId                     ID[File]                      `json:"fileId" pg:"file_id,notnull"`
+	File                       *File                         `json:"file,omitempty" pg:"rel:has-one"`
+	TransactionImportMappingId *ID[TransactionImportMapping] `json:"transactionImportMappingId" pg:"transaction_import_mapping_id"`
+	TransactionImportMapping   *TransactionImportMapping     `json:"transactionImportMapping,omitempty" pg:"rel:has-one"`
+	Headers                    []string                      `json:"headers" pg:"headers,notnull,type:'text[]'"`
+	Status                     TransactionImportStatus       `json:"status" pg:"status,notnull"`
+	CreatedAt                  time.Time                     `json:"createdAt" pg:"created_at,notnull"`
+	UpdatedAt                  time.Time                     `json:"updatedAt" pg:"updated_at,notnull"`
+	CompletedAt                *time.Time                    `json:"completedAt" pg:"completed_at"`
+	CreatedBy                  ID[User]                      `json:"createdBy" pg:"created_by,notnull"`
+	CreatedByUser              *User                         `json:"-" pg:"rel:has-one,fk:created_by"`
+}
+
+func (TransactionImport) FileKind() string {
+	return "transactions/imports"
+}
+
+// TransactionImport files expire after 1 hour be default.
+func (TransactionImport) FileExpiration(clock clock.Clock) *time.Time {
+	expiration := clock.Now().Add(1 * time.Hour)
+	return &expiration
+}
+
+func (TransactionImport) IdentityPrefix() string {
+	return "txim"
+}
+
+func (o *TransactionImport) BeforeInsert(ctx context.Context) (context.Context, error) {
+	if o.TransactionImportId.IsZero() {
+		o.TransactionImportId = NewID[TransactionImport]()
+	}
+
+	now := time.Now()
+	if o.CreatedAt.IsZero() {
+		o.CreatedAt = now
+	}
+	if o.UpdatedAt.IsZero() {
+		o.UpdatedAt = now
+	}
+
+	return ctx, nil
+}
+
+func (TransactionImport) PatchSchemas() []validation.MapRule {
+	return []validation.MapRule{
+		// When we do not yet have a mapping then they must specify a new mapping ID
+		// and say that we are moving to the pending preview status.
+		validation.Map(
+			validation.Key(
+				"transactionImportMappingId",
+				ValidID[TransactionImportMapping]().Error("Transaction import mapping ID must be valid if provided"),
+			).Required(validators.Require),
+			validation.Key(
+				"status",
+				validators.In(string(TransactionImportStatusPendingPreview)),
+			).Required(validators.Require),
+		),
+		// Otherwise the user can only progress the import to pending processing.
+		validation.Map(
+			validation.Key(
+				"status",
+				validators.In(string(TransactionImportStatusPendingProcessing)),
+			).Required(validators.Require),
+		),
+	}
+}

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -154,6 +154,22 @@ type BaseRepository interface {
 		limit, offset int,
 	) ([]TransactionImportMapping, error)
 
+	GetTransactionImport(
+		ctx context.Context,
+		bankAccountId ID[BankAccount],
+		transactionImportId ID[TransactionImport],
+	) (*TransactionImport, error)
+	CreateTransactionImport(
+		ctx context.Context,
+		bankAccountId ID[BankAccount],
+		transactionImport *TransactionImport,
+	) error
+	UpdateTransactionImport(
+		ctx context.Context,
+		bankAccountId ID[BankAccount],
+		transactionImport *TransactionImport,
+	) error
+
 	CreateLunchFlowLink(ctx context.Context, link *LunchFlowLink) error
 	UpdateLunchFlowLink(ctx context.Context, link *LunchFlowLink) error
 	RemoveLunchFlowLink(ctx context.Context, id ID[LunchFlowLink]) error

--- a/server/repository/transaction_imports.go
+++ b/server/repository/transaction_imports.go
@@ -1,0 +1,85 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/monetr/monetr/server/crumbs"
+	. "github.com/monetr/monetr/server/models"
+	"github.com/pkg/errors"
+)
+
+func (r *repositoryBase) GetTransactionImport(
+	ctx context.Context,
+	bankAccountId ID[BankAccount],
+	transactionImportId ID[TransactionImport],
+) (*TransactionImport, error) {
+	span := crumbs.StartFnTrace(ctx)
+	defer span.Finish()
+
+	var item TransactionImport
+	err := r.txn.ModelContext(span.Context(), &item).
+		Where(`"account_id" = ?`, r.AccountId()).
+		Where(`"bank_account_id" = ?`, bankAccountId).
+		Where(`"transaction_import_id" = ?`, transactionImportId).
+		Limit(1).
+		Select(&item)
+	if err != nil {
+		span.Status = sentry.SpanStatusInternalError
+		return nil, errors.Wrap(err, "failed to retrieve transaction import")
+	}
+
+	span.Status = sentry.SpanStatusOK
+
+	return &item, nil
+}
+
+func (r *repositoryBase) CreateTransactionImport(
+	ctx context.Context,
+	bankAccountId ID[BankAccount],
+	transactionImport *TransactionImport,
+) error {
+	span := crumbs.StartFnTrace(ctx)
+	defer span.Finish()
+
+	transactionImport.AccountId = r.AccountId()
+	transactionImport.BankAccountId = bankAccountId
+	transactionImport.CreatedAt = r.clock.Now().UTC()
+	transactionImport.CreatedBy = r.UserId()
+
+	_, err := r.txn.ModelContext(span.Context(), transactionImport).
+		Insert(transactionImport)
+	if err != nil {
+		return errors.Wrap(err, "failed to create transaction import record")
+	}
+
+	span.SetData("transactionImportId", transactionImport.TransactionImportId.String())
+	span.Status = sentry.SpanStatusOK
+
+	return nil
+}
+
+func (r *repositoryBase) UpdateTransactionImport(
+	ctx context.Context,
+	bankAccountId ID[BankAccount],
+	transactionImport *TransactionImport,
+) error {
+	span := crumbs.StartFnTrace(ctx)
+	defer span.Finish()
+
+	transactionImport.AccountId = r.AccountId()
+	transactionImport.BankAccountId = bankAccountId
+	transactionImport.UpdatedAt = r.clock.Now().UTC()
+
+	_, err := r.txn.ModelContext(span.Context(), transactionImport).
+		WherePK().
+		Update(transactionImport)
+	if err != nil {
+		span.Status = sentry.SpanStatusInternalError
+		return errors.Wrap(err, "failed to update transaction import")
+	}
+
+	span.Status = sentry.SpanStatusOK
+
+	return nil
+}

--- a/server/storage/filesystem.go
+++ b/server/storage/filesystem.go
@@ -58,7 +58,7 @@ func NewFilesystemStorage(
 
 func (f *filesystemStorage) Store(
 	ctx context.Context,
-	buf io.ReadSeekCloser,
+	buf io.Reader,
 	file models.File,
 ) error {
 	span := crumbs.StartFnTrace(ctx)

--- a/server/storage/s3.go
+++ b/server/storage/s3.go
@@ -32,7 +32,7 @@ func NewS3StorageBackend(
 
 func (s *s3Storage) Store(
 	ctx context.Context,
-	buf io.ReadSeekCloser,
+	buf io.Reader,
 	file models.File,
 ) error {
 	span := crumbs.StartFnTrace(ctx)

--- a/server/storage/storage.go
+++ b/server/storage/storage.go
@@ -31,7 +31,7 @@ type Storage interface {
 	// be present in whatever storage system even if the file was not successfully
 	// stored. This should be considered on a per-implementation basis as it will
 	// be unique to the implementation itself.
-	Store(ctx context.Context, buf io.ReadSeekCloser, file models.File) error
+	Store(ctx context.Context, buf io.Reader, file models.File) error
 	// Read will take a file model and will read it from the underlying storage
 	// system. If a file can be read then a buffer will be returned for that file.
 	Read(ctx context.Context, file models.File) (buf io.ReadCloser, err error)

--- a/server/validators/CMakeLists.txt
+++ b/server/validators/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(GolangTestUtils)
+
+provision_golang_tests(${CMAKE_CURRENT_SOURCE_DIR})

--- a/server/validators/error_test.go
+++ b/server/validators/error_test.go
@@ -136,7 +136,7 @@ func TestMarshalErrorTree(t *testing.T) {
 		assert.Nil(t, validators.MarshalErrorTree(nil))
 	})
 
-	t.Run("strips pkg/errors wraps and produces a JSON-marshalable map", func(t *testing.T) {
+	t.Run("strips pkg.errors wraps and produces a JSON-marshalable map", func(t *testing.T) {
 		inner := validation.Errors{"name": errors.New("cannot be blank")}
 		wrapped := errors.Wrapf(inner, "failed to validate %T", &sampleStruct{})
 		got := validators.MarshalErrorTree(wrapped)

--- a/server/validators/printable_unicode.go
+++ b/server/validators/printable_unicode.go
@@ -1,0 +1,43 @@
+package validators
+
+import (
+	"unicode"
+
+	"github.com/monetr/validation"
+)
+
+// ErrPrintableUnicode is what [PrintableUnicode] returns when the value has any
+// rune that isn't printable.
+var ErrPrintableUnicode = validation.NewError(
+	"validation_is_printable_unicode",
+	"must contain printable characters only",
+)
+
+// PrintableUnicode is the same idea as [is.PrintableASCII] but doesn't reject
+// every non-ASCII rune. It accepts whatever Go's [unicode.IsPrint] thinks is
+// printable, which means letters, marks, numbers, punctuation, symbols, and the
+// regular ASCII space. monetr uses this for free text fields where users might
+// reasonably type things like "Pösted" or "Café" or even an emoji, but where we
+// still don't want the value to contain a tab or a newline or one of those
+// invisible whitespace characters that sneak in from copy/paste (no break
+// space, zero width joiner, etc).
+//
+// Empty values pass, the same way the rest of the [validation.StringRule] rules
+// do. Pair it with [validation.Required] when the field is required.
+//
+// One thing to know about: invalid UTF-8 byte sequences get replaced with
+// U+FFFD when Go ranges over the string, and U+FFFD itself is printable. So
+// this rule won't catch malformed input on its own. If we ever care about that
+// we'll have to add a utf8.ValidString check at the boundary; so far it hasn't
+// come up.
+var PrintableUnicode = validation.NewStringRuleWithError(
+	func(s string) bool {
+		for _, r := range s {
+			if !unicode.IsPrint(r) {
+				return false
+			}
+		}
+		return true
+	},
+	ErrPrintableUnicode,
+)

--- a/server/validators/printable_unicode_test.go
+++ b/server/validators/printable_unicode_test.go
@@ -1,0 +1,252 @@
+package validators_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/monetr/monetr/server/validators"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintableUnicode(t *testing.T) {
+	// The rule leans on Go's [unicode.IsPrint], which is generous with
+	// letters/marks/numbers/punctuation/symbols across scripts but strict about
+	// anything else. The cases below try to pin both halves: the stuff we
+	// actually want users to be able to type (umlauts, accents, CJK, emoji), and
+	// the stuff we want to keep out (control characters, non-ASCII whitespace,
+	// formatting code points). Empty input passes because that matches what the
+	// other [validation.StringRule] rules do; we lean on [validation.Required]
+	// elsewhere when the field has to be set.
+	const wantErr = "must contain printable characters only"
+	cases := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		// Things we want to accept.
+		{
+			name:    "empty",
+			input:   "",
+			wantErr: "",
+		},
+		{
+			name:    "ascii letters",
+			input:   "POSTED",
+			wantErr: "",
+		},
+		{
+			name:    "ascii digits",
+			input:   "1234567890",
+			wantErr: "",
+		},
+		{
+			name:    "ascii punctuation",
+			input:   "!@#$%^&*()_+-=,.<>/?;:'\"[]{}|\\`~",
+			wantErr: "",
+		},
+		{
+			name:    "ascii space",
+			input:   "hello world",
+			wantErr: "",
+		},
+		{
+			// The headline reason this rule exists. "Pösted" is the kind of value a
+			// real bank export might use that the old ASCII rule would have rejected.
+			name:    "umlauts",
+			input:   "Pösted",
+			wantErr: "",
+		},
+		{
+			name:    "accented vowels",
+			input:   "Café résumé naïve",
+			wantErr: "",
+		},
+		{
+			name:    "spanish punctuation",
+			input:   "¡hola! ¿qué tal?",
+			wantErr: "",
+		},
+		{
+			// Eszett and the oe ligature live above U+00FF so they exercise the
+			// multi-byte path through the validator, not just the Latin-1 fast path.
+			name:    "eszett and oe ligature",
+			input:   "Straße cœur",
+			wantErr: "",
+		},
+		{
+			name:    "cjk",
+			input:   "中文 日本語 한국어",
+			wantErr: "",
+		},
+		{
+			name:    "cyrillic",
+			input:   "Привет",
+			wantErr: "",
+		},
+		{
+			name:    "greek",
+			input:   "Καλημέρα",
+			wantErr: "",
+		},
+		{
+			name:    "arabic",
+			input:   "مرحبا",
+			wantErr: "",
+		},
+		{
+			name:    "hebrew",
+			input:   "שלום",
+			wantErr: "",
+		},
+		{
+			// If a user wants to put an emoji in their memo we're not going to stop
+			// them.
+			name:    "emoji",
+			input:   "POSTED 💸",
+			wantErr: "",
+		},
+		{
+			// Combining marks (the kind that stack on top of a letter) are printable
+			// on their own. The 'é' here is actually two runes: 'e' followed by
+			// U+0301 combining acute.
+			name:    "combining diacritic",
+			input:   "é",
+			wantErr: "",
+		},
+		{
+			name:    "currency symbols",
+			input:   "$ € £ ¥ ₹",
+			wantErr: "",
+		},
+		{
+			// The rule itself doesn't care about length. That's [validation.Length]'s
+			// job. Pin it just so we don't accidentally start short-circuiting
+			// somewhere.
+			name:    "long printable input",
+			input:   strings.Repeat("á", 1000),
+			wantErr: "",
+		},
+
+		// Things we want to keep out: control characters.
+		{
+			name:    "tab",
+			input:   "POS\tTED",
+			wantErr: wantErr,
+		},
+		{
+			name:    "newline",
+			input:   "POS\nTED",
+			wantErr: wantErr,
+		},
+		{
+			name:    "carriage return",
+			input:   "POS\rTED",
+			wantErr: wantErr,
+		},
+		{
+			name:    "nul",
+			input:   "POS\x00TED",
+			wantErr: wantErr,
+		},
+		{
+			// DEL is the same byte the old [is.PrintableASCII] rule used to catch.
+			// Worth pinning here so the swap doesn't accidentally regress that.
+			name:    "del",
+			input:   "POSTED\x7f",
+			wantErr: wantErr,
+		},
+		{
+			name:    "bell",
+			input:   "POS\x07TED",
+			wantErr: wantErr,
+		},
+		{
+			// The "C1" range from U+0080 to U+009F. ASCII never gets here but a
+			// botched encoding conversion can, and we don't want it.
+			name:    "c1 control",
+			input:   "POSTED",
+			wantErr: wantErr,
+		},
+
+		// Things we want to keep out: invisible characters that look like regular
+		// spaces or look like nothing at all.
+		{
+			// The classic copy/paste bug. NBSP looks identical to a regular space but
+			// compares differently, which causes all kinds of fun downstream.
+			name:    "no-break space",
+			input:   "hello world",
+			wantErr: wantErr,
+		},
+		{
+			name:    "en space",
+			input:   "hello world",
+			wantErr: wantErr,
+		},
+		{
+			name:    "zero-width joiner",
+			input:   "POS‍TED",
+			wantErr: wantErr,
+		},
+		{
+			name:    "zero-width non-joiner",
+			input:   "POS‌TED",
+			wantErr: wantErr,
+		},
+		{
+			// The BOM at the start of a string is the textbook "I copied this from
+			// somewhere" giveaway. Spelled with the escape sequence so this file
+			// itself stays clean.
+			name:    "byte order mark",
+			input:   "\uFEFFPOSTED",
+			wantErr: wantErr,
+		},
+		{
+			name:    "line separator",
+			input:   "POS TED",
+			wantErr: wantErr,
+		},
+
+		// One bad rune anywhere is enough to fail the whole input. Pin both ends so
+		// we don't accidentally start short-circuiting.
+		{
+			name:    "valid prefix then control char",
+			input:   "Pösted\t",
+			wantErr: wantErr,
+		},
+		{
+			name:    "control char then valid suffix",
+			input:   "\tPösted",
+			wantErr: wantErr,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := validators.PrintableUnicode.Validate(tc.input)
+			if tc.wantErr == "" {
+				assert.NoError(t, err, "input must be accepted")
+			} else {
+				assert.EqualError(t, err, tc.wantErr, "input must be rejected with the expected message")
+			}
+		})
+	}
+}
+
+func TestPrintableUnicode_ErrorIdentity(t *testing.T) {
+	// The error the rule reports comes from [validators.ErrPrintableUnicode] so
+	// callers can match on the sentinel rather than scraping the message text.
+	// The "validation_is_*" code lines up with the other rules in the validation
+	// library, which gives us a consistent shape on the wire.
+	err := validators.PrintableUnicode.Validate("bad\tinput")
+	assert.Error(t, err, "control character must surface an error")
+
+	verr, ok := err.(interface {
+		Code() string
+		Message() string
+	})
+	if assert.True(t, ok, "rule error must implement validation.Error") {
+		assert.Equal(t, "validation_is_printable_unicode", verr.Code(), "error code must be stable for clients")
+		assert.Equal(t, "must contain printable characters only", verr.Message(), "default message must be stable")
+	}
+}


### PR DESCRIPTION
Transaction imports will succeed transaction uploads, where imports will
ultimately support more file types in the end.

---

This PR adds more groundwork for transaction imports, specifically to support CSV file imports as a first pass.

It trims some of the features in the mapping spec (reducing row number by X things for complexity reasons).

It also adds the table struct in order to take a mapping spec and a CSV file input and turn that into meaningful data.

There is still a lot of work to be done here, like how does preview data ultimately get stored and served back to the UI? How long is preview data considered valid?