### PR TITLE
refactor(ui): Migrating from react-router to wouter

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -53,14 +53,13 @@
                 "react-number-format",
                 "react-plaid-link",
                 "react-qr-code",
-                "react-router-dom",
                 "rrule",
                 "storybook/**",
                 "tailwind-merge",
                 "tailwindcss",
                 "tailwindcss-animate",
                 "tailwindcss/**",
-                "vaul"
+                "wouter"
               ],
               ":BLANK_LINE:",
               [

--- a/interface/package.json
+++ b/interface/package.json
@@ -54,11 +54,11 @@
     "react-number-format": "5.4.5",
     "react-plaid-link": "4.1.1",
     "react-qr-code": "2.0.21",
-    "react-router-dom": "6.30.3",
     "rrule": "2.8.1",
     "tailwind-merge": "1.14.0",
     "tailwindcss": "3.4.19",
-    "tailwindcss-animate": "1.0.7"
+    "tailwindcss-animate": "1.0.7",
+    "wouter": "3.9.0"
   },
   "devDependencies": {
     "@imagemagick/magick-wasm": "0.0.40",

--- a/interface/src/Root.tsx
+++ b/interface/src/Root.tsx
@@ -1,6 +1,5 @@
 import NiceModal from '@ebay/nice-modal-react';
 import { ErrorBoundary } from '@sentry/react';
-import { BrowserRouter } from 'react-router-dom';
 
 import MQueryClient from '@monetr/interface/components/MQueryClient';
 import MSnackbarProvider from '@monetr/interface/components/MSnackbarProvider';
@@ -10,19 +9,17 @@ import Monetr from '@monetr/interface/monetr';
 
 export default function Root(): JSX.Element {
   return (
-    <BrowserRouter future={{ v7_startTransition: false, v7_relativeSplatPath: false }}>
-      <ErrorBoundary>
-        <MQueryClient>
-          <MSnackbarProvider>
-            <TooltipProvider>
-              <NiceModal.Provider>
-                <PullToRefresh />
-                <Monetr />
-              </NiceModal.Provider>
-            </TooltipProvider>
-          </MSnackbarProvider>
-        </MQueryClient>
-      </ErrorBoundary>
-    </BrowserRouter>
+    <ErrorBoundary>
+      <MQueryClient>
+        <MSnackbarProvider>
+          <TooltipProvider>
+            <NiceModal.Provider>
+              <PullToRefresh />
+              <Monetr />
+            </NiceModal.Provider>
+          </TooltipProvider>
+        </MSnackbarProvider>
+      </MQueryClient>
+    </ErrorBoundary>
   );
 }

--- a/interface/src/components/ArrowLink.tsx
+++ b/interface/src/components/ArrowLink.tsx
@@ -1,8 +1,7 @@
 import { ChevronRight } from 'lucide-react';
+import { Link } from 'wouter';
 
 import styles from './ArrowLink.module.scss';
-
-import { Link } from 'wouter';
 
 export interface ArrowRedirectProps {
   to: string;

--- a/interface/src/components/ArrowLink.tsx
+++ b/interface/src/components/ArrowLink.tsx
@@ -1,7 +1,8 @@
 import { ChevronRight } from 'lucide-react';
-import { Link } from 'react-router-dom';
 
 import styles from './ArrowLink.module.scss';
+
+import { Link } from 'wouter';
 
 export interface ArrowRedirectProps {
   to: string;

--- a/interface/src/components/Layout/BankSidebar.tsx
+++ b/interface/src/components/Layout/BankSidebar.tsx
@@ -1,4 +1,5 @@
 import { CircleAlert, LogOut, Settings } from 'lucide-react';
+import { Link } from 'wouter';
 
 import Logo from '@monetr/interface/assets/Logo';
 import Divider from '@monetr/interface/components/Divider';
@@ -10,8 +11,6 @@ import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 
 import styles from './BankSidebar.module.scss';
 import BankSidebarSubscriptionItem from './BankSidebarSubscriptionItem';
-
-import { Link } from 'wouter';
 
 export interface BankSidebarProps {
   className?: string;

--- a/interface/src/components/Layout/BankSidebar.tsx
+++ b/interface/src/components/Layout/BankSidebar.tsx
@@ -1,5 +1,4 @@
 import { CircleAlert, LogOut, Settings } from 'lucide-react';
-import { Link } from 'react-router-dom';
 
 import Logo from '@monetr/interface/assets/Logo';
 import Divider from '@monetr/interface/components/Divider';
@@ -11,6 +10,8 @@ import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 
 import styles from './BankSidebar.module.scss';
 import BankSidebarSubscriptionItem from './BankSidebarSubscriptionItem';
+
+import { Link } from 'wouter';
 
 export interface BankSidebarProps {
   className?: string;

--- a/interface/src/components/Layout/BankSidebarItem.tsx
+++ b/interface/src/components/Layout/BankSidebarItem.tsx
@@ -1,5 +1,3 @@
-import { Link } from 'react-router-dom';
-
 import PlaidInstitutionLogo from '@monetr/interface/components/Plaid/InstitutionLogo';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@monetr/interface/components/Tooltip';
 import { useBankAccounts } from '@monetr/interface/hooks/useBankAccounts';
@@ -8,6 +6,8 @@ import type MonetrLink from '@monetr/interface/models/Link';
 import sortAccounts from '@monetr/interface/util/sortAccounts';
 
 import styles from './BankSidebarItem.module.scss';
+
+import { Link } from 'wouter';
 
 interface BankSidebarItemProps {
   link: MonetrLink;

--- a/interface/src/components/Layout/BankSidebarItem.tsx
+++ b/interface/src/components/Layout/BankSidebarItem.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'wouter';
+
 import PlaidInstitutionLogo from '@monetr/interface/components/Plaid/InstitutionLogo';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@monetr/interface/components/Tooltip';
 import { useBankAccounts } from '@monetr/interface/hooks/useBankAccounts';
@@ -6,8 +8,6 @@ import type MonetrLink from '@monetr/interface/models/Link';
 import sortAccounts from '@monetr/interface/util/sortAccounts';
 
 import styles from './BankSidebarItem.module.scss';
-
-import { Link } from 'wouter';
 
 interface BankSidebarItemProps {
   link: MonetrLink;

--- a/interface/src/components/Layout/BankSidebarSubscriptionItem.tsx
+++ b/interface/src/components/Layout/BankSidebarSubscriptionItem.tsx
@@ -1,13 +1,12 @@
 import { formatDistance } from 'date-fns';
 import { CreditCard } from 'lucide-react';
+import { Link } from 'wouter';
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '@monetr/interface/components/Tooltip';
 import { useAppConfiguration } from '@monetr/interface/hooks/useAppConfiguration';
 import { useAuthentication } from '@monetr/interface/hooks/useAuthentication';
 
 import styles from './BankSidebarSubscriptionItem.module.scss';
-
-import { Link } from 'wouter';
 
 export default function BankSidebarSubscriptionItem(): JSX.Element {
   const { data: config } = useAppConfiguration();

--- a/interface/src/components/Layout/BankSidebarSubscriptionItem.tsx
+++ b/interface/src/components/Layout/BankSidebarSubscriptionItem.tsx
@@ -1,12 +1,13 @@
 import { formatDistance } from 'date-fns';
 import { CreditCard } from 'lucide-react';
-import { Link } from 'react-router-dom';
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '@monetr/interface/components/Tooltip';
 import { useAppConfiguration } from '@monetr/interface/hooks/useAppConfiguration';
 import { useAuthentication } from '@monetr/interface/hooks/useAuthentication';
 
 import styles from './BankSidebarSubscriptionItem.module.scss';
+
+import { Link } from 'wouter';
 
 export default function BankSidebarSubscriptionItem(): JSX.Element {
   const { data: config } = useAppConfiguration();

--- a/interface/src/components/Layout/BudgetLayout.tsx
+++ b/interface/src/components/Layout/BudgetLayout.tsx
@@ -1,19 +1,20 @@
 import { Fragment } from 'react';
-import { Outlet } from 'react-router-dom';
 
 import BudgetingSidebar from '@monetr/interface/components/Layout/BudgetingSidebar';
 
 import styles from './BudgetLayout.module.scss';
 
-export default function BudgetingLayout(): JSX.Element {
+export interface BudgetingLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function BudgetingLayout(props: BudgetingLayoutProps): JSX.Element {
   // className='hidden lg:flex'
   // className='min-w-0 flex flex-col grow'
   return (
     <Fragment>
       <BudgetingSidebar />
-      <div className={styles.budgetLayoutRoot}>
-        <Outlet />
-      </div>
+      <div className={styles.budgetLayoutRoot}>{props.children}</div>
     </Fragment>
   );
 }

--- a/interface/src/components/Layout/BudgetingSidebar.tsx
+++ b/interface/src/components/Layout/BudgetingSidebar.tsx
@@ -1,5 +1,4 @@
 import { CalendarSync, PiggyBank, Receipt, ShoppingCart } from 'lucide-react';
-import { Link, useLocation } from 'react-router-dom';
 
 import Badge from '@monetr/interface/components/Badge';
 import Divider from '@monetr/interface/components/Divider';
@@ -21,6 +20,8 @@ import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 
 import BudgetingSidebarTitle from './BudgetingSidebarTitle';
 import styles from './BudgetSidebar.module.scss';
+
+import { Link, useLocation } from 'wouter';
 
 export interface BudgetingSidebarProps {
   className?: string;
@@ -96,8 +97,8 @@ interface NavigationItemProps {
 }
 
 function NavigationItem(props: NavigationItemProps): JSX.Element {
-  const location = useLocation();
-  const active = location.pathname.endsWith(props.to.replaceAll('.', ''));
+  const [pathname] = useLocation();
+  const active = pathname.endsWith(props.to.replaceAll('.', ''));
 
   const className = mergeTailwind(
     {

--- a/interface/src/components/Layout/BudgetingSidebar.tsx
+++ b/interface/src/components/Layout/BudgetingSidebar.tsx
@@ -1,4 +1,5 @@
 import { CalendarSync, PiggyBank, Receipt, ShoppingCart } from 'lucide-react';
+import { Link, useLocation } from 'wouter';
 
 import Badge from '@monetr/interface/components/Badge';
 import Divider from '@monetr/interface/components/Divider';
@@ -20,8 +21,6 @@ import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 
 import BudgetingSidebarTitle from './BudgetingSidebarTitle';
 import styles from './BudgetSidebar.module.scss';
-
-import { Link, useLocation } from 'wouter';
 
 export interface BudgetingSidebarProps {
   className?: string;

--- a/interface/src/components/Layout/BudgetingSidebarTitle.tsx
+++ b/interface/src/components/Layout/BudgetingSidebarTitle.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useCallback } from 'react';
 import { EllipsisVertical, LogIn, Plug, RefreshCw, Settings, Trash2 } from 'lucide-react';
+import { useLocation } from 'wouter';
 
 import Divider from '@monetr/interface/components/Divider';
 import {
@@ -14,8 +15,6 @@ import { useSelectedBankAccount } from '@monetr/interface/hooks/useSelectedBankA
 import { useTriggerManualPlaidSync } from '@monetr/interface/hooks/useTriggerManualPlaidSync';
 import { showRemoveLinkModal } from '@monetr/interface/modals/RemoveLinkModal';
 import { showUpdatePlaidAccountOverlay } from '@monetr/interface/modals/UpdatePlaidAccountOverlay';
-
-import { useLocation } from 'wouter';
 
 export default function BudgetingSidebarTitle(): JSX.Element {
   const { data: bankAccount } = useSelectedBankAccount();

--- a/interface/src/components/Layout/BudgetingSidebarTitle.tsx
+++ b/interface/src/components/Layout/BudgetingSidebarTitle.tsx
@@ -1,6 +1,5 @@
 import { Fragment, useCallback } from 'react';
 import { EllipsisVertical, LogIn, Plug, RefreshCw, Settings, Trash2 } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
 
 import Divider from '@monetr/interface/components/Divider';
 import {
@@ -16,10 +15,12 @@ import { useTriggerManualPlaidSync } from '@monetr/interface/hooks/useTriggerMan
 import { showRemoveLinkModal } from '@monetr/interface/modals/RemoveLinkModal';
 import { showUpdatePlaidAccountOverlay } from '@monetr/interface/modals/UpdatePlaidAccountOverlay';
 
+import { useLocation } from 'wouter';
+
 export default function BudgetingSidebarTitle(): JSX.Element {
   const { data: bankAccount } = useSelectedBankAccount();
   const { data: link } = useCurrentLink();
-  const navigate = useNavigate();
+  const [, navigate] = useLocation();
   const triggerSync = useTriggerManualPlaidSync();
 
   const handleReauthenticateLink = useCallback(() => {

--- a/interface/src/components/Layout/MobileSidebar.tsx
+++ b/interface/src/components/Layout/MobileSidebar.tsx
@@ -1,11 +1,10 @@
 import { useContext, useEffect } from 'react';
+import { useLocation, useRoute } from 'wouter';
 
 import BankSidebar from '@monetr/interface/components/Layout/BankSidebar';
 import BudgetingSidebar from '@monetr/interface/components/Layout/BudgetingSidebar';
 import { MobileSidebarContext } from '@monetr/interface/components/Layout/MobileSidebarContextProvider';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
-
-import { useLocation, useRoute } from 'wouter';
 
 export default function MobileSidebar(): JSX.Element {
   const { isOpen, setIsOpen } = useContext(MobileSidebarContext);

--- a/interface/src/components/Layout/MobileSidebar.tsx
+++ b/interface/src/components/Layout/MobileSidebar.tsx
@@ -1,16 +1,17 @@
 import { useContext, useEffect } from 'react';
-import { useLocation, useMatch } from 'react-router-dom';
 
 import BankSidebar from '@monetr/interface/components/Layout/BankSidebar';
 import BudgetingSidebar from '@monetr/interface/components/Layout/BudgetingSidebar';
 import { MobileSidebarContext } from '@monetr/interface/components/Layout/MobileSidebarContextProvider';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 
+import { useLocation, useRoute } from 'wouter';
+
 export default function MobileSidebar(): JSX.Element {
   const { isOpen, setIsOpen } = useContext(MobileSidebarContext);
-  const match = useMatch('/bank/:bankId/*');
-  const isBankRoute = Boolean(match?.params?.bankId || null);
-  const { pathname } = useLocation();
+  const [, params] = useRoute<{ bankId: string }>('/bank/:bankId/*');
+  const isBankRoute = Boolean(params?.bankId);
+  const [pathname] = useLocation();
 
   // When we navigate away from the current page, if the sidebar is open; close it.
   // This achieves the behavior of; if they click a navigation item in the sidebar we automatically

--- a/interface/src/components/Layout/MobileSidebarContextProvider.tsx
+++ b/interface/src/components/Layout/MobileSidebarContextProvider.tsx
@@ -1,5 +1,4 @@
 import { createContext, useEffect, useState } from 'react';
-
 import { useLocation } from 'wouter';
 
 export interface IMobileSidebarContext {

--- a/interface/src/components/Layout/MobileSidebarContextProvider.tsx
+++ b/interface/src/components/Layout/MobileSidebarContextProvider.tsx
@@ -1,5 +1,6 @@
 import { createContext, useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+
+import { useLocation } from 'wouter';
 
 export interface IMobileSidebarContext {
   isOpen: boolean;
@@ -16,7 +17,7 @@ export interface MobileSidebarContextProviderProps {
 }
 
 export default function MobileSidebarContextProvider(props: MobileSidebarContextProviderProps): JSX.Element {
-  const { pathname } = useLocation();
+  const [pathname] = useLocation();
   const [isOpen, setIsOpen] = useState(false);
   useEffect(() => {
     const root = document.querySelector('#root');

--- a/interface/src/components/Layout/SelectBankAccount.tsx
+++ b/interface/src/components/Layout/SelectBankAccount.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Check, ChevronsUpDown, CirclePlus, Settings } from 'lucide-react';
-import { Link, useNavigate } from 'react-router-dom';
 
 import Badge from '@monetr/interface/components/Badge';
 import { Button, buttonVariants } from '@monetr/interface/components/Button';
@@ -28,8 +27,10 @@ import type { BankAccountStatus } from '@monetr/interface/models/BankAccount';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 import sortAccounts from '@monetr/interface/util/sortAccounts';
 
+import { Link, useLocation } from 'wouter';
+
 export default function SelectBankAccount(): JSX.Element {
-  const navigate = useNavigate();
+  const [, navigate] = useLocation();
   const { data: allBankAccounts, isLoading: allIsLoading } = useBankAccounts();
   const { data: selectedBankAccount, isLoading: selectedIsLoading } = useSelectedBankAccount();
   const [open, setOpen] = React.useState(false);

--- a/interface/src/components/Layout/SelectBankAccount.tsx
+++ b/interface/src/components/Layout/SelectBankAccount.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Check, ChevronsUpDown, CirclePlus, Settings } from 'lucide-react';
+import { Link, useLocation } from 'wouter';
 
 import Badge from '@monetr/interface/components/Badge';
 import { Button, buttonVariants } from '@monetr/interface/components/Button';
@@ -26,8 +27,6 @@ import { showNewBankAccountModal } from '@monetr/interface/modals/NewBankAccount
 import type { BankAccountStatus } from '@monetr/interface/models/BankAccount';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 import sortAccounts from '@monetr/interface/util/sortAccounts';
-
-import { Link, useLocation } from 'wouter';
 
 export default function SelectBankAccount(): JSX.Element {
   const [, navigate] = useLocation();

--- a/interface/src/components/Layout/SettingsLayout.tsx
+++ b/interface/src/components/Layout/SettingsLayout.tsx
@@ -1,5 +1,4 @@
 import { Settings } from 'lucide-react';
-import { Link, Outlet, useLocation } from 'react-router-dom';
 
 import Divider from '@monetr/interface/components/Divider';
 import MTopNavigation from '@monetr/interface/components/MTopNavigation';
@@ -7,7 +6,13 @@ import { textVariants } from '@monetr/interface/components/Typography';
 import { useAppConfiguration } from '@monetr/interface/hooks/useAppConfiguration';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 
-export default function SettingsLayout(): JSX.Element {
+import { Link, useLocation } from 'wouter';
+
+export interface SettingsLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function SettingsLayout(props: SettingsLayoutProps): JSX.Element {
   const config = useAppConfiguration();
 
   return (
@@ -20,7 +25,7 @@ export default function SettingsLayout(): JSX.Element {
         <SettingTab to='/settings/about'>About</SettingTab>
       </div>
       <Divider />
-      <Outlet />
+      {props.children}
     </div>
   );
 }
@@ -31,8 +36,8 @@ interface SettingTabProps {
 }
 
 function SettingTab(props: SettingTabProps): JSX.Element {
-  const location = useLocation();
-  const active = location.pathname === props.to;
+  const [pathname] = useLocation();
+  const active = pathname === props.to;
   const className = mergeTailwind(
     textVariants({
       size: 'inherit',

--- a/interface/src/components/Layout/SettingsLayout.tsx
+++ b/interface/src/components/Layout/SettingsLayout.tsx
@@ -1,12 +1,11 @@
 import { Settings } from 'lucide-react';
+import { Link, useLocation } from 'wouter';
 
 import Divider from '@monetr/interface/components/Divider';
 import MTopNavigation from '@monetr/interface/components/MTopNavigation';
 import { textVariants } from '@monetr/interface/components/Typography';
 import { useAppConfiguration } from '@monetr/interface/hooks/useAppConfiguration';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
-
-import { Link, useLocation } from 'wouter';
 
 export interface SettingsLayoutProps {
   children: React.ReactNode;

--- a/interface/src/components/Layout/SidebarPaddingLayout.tsx
+++ b/interface/src/components/Layout/SidebarPaddingLayout.tsx
@@ -1,11 +1,9 @@
-import { Outlet } from 'react-router-dom';
-
 import styles from './SidebarPaddingLayout.module.scss';
 
-export default function SidebarPaddingLayout(): React.JSX.Element {
-  return (
-    <div className={styles.sidebarPaddingLayout}>
-      <Outlet />
-    </div>
-  );
+export interface SidebarPaddingLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function SidebarPaddingLayout(props: SidebarPaddingLayoutProps): React.JSX.Element {
+  return <div className={styles.sidebarPaddingLayout}>{props.children}</div>;
 }

--- a/interface/src/components/MLink.tsx
+++ b/interface/src/components/MLink.tsx
@@ -1,12 +1,13 @@
 import type React from 'react';
-import { Link, type LinkProps } from 'react-router-dom';
 
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 
 import type { TextSize } from './types';
 
-type BaseLinkProps = LinkProps & React.RefAttributes<HTMLAnchorElement>;
-export interface MLinkProps extends BaseLinkProps {
+import { Link } from 'wouter';
+
+export interface MLinkProps extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
+  to: string;
   children: React.ReactNode;
   color?: 'primary' | 'secondary';
   size?: TextSize;

--- a/interface/src/components/MLink.tsx
+++ b/interface/src/components/MLink.tsx
@@ -1,10 +1,9 @@
 import type React from 'react';
+import { Link } from 'wouter';
 
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 
 import type { TextSize } from './types';
-
-import { Link } from 'wouter';
 
 export interface MLinkProps extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
   to: string;

--- a/interface/src/components/MSidebarToggle.tsx
+++ b/interface/src/components/MSidebarToggle.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useContext } from 'react';
 import { ArrowLeft, PanelLeft, PanelLeftClose } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
 
 import { MobileSidebarContext } from '@monetr/interface/components/Layout/MobileSidebarContextProvider';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
+
+import { useLocation } from 'wouter';
 
 export interface MSidebarToggleProps {
   backButton?: string;
@@ -11,7 +12,7 @@ export interface MSidebarToggleProps {
 }
 
 export default function MSidebarToggle(props: MSidebarToggleProps): JSX.Element {
-  const navigate = useNavigate();
+  const [, navigate] = useLocation();
   const { isOpen, setIsOpen } = useContext(MobileSidebarContext);
 
   const onClick = useCallback(() => {

--- a/interface/src/components/MSidebarToggle.tsx
+++ b/interface/src/components/MSidebarToggle.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useContext } from 'react';
 import { ArrowLeft, PanelLeft, PanelLeftClose } from 'lucide-react';
+import { useLocation } from 'wouter';
 
 import { MobileSidebarContext } from '@monetr/interface/components/Layout/MobileSidebarContextProvider';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
-
-import { useLocation } from 'wouter';
 
 export interface MSidebarToggleProps {
   backButton?: string;

--- a/interface/src/components/MTopNavigation.tsx
+++ b/interface/src/components/MTopNavigation.tsx
@@ -1,12 +1,13 @@
 import type React from 'react';
 import { Fragment, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import MSidebarToggle from '@monetr/interface/components/MSidebarToggle';
 import Typography from '@monetr/interface/components/Typography';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 
 import styles from './MTopNavigation.module.scss';
+
+import { useLocation } from 'wouter';
 
 export interface MTopNavigationProps {
   icon: React.FC<{ className?: string }>;
@@ -18,7 +19,7 @@ export interface MTopNavigationProps {
 
 export default function MTopNavigation(props: MTopNavigationProps): JSX.Element {
   const Icon = props.icon;
-  const navigate = useNavigate();
+  const [, navigate] = useLocation();
 
   const onInitialClick = useCallback(() => {
     if (props.base) {

--- a/interface/src/components/MTopNavigation.tsx
+++ b/interface/src/components/MTopNavigation.tsx
@@ -1,13 +1,12 @@
 import type React from 'react';
 import { Fragment, useCallback } from 'react';
+import { useLocation } from 'wouter';
 
 import MSidebarToggle from '@monetr/interface/components/MSidebarToggle';
 import Typography from '@monetr/interface/components/Typography';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 
 import styles from './MTopNavigation.module.scss';
-
-import { useLocation } from 'wouter';
 
 export interface MTopNavigationProps {
   icon: React.FC<{ className?: string }>;

--- a/interface/src/components/PullToRefresh.tsx
+++ b/interface/src/components/PullToRefresh.tsx
@@ -27,11 +27,8 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { RefreshCcw } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
 
 export default function PullToRefresh(): JSX.Element {
-  const navigate = useNavigate();
-
   const [pullStartPoint, setPullStartPoint] = useState(0);
   const [pullChange, setPullChange] = useState(0);
   const refreshDiv = useRef<HTMLDivElement>(null);
@@ -48,7 +45,7 @@ export default function PullToRefresh(): JSX.Element {
     const forceReload = () => {
       refreshDiv.current?.classList.add('loading');
       setTimeout(() => {
-        navigate(0);
+        window.location.reload();
       }, 1000);
     };
 
@@ -141,7 +138,7 @@ export default function PullToRefresh(): JSX.Element {
       window.removeEventListener('touchmove', pullDown);
       window.removeEventListener('touchend', pullFinish);
     };
-  }, [pullDownReloadThreshold, pullStartPoint, navigate]);
+  }, [pullDownReloadThreshold, pullStartPoint]);
 
   return (
     <div

--- a/interface/src/components/TextLink.tsx
+++ b/interface/src/components/TextLink.tsx
@@ -1,12 +1,11 @@
 import type React from 'react';
 import { cva } from 'class-variance-authority';
+import { Link } from 'wouter';
 
 import { textSizes, textWeights } from '@monetr/interface/components/Typography';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 
 import styles from './TextLink.module.scss';
-
-import { Link } from 'wouter';
 
 export const textLinkVariants = cva([styles.textLink], {
   variants: {

--- a/interface/src/components/TextLink.tsx
+++ b/interface/src/components/TextLink.tsx
@@ -1,11 +1,12 @@
 import type React from 'react';
 import { cva } from 'class-variance-authority';
-import { Link, type LinkProps } from 'react-router-dom';
 
 import { textSizes, textWeights } from '@monetr/interface/components/Typography';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 
 import styles from './TextLink.module.scss';
+
+import { Link } from 'wouter';
 
 export const textLinkVariants = cva([styles.textLink], {
   variants: {
@@ -25,7 +26,10 @@ export const textLinkVariants = cva([styles.textLink], {
 
 type VariantProps = Omit<Parameters<typeof textLinkVariants>[0], 'className' | 'class'>;
 
-export type TextLinkProps = VariantProps & LinkProps;
+export type TextLinkProps = VariantProps &
+  Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> & {
+    to: string;
+  };
 
 export default function TextLink({ variant, size, className, ...props }: TextLinkProps): React.JSX.Element {
   return (

--- a/interface/src/components/expenses/ExpenseItem.tsx
+++ b/interface/src/components/expenses/ExpenseItem.tsx
@@ -1,6 +1,7 @@
 import { format, isThisYear } from 'date-fns';
 import { ChevronRight } from 'lucide-react';
 import { rrulestr } from 'rrule';
+import { Link } from 'wouter';
 
 import Badge from '@monetr/interface/components/Badge';
 import MerchantIcon from '@monetr/interface/components/MerchantIcon';
@@ -12,8 +13,6 @@ import { AmountType } from '@monetr/interface/util/amounts';
 import capitalize from '@monetr/interface/util/capitalize';
 
 import styles from './ExpenseItem.module.scss';
-
-import { Link } from 'wouter';
 
 export interface ExpenseItemProps {
   spending: Spending;

--- a/interface/src/components/expenses/ExpenseItem.tsx
+++ b/interface/src/components/expenses/ExpenseItem.tsx
@@ -1,6 +1,5 @@
 import { format, isThisYear } from 'date-fns';
 import { ChevronRight } from 'lucide-react';
-import { Link } from 'react-router-dom';
 import { rrulestr } from 'rrule';
 
 import Badge from '@monetr/interface/components/Badge';
@@ -13,6 +12,8 @@ import { AmountType } from '@monetr/interface/util/amounts';
 import capitalize from '@monetr/interface/util/capitalize';
 
 import styles from './ExpenseItem.module.scss';
+
+import { Link } from 'wouter';
 
 export interface ExpenseItemProps {
   spending: Spending;

--- a/interface/src/components/expenses/ExpenseTransactionList.tsx
+++ b/interface/src/components/expenses/ExpenseTransactionList.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from 'react';
 import { ChevronRight } from 'lucide-react';
+import { Link } from 'wouter';
 
 import { flexVariants } from '@monetr/interface/components/Flex';
 import { Item, ItemContent } from '@monetr/interface/components/Item';
@@ -11,8 +12,6 @@ import useSpendingTransactions from '@monetr/interface/hooks/useSpendingTransact
 import useTimezone from '@monetr/interface/hooks/useTimezone';
 import type Spending from '@monetr/interface/models/Spending';
 import { DateLength, formatDate } from '@monetr/interface/util/formatDate';
-
-import { Link } from 'wouter';
 
 export interface ExpenseTransactionListProps {
   spending: Spending;

--- a/interface/src/components/expenses/ExpenseTransactionList.tsx
+++ b/interface/src/components/expenses/ExpenseTransactionList.tsx
@@ -1,6 +1,5 @@
 import { Fragment } from 'react';
 import { ChevronRight } from 'lucide-react';
-import { Link } from 'react-router-dom';
 
 import { flexVariants } from '@monetr/interface/components/Flex';
 import { Item, ItemContent } from '@monetr/interface/components/Item';
@@ -12,6 +11,8 @@ import useSpendingTransactions from '@monetr/interface/hooks/useSpendingTransact
 import useTimezone from '@monetr/interface/hooks/useTimezone';
 import type Spending from '@monetr/interface/models/Spending';
 import { DateLength, formatDate } from '@monetr/interface/util/formatDate';
+
+import { Link } from 'wouter';
 
 export interface ExpenseTransactionListProps {
   spending: Spending;

--- a/interface/src/components/funding/FundingItem.tsx
+++ b/interface/src/components/funding/FundingItem.tsx
@@ -1,6 +1,7 @@
 import { format } from 'date-fns';
 import { ChevronRight } from 'lucide-react';
 import { rrulestr } from 'rrule';
+import { Link, useLocation } from 'wouter';
 
 import { Avatar, AvatarFallback } from '@monetr/interface/components/Avatar';
 import Typography from '@monetr/interface/components/Typography';
@@ -10,8 +11,6 @@ import { useNextFundingForecast } from '@monetr/interface/hooks/useNextFundingFo
 import type FundingSchedule from '@monetr/interface/models/FundingSchedule';
 import { AmountType } from '@monetr/interface/util/amounts';
 import capitalize from '@monetr/interface/util/capitalize';
-
-import { Link, useLocation } from 'wouter';
 
 export interface FundingItemProps {
   funding: FundingSchedule;

--- a/interface/src/components/funding/FundingItem.tsx
+++ b/interface/src/components/funding/FundingItem.tsx
@@ -1,6 +1,5 @@
 import { format } from 'date-fns';
 import { ChevronRight } from 'lucide-react';
-import { Link, useNavigate } from 'react-router-dom';
 import { rrulestr } from 'rrule';
 
 import { Avatar, AvatarFallback } from '@monetr/interface/components/Avatar';
@@ -12,6 +11,8 @@ import type FundingSchedule from '@monetr/interface/models/FundingSchedule';
 import { AmountType } from '@monetr/interface/util/amounts';
 import capitalize from '@monetr/interface/util/capitalize';
 
+import { Link, useLocation } from 'wouter';
+
 export interface FundingItemProps {
   funding: FundingSchedule;
 }
@@ -19,7 +20,7 @@ export interface FundingItemProps {
 export default function FundingItem(props: FundingItemProps): JSX.Element {
   const { data: localeCurrency } = useLocaleCurrency();
   const { data: locale } = useLocale();
-  const navigate = useNavigate();
+  const [, navigate] = useLocation();
   const { funding } = props;
   const contributionForecast = useNextFundingForecast(funding.fundingScheduleId);
   const rule = rrulestr(funding.ruleset);

--- a/interface/src/components/goals/GoalItem.tsx
+++ b/interface/src/components/goals/GoalItem.tsx
@@ -1,5 +1,4 @@
 import { Fragment } from 'react';
-import { Link } from 'react-router-dom';
 
 import ArrowLink from '@monetr/interface/components/ArrowLink';
 import Badge from '@monetr/interface/components/Badge';
@@ -9,6 +8,8 @@ import useLocaleCurrency from '@monetr/interface/hooks/useLocaleCurrency';
 import type Spending from '@monetr/interface/models/Spending';
 import { AmountType } from '@monetr/interface/util/amounts';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
+
+import { Link } from 'wouter';
 
 export interface GoalItemProps {
   spending: Spending;

--- a/interface/src/components/goals/GoalItem.tsx
+++ b/interface/src/components/goals/GoalItem.tsx
@@ -1,4 +1,5 @@
 import { Fragment } from 'react';
+import { Link } from 'wouter';
 
 import ArrowLink from '@monetr/interface/components/ArrowLink';
 import Badge from '@monetr/interface/components/Badge';
@@ -8,8 +9,6 @@ import useLocaleCurrency from '@monetr/interface/hooks/useLocaleCurrency';
 import type Spending from '@monetr/interface/models/Spending';
 import { AmountType } from '@monetr/interface/util/amounts';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
-
-import { Link } from 'wouter';
 
 export interface GoalItemProps {
   spending: Spending;

--- a/interface/src/components/setup/PlaidSetup.tsx
+++ b/interface/src/components/setup/PlaidSetup.tsx
@@ -8,6 +8,7 @@ import {
   type PlaidLinkOptionsWithLinkToken,
   usePlaidLink,
 } from 'react-plaid-link';
+import { useLocation } from 'wouter';
 
 import MLink from '@monetr/interface/components/MLink';
 import MLogo from '@monetr/interface/components/MLogo';
@@ -15,8 +16,6 @@ import MSpinner from '@monetr/interface/components/MSpinner';
 import LogoutFooter from '@monetr/interface/components/setup/LogoutFooter';
 import Typography from '@monetr/interface/components/Typography';
 import request from '@monetr/interface/util/request';
-
-import { useLocation } from 'wouter';
 
 interface PlaidProps {
   alreadyOnboarded?: boolean;

--- a/interface/src/components/setup/PlaidSetup.tsx
+++ b/interface/src/components/setup/PlaidSetup.tsx
@@ -8,7 +8,6 @@ import {
   type PlaidLinkOptionsWithLinkToken,
   usePlaidLink,
 } from 'react-plaid-link';
-import { useNavigate } from 'react-router-dom';
 
 import MLink from '@monetr/interface/components/MLink';
 import MLogo from '@monetr/interface/components/MLogo';
@@ -16,6 +15,8 @@ import MSpinner from '@monetr/interface/components/MSpinner';
 import LogoutFooter from '@monetr/interface/components/setup/LogoutFooter';
 import Typography from '@monetr/interface/components/Typography';
 import request from '@monetr/interface/util/request';
+
+import { useLocation } from 'wouter';
 
 interface PlaidProps {
   alreadyOnboarded?: boolean;
@@ -39,7 +40,7 @@ export default function PlaidSetup(props: PlaidProps): JSX.Element {
   });
 
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
+  const [, navigate] = useLocation();
 
   async function longPollSetup(recur: number, linkId: number): Promise<void> {
     setState({

--- a/interface/src/components/setup/lunchflow/LunchFlowSetupAccounts.tsx
+++ b/interface/src/components/setup/lunchflow/LunchFlowSetupAccounts.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import type { FormikErrors, FormikHelpers } from 'formik';
+import { useLocation, useParams } from 'wouter';
 
 import { flexVariants } from '@monetr/interface/components/Flex';
 import FormButton from '@monetr/interface/components/FormButton';
@@ -16,8 +17,6 @@ import { useLunchFlowLink } from '@monetr/interface/hooks/useLunchFlowLink';
 import { BankAccountSubType, BankAccountType } from '@monetr/interface/models/BankAccount';
 import { LunchFlowBankAccountStatus } from '@monetr/interface/models/LunchFlowBankAccount';
 import { LunchFlowLinkStatus } from '@monetr/interface/models/LunchFlowLink';
-
-import { useLocation, useParams } from 'wouter';
 
 export interface LunchFlowSetupAccountsForm {
   items: { [key: string]: boolean };

--- a/interface/src/components/setup/lunchflow/LunchFlowSetupAccounts.tsx
+++ b/interface/src/components/setup/lunchflow/LunchFlowSetupAccounts.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import type { FormikErrors, FormikHelpers } from 'formik';
-import { useNavigate, useParams } from 'react-router-dom';
 
 import { flexVariants } from '@monetr/interface/components/Flex';
 import FormButton from '@monetr/interface/components/FormButton';
@@ -18,13 +17,15 @@ import { BankAccountSubType, BankAccountType } from '@monetr/interface/models/Ba
 import { LunchFlowBankAccountStatus } from '@monetr/interface/models/LunchFlowBankAccount';
 import { LunchFlowLinkStatus } from '@monetr/interface/models/LunchFlowLink';
 
+import { useLocation, useParams } from 'wouter';
+
 export interface LunchFlowSetupAccountsForm {
   items: { [key: string]: boolean };
 }
 
 export default function LunchFlowSetupAccounts(): React.JSX.Element {
-  const { lunchFlowLinkId } = useParams();
-  const navigate = useNavigate();
+  const { lunchFlowLinkId } = useParams<{ lunchFlowLinkId: string }>();
+  const [, navigate] = useLocation();
   const createLink = useCreateLink();
   const createBankAccount = useCreateBankAccount();
   // When the page loads, use the ID from the url params to trigger a refresh of bank accounts. This refresh will fail

--- a/interface/src/components/setup/lunchflow/LunchFlowSetupIntro.tsx
+++ b/interface/src/components/setup/lunchflow/LunchFlowSetupIntro.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import type { FormikHelpers } from 'formik';
 import { useFormikContext } from 'formik';
-import { useNavigate } from 'react-router-dom';
 
 import type { ApiError } from '@monetr/interface/api/client';
 import { flexVariants } from '@monetr/interface/components/Flex';
@@ -18,6 +17,8 @@ import LunchFlowLink from '@monetr/interface/models/LunchFlowLink';
 import request, { type APIError } from '@monetr/interface/util/request';
 import { useSnackbar } from '@monetr/notify';
 
+import { useLocation } from 'wouter';
+
 export type LunchFlowSetupIntroValues = {
   name: string;
   apiURL: string;
@@ -27,7 +28,7 @@ export type LunchFlowSetupIntroValues = {
 export default function LunchFlowSetupIntro(): React.JSX.Element {
   const { data: config } = useAppConfiguration();
   const { enqueueSnackbar } = useSnackbar();
-  const navigate = useNavigate();
+  const [pathname, navigate] = useLocation();
 
   const allowedAPIURLs = config.lunchFlowAllowedAPIURLs ?? [];
   const initialApiURL = allowedAPIURLs.length > 0 ? allowedAPIURLs[0] : '';
@@ -54,11 +55,7 @@ export default function LunchFlowSetupIntro(): React.JSX.Element {
         },
       })
         .then(result => new LunchFlowLink(result?.data))
-        .then(lunchFlowLink =>
-          navigate(lunchFlowLink.lunchFlowLinkId, {
-            relative: 'path',
-          }),
-        )
+        .then(lunchFlowLink => navigate(`${pathname}/${lunchFlowLink.lunchFlowLinkId}`))
         .catch((error: ApiError<APIError>) =>
           enqueueSnackbar(
             <div>
@@ -77,7 +74,7 @@ export default function LunchFlowSetupIntro(): React.JSX.Element {
         )
         .finally(() => helpers.setSubmitting(false));
     },
-    [navigate, enqueueSnackbar],
+    [navigate, pathname, enqueueSnackbar],
   );
 
   return (

--- a/interface/src/components/setup/lunchflow/LunchFlowSetupIntro.tsx
+++ b/interface/src/components/setup/lunchflow/LunchFlowSetupIntro.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import type { FormikHelpers } from 'formik';
 import { useFormikContext } from 'formik';
+import { useLocation } from 'wouter';
 
 import type { ApiError } from '@monetr/interface/api/client';
 import { flexVariants } from '@monetr/interface/components/Flex';
@@ -16,8 +17,6 @@ import { useAppConfiguration } from '@monetr/interface/hooks/useAppConfiguration
 import LunchFlowLink from '@monetr/interface/models/LunchFlowLink';
 import request, { type APIError } from '@monetr/interface/util/request';
 import { useSnackbar } from '@monetr/notify';
-
-import { useLocation } from 'wouter';
 
 export type LunchFlowSetupIntroValues = {
   name: string;

--- a/interface/src/components/setup/lunchflow/LunchFlowSetupSync.tsx
+++ b/interface/src/components/setup/lunchflow/LunchFlowSetupSync.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useLocation, useParams } from 'wouter';
 
 import { Button } from '@monetr/interface/components/Button';
 import { flexVariants } from '@monetr/interface/components/Flex';
@@ -8,8 +9,6 @@ import LunchFlowSetupSyncItem from '@monetr/interface/components/setup/lunchflow
 import Typography from '@monetr/interface/components/Typography';
 import { useBankAccountsForLink } from '@monetr/interface/hooks/useBankAccountsForLink';
 import request from '@monetr/interface/util/request';
-
-import { useLocation, useParams } from 'wouter';
 
 export default function LunchFlowSetupSync(): React.JSX.Element {
   const [, navigate] = useLocation();

--- a/interface/src/components/setup/lunchflow/LunchFlowSetupSync.tsx
+++ b/interface/src/components/setup/lunchflow/LunchFlowSetupSync.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
 
 import { Button } from '@monetr/interface/components/Button';
 import { flexVariants } from '@monetr/interface/components/Flex';
@@ -10,9 +9,11 @@ import Typography from '@monetr/interface/components/Typography';
 import { useBankAccountsForLink } from '@monetr/interface/hooks/useBankAccountsForLink';
 import request from '@monetr/interface/util/request';
 
+import { useLocation, useParams } from 'wouter';
+
 export default function LunchFlowSetupSync(): React.JSX.Element {
-  const navigate = useNavigate();
-  const { linkId } = useParams();
+  const [, navigate] = useLocation();
+  const { linkId } = useParams<{ linkId: string }>();
   const { data: bankAccounts } = useBankAccountsForLink(linkId);
 
   // As soon as this page loads immediately trigger the lunch flow sync

--- a/interface/src/components/setup/manual/ManualLinkSetupIncome.tsx
+++ b/interface/src/components/setup/manual/ManualLinkSetupIncome.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'react';
 import { startOfDay, startOfTomorrow } from 'date-fns';
 import type { FormikHelpers } from 'formik';
+import { useLocation } from 'wouter';
 
 import { flexVariants } from '@monetr/interface/components/Flex';
 import FormAmountField from '@monetr/interface/components/FormAmountField';
@@ -18,8 +19,6 @@ import { useCreateLink } from '@monetr/interface/hooks/useCreateLink';
 import useLocaleCurrency from '@monetr/interface/hooks/useLocaleCurrency';
 import useTimezone from '@monetr/interface/hooks/useTimezone';
 import { BankAccountSubType, BankAccountType } from '@monetr/interface/models/BankAccount';
-
-import { useLocation } from 'wouter';
 
 export type ManualLinkSetupIncomeValues = {
   nextPayday: Date;

--- a/interface/src/components/setup/manual/ManualLinkSetupIncome.tsx
+++ b/interface/src/components/setup/manual/ManualLinkSetupIncome.tsx
@@ -1,7 +1,6 @@
 import { Fragment } from 'react';
 import { startOfDay, startOfTomorrow } from 'date-fns';
 import type { FormikHelpers } from 'formik';
-import { useNavigate } from 'react-router-dom';
 
 import { flexVariants } from '@monetr/interface/components/Flex';
 import FormAmountField from '@monetr/interface/components/FormAmountField';
@@ -20,6 +19,8 @@ import useLocaleCurrency from '@monetr/interface/hooks/useLocaleCurrency';
 import useTimezone from '@monetr/interface/hooks/useTimezone';
 import { BankAccountSubType, BankAccountType } from '@monetr/interface/models/BankAccount';
 
+import { useLocation } from 'wouter';
+
 export type ManualLinkSetupIncomeValues = {
   nextPayday: Date;
   ruleset: string;
@@ -32,7 +33,7 @@ export default function ManualLinkSetupIncome(): JSX.Element {
   const createLink = useCreateLink();
   const createBankAccount = useCreateBankAccount();
   const createFundingSchedule = useCreateFundingSchedule();
-  const navigate = useNavigate();
+  const [, navigate] = useLocation();
   const viewContext = useViewContext<ManualLinkSetupSteps, unknown, ManualLinkSetupForm>();
   const { data: locale } = useLocaleCurrency(viewContext.formData.currency);
   const initialValues: ManualLinkSetupIncomeValues = {

--- a/interface/src/components/transactions/RemoveTransactionButton.tsx
+++ b/interface/src/components/transactions/RemoveTransactionButton.tsx
@@ -1,11 +1,12 @@
 import { useCallback } from 'react';
 import { Trash } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
 
 import { Button } from '@monetr/interface/components/Button';
 import { useCurrentLink } from '@monetr/interface/hooks/useCurrentLink';
 import { showRemoveTransactionModal } from '@monetr/interface/modals/RemoveTransactionModal';
 import type Transaction from '@monetr/interface/models/Transaction';
+
+import { useLocation } from 'wouter';
 
 interface RemoveTransactionButtonProps {
   transaction: Transaction;
@@ -14,7 +15,7 @@ interface RemoveTransactionButtonProps {
 export default function RemoveTransactionButton(props: RemoveTransactionButtonProps): JSX.Element {
   const { transaction } = props;
   const { data: link } = useCurrentLink();
-  const navigate = useNavigate();
+  const [, navigate] = useLocation();
 
   const promptRemoveTransaction = useCallback(async () => {
     return await showRemoveTransactionModal({

--- a/interface/src/components/transactions/RemoveTransactionButton.tsx
+++ b/interface/src/components/transactions/RemoveTransactionButton.tsx
@@ -1,12 +1,11 @@
 import { useCallback } from 'react';
 import { Trash } from 'lucide-react';
+import { useLocation } from 'wouter';
 
 import { Button } from '@monetr/interface/components/Button';
 import { useCurrentLink } from '@monetr/interface/hooks/useCurrentLink';
 import { showRemoveTransactionModal } from '@monetr/interface/modals/RemoveTransactionModal';
 import type Transaction from '@monetr/interface/models/Transaction';
-
-import { useLocation } from 'wouter';
 
 interface RemoveTransactionButtonProps {
   transaction: Transaction;

--- a/interface/src/components/transactions/SimilarTransactionItem.tsx
+++ b/interface/src/components/transactions/SimilarTransactionItem.tsx
@@ -1,5 +1,4 @@
 import { ChevronRight } from 'lucide-react';
-import { Link } from 'react-router-dom';
 
 import { flexVariants } from '@monetr/interface/components/Flex';
 import { Item, ItemContent } from '@monetr/interface/components/Item';
@@ -10,6 +9,8 @@ import { useLocale } from '@monetr/interface/hooks/useLocale';
 import useTimezone from '@monetr/interface/hooks/useTimezone';
 import { useTransaction } from '@monetr/interface/hooks/useTransaction';
 import { DateLength, formatDate } from '@monetr/interface/util/formatDate';
+
+import { Link } from 'wouter';
 
 export interface SimilarTransactionItemProps {
   transactionId: string;

--- a/interface/src/components/transactions/SimilarTransactionItem.tsx
+++ b/interface/src/components/transactions/SimilarTransactionItem.tsx
@@ -1,4 +1,5 @@
 import { ChevronRight } from 'lucide-react';
+import { Link } from 'wouter';
 
 import { flexVariants } from '@monetr/interface/components/Flex';
 import { Item, ItemContent } from '@monetr/interface/components/Item';
@@ -9,8 +10,6 @@ import { useLocale } from '@monetr/interface/hooks/useLocale';
 import useTimezone from '@monetr/interface/hooks/useTimezone';
 import { useTransaction } from '@monetr/interface/hooks/useTransaction';
 import { DateLength, formatDate } from '@monetr/interface/util/formatDate';
-
-import { Link } from 'wouter';
 
 export interface SimilarTransactionItemProps {
   transactionId: string;

--- a/interface/src/components/transactions/TransactionItem.tsx
+++ b/interface/src/components/transactions/TransactionItem.tsx
@@ -1,4 +1,5 @@
 import { ChevronRight } from 'lucide-react';
+import { Link } from 'wouter';
 
 import Flex from '@monetr/interface/components/Flex';
 import Typography from '@monetr/interface/components/Typography';
@@ -11,8 +12,6 @@ import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 
 import itemStyles from './TransactionItem.module.scss';
 import selectSpendingStyles from './TransactionItemSelectSpending.module.scss';
-
-import { Link } from 'wouter';
 
 export interface TransactionItemProps {
   transaction: Transaction;

--- a/interface/src/components/transactions/TransactionItem.tsx
+++ b/interface/src/components/transactions/TransactionItem.tsx
@@ -1,5 +1,4 @@
 import { ChevronRight } from 'lucide-react';
-import { Link } from 'react-router-dom';
 
 import Flex from '@monetr/interface/components/Flex';
 import Typography from '@monetr/interface/components/Typography';
@@ -12,6 +11,8 @@ import mergeTailwind from '@monetr/interface/util/mergeTailwind';
 
 import itemStyles from './TransactionItem.module.scss';
 import selectSpendingStyles from './TransactionItemSelectSpending.module.scss';
+
+import { Link } from 'wouter';
 
 export interface TransactionItemProps {
   transaction: Transaction;

--- a/interface/src/hooks/useLogin.spec.ts
+++ b/interface/src/hooks/useLogin.spec.ts
@@ -1,11 +1,10 @@
 import { act } from 'react';
 import { rs } from '@rstest/core';
+import * as wouterActual from 'wouter' with { rstest: 'importActual' };
 
 import useLogin from '@monetr/interface/hooks/useLogin';
 import FetchMock from '@monetr/interface/testutils/fetchMock';
 import testRenderHook from '@monetr/interface/testutils/hooks';
-
-import * as wouterActual from 'wouter' with { rstest: 'importActual' };
 
 const mockNavigate = rs.fn((_url: string) => {});
 rs.mock('wouter', () => ({

--- a/interface/src/hooks/useLogin.spec.ts
+++ b/interface/src/hooks/useLogin.spec.ts
@@ -1,15 +1,16 @@
 import { act } from 'react';
 import { rs } from '@rstest/core';
-import * as reactRouterDomActual from 'react-router-dom' with { rstest: 'importActual' };
 
 import useLogin from '@monetr/interface/hooks/useLogin';
 import FetchMock from '@monetr/interface/testutils/fetchMock';
 import testRenderHook from '@monetr/interface/testutils/hooks';
 
-const mockUseNavigate = rs.fn((_url: string) => {});
-rs.mock('react-router-dom', () => ({
-  ...reactRouterDomActual,
-  useNavigate: () => mockUseNavigate,
+import * as wouterActual from 'wouter' with { rstest: 'importActual' };
+
+const mockNavigate = rs.fn((_url: string) => {});
+rs.mock('wouter', () => ({
+  ...wouterActual,
+  useLocation: () => ['/login', mockNavigate],
 }));
 
 describe('login', () => {
@@ -17,7 +18,7 @@ describe('login', () => {
 
   beforeEach(() => {
     mockFetch = new FetchMock();
-    mockUseNavigate.mockReset();
+    mockNavigate.mockReset();
   });
   afterEach(() => {
     mockFetch.reset();
@@ -44,7 +45,7 @@ describe('login', () => {
     });
 
     // Make sure we end up navigating to the url returned by the login endpoint.
-    expect(mockUseNavigate).toHaveBeenCalledWith('/account/subscribe');
+    expect(mockNavigate).toHaveBeenCalledWith('/account/subscribe');
   });
 
   it('will navigate without a next url', async () => {
@@ -64,7 +65,7 @@ describe('login', () => {
     });
 
     // When the login endpoint does not return a next url, navigate to an index route.
-    expect(mockUseNavigate).toHaveBeenCalledWith('/');
+    expect(mockNavigate).toHaveBeenCalledWith('/');
   });
 
   it('will require a password reset', async () => {
@@ -86,12 +87,7 @@ describe('login', () => {
 
     // When the login endpoint returns a password change required error; then make sure we navigate to the password
     // reset page.
-    expect(mockUseNavigate).toHaveBeenCalledWith('/password/reset', {
-      state: {
-        message: 'You are required to change your password before authenticating.',
-        token: 'abc123',
-      },
-    });
+    expect(mockNavigate).toHaveBeenCalledWith('/password/reset?token=abc123&reason=password_change_required');
   });
 
   it('email has not been verified', async () => {
@@ -111,10 +107,6 @@ describe('login', () => {
     });
 
     // When our email is not verified, make sure we navigate to the resend page.
-    expect(mockUseNavigate).toHaveBeenCalledWith('/verify/email/resend', {
-      state: {
-        emailAddress: 'test@test.com',
-      },
-    });
+    expect(mockNavigate).toHaveBeenCalledWith('/verify/email/resend?email=test%40test.com');
   });
 });

--- a/interface/src/hooks/useLogin.ts
+++ b/interface/src/hooks/useLogin.ts
@@ -1,8 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
+import { useLocation } from 'wouter';
 
 import request from '@monetr/interface/util/request';
-
-import { useLocation } from 'wouter';
 
 export interface LoginArguments {
   email: string;

--- a/interface/src/hooks/useLogin.ts
+++ b/interface/src/hooks/useLogin.ts
@@ -1,7 +1,8 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
 
 import request from '@monetr/interface/util/request';
+
+import { useLocation } from 'wouter';
 
 export interface LoginArguments {
   email: string;
@@ -11,7 +12,7 @@ export interface LoginArguments {
 }
 
 export default function useLogin(): (loginArgs: LoginArguments) => Promise<void> {
-  const navigate = useNavigate();
+  const [, navigate] = useLocation();
   const queryClient = useQueryClient();
 
   return async (loginArgs: LoginArguments): Promise<void> => {
@@ -32,12 +33,9 @@ export default function useLogin(): (loginArgs: LoginArguments) => Promise<void>
           case 428: // The user needs to take some action before they can be fully authenticated.
             switch (error?.response?.data?.code) {
               case 'PASSWORD_CHANGE_REQUIRED':
-                return navigate('/password/reset', {
-                  state: {
-                    message: 'You are required to change your password before authenticating.',
-                    token: error?.response?.data?.resetToken,
-                  },
-                });
+                return navigate(
+                  `/password/reset?token=${encodeURIComponent(error?.response?.data?.resetToken)}&reason=password_change_required`,
+                );
               case 'MFA_REQUIRED':
                 // If we are required to provide multifactor authentication then we should be able to retrieve our user
                 // details at least.
@@ -45,11 +43,7 @@ export default function useLogin(): (loginArgs: LoginArguments) => Promise<void>
                   .invalidateQueries({ queryKey: ['/api/users/me'] })
                   .then(() => navigate('/login/multifactor'));
               case 'EMAIL_NOT_VERIFIED':
-                return navigate('/verify/email/resend', {
-                  state: {
-                    emailAddress: loginArgs.email,
-                  },
-                });
+                return navigate(`/verify/email/resend?email=${encodeURIComponent(loginArgs.email)}`);
               default:
                 throw error;
             }

--- a/interface/src/hooks/useResetPassword.ts
+++ b/interface/src/hooks/useResetPassword.ts
@@ -1,8 +1,8 @@
+import { useLocation } from 'wouter';
+
 import type { ApiError } from '@monetr/interface/api/client';
 import request, { type APIError } from '@monetr/interface/util/request';
 import { useSnackbar } from '@monetr/notify';
-
-import { useLocation } from 'wouter';
 
 export default function useResetPassword(): (newPassword: string, token: string) => Promise<void> {
   const { enqueueSnackbar } = useSnackbar();

--- a/interface/src/hooks/useResetPassword.ts
+++ b/interface/src/hooks/useResetPassword.ts
@@ -1,12 +1,12 @@
-import { useNavigate } from 'react-router-dom';
-
 import type { ApiError } from '@monetr/interface/api/client';
 import request, { type APIError } from '@monetr/interface/util/request';
 import { useSnackbar } from '@monetr/notify';
 
+import { useLocation } from 'wouter';
+
 export default function useResetPassword(): (newPassword: string, token: string) => Promise<void> {
   const { enqueueSnackbar } = useSnackbar();
-  const navigate = useNavigate();
+  const [, navigate] = useLocation();
   return async (newPassword: string, token: string) => {
     return request({
       method: 'POST',

--- a/interface/src/hooks/useSelectedBankAccountId.ts
+++ b/interface/src/hooks/useSelectedBankAccountId.ts
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
-import { useMatch } from 'react-router-dom';
+import { useRoute } from 'wouter';
 
 export function useSelectedBankAccountId(): string | undefined {
-  const match = useMatch('/bank/:bankId/*');
+  const [, params] = useRoute<{ bankId: string }>('/bank/:bankId/*');
   return useMemo(() => {
-    return match?.params?.bankId || undefined;
-  }, [match]);
+    return params?.bankId || undefined;
+  }, [params]);
 }

--- a/interface/src/index.tsx
+++ b/interface/src/index.tsx
@@ -1,8 +1,6 @@
 import '@fontsource-variable/inter';
 
-import React from 'react';
-import { init, reactRouterV6BrowserTracingIntegration, showReportDialog } from '@sentry/react';
-import { createRoutesFromChildren, matchRoutes, useLocation, useNavigationType } from 'react-router-dom';
+import { browserTracingIntegration, init, showReportDialog } from '@sentry/react';
 
 import Root from '@monetr/interface/Root';
 import { makeSneakyFetchTransport } from '@monetr/interface/relay/transport';
@@ -19,15 +17,7 @@ if (window?.__MONETR__?.SENTRY_DSN) {
   init({
     dsn: window?.__MONETR__?.SENTRY_DSN,
     transport: makeSneakyFetchTransport,
-    integrations: [
-      reactRouterV6BrowserTracingIntegration({
-        useEffect: React.useEffect,
-        useLocation,
-        useNavigationType,
-        createRoutesFromChildren,
-        matchRoutes,
-      }),
-    ],
+    integrations: [browserTracingIntegration()],
     release: RELEASE,
     // We recommend adjusting this value in production, or using tracesSampler
     // for finer control

--- a/interface/src/modals/NewBankAccountModal.spec.tsx
+++ b/interface/src/modals/NewBankAccountModal.spec.tsx
@@ -1,5 +1,6 @@
 import { act } from 'react';
 import { rs } from '@rstest/core';
+import * as wouterActual from 'wouter' with { rstest: 'importActual' };
 
 import { waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -7,8 +8,6 @@ import userEvent from '@testing-library/user-event';
 import { showNewBankAccountModal } from '@monetr/interface/modals/NewBankAccountModal';
 import FetchMock from '@monetr/interface/testutils/fetchMock';
 import testRenderer from '@monetr/interface/testutils/renderer';
-
-import * as wouterActual from 'wouter' with { rstest: 'importActual' };
 
 const mockNavigate = rs.fn((_url: string) => {});
 rs.mock('wouter', () => ({

--- a/interface/src/modals/NewBankAccountModal.spec.tsx
+++ b/interface/src/modals/NewBankAccountModal.spec.tsx
@@ -1,6 +1,5 @@
 import { act } from 'react';
 import { rs } from '@rstest/core';
-import * as reactRouterDomActual from 'react-router-dom' with { rstest: 'importActual' };
 
 import { waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -9,10 +8,12 @@ import { showNewBankAccountModal } from '@monetr/interface/modals/NewBankAccount
 import FetchMock from '@monetr/interface/testutils/fetchMock';
 import testRenderer from '@monetr/interface/testutils/renderer';
 
-const mockUseNavigate = rs.fn((_url: string) => {});
-rs.mock('react-router-dom', () => ({
-  ...reactRouterDomActual,
-  useNavigate: () => mockUseNavigate,
+import * as wouterActual from 'wouter' with { rstest: 'importActual' };
+
+const mockNavigate = rs.fn((_url: string) => {});
+rs.mock('wouter', () => ({
+  ...wouterActual,
+  useLocation: () => ['/login', mockNavigate],
 }));
 
 describe('new bank account modal', () => {
@@ -20,7 +21,7 @@ describe('new bank account modal', () => {
 
   beforeEach(() => {
     mockFetch = new FetchMock();
-    mockUseNavigate.mockReset();
+    mockNavigate.mockReset();
   });
   afterEach(() => {
     mockFetch.reset();
@@ -168,7 +169,7 @@ describe('new bank account modal', () => {
     await act(() => userEvent.click(world.getByTestId('bank-account-submit')));
 
     // When we submit it we should get redirected to our new bank account.
-    await waitFor(() => expect(mockUseNavigate).toHaveBeenCalledWith('/bank/bac_created/transactions'));
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/bank/bac_created/transactions'));
 
     // Make sure the modal was also closed.
     await waitFor(() => expect(world.queryByTestId('new-bank-account-modal')).not.toBeInTheDocument());
@@ -251,7 +252,7 @@ describe('new bank account modal', () => {
     await act(() => userEvent.click(world.getByTestId('bank-account-submit')));
 
     // When we submit it we should get redirected to our new bank account.
-    await waitFor(() => expect(mockUseNavigate).toHaveBeenCalledWith('/bank/bac_created/transactions'));
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/bank/bac_created/transactions'));
 
     // Make sure the modal was also closed.
     await waitFor(() => expect(world.queryByTestId('new-bank-account-modal')).not.toBeInTheDocument());

--- a/interface/src/modals/NewBankAccountModal.tsx
+++ b/interface/src/modals/NewBankAccountModal.tsx
@@ -1,7 +1,6 @@
 import { Fragment, useRef } from 'react';
 import NiceModal, { useModal } from '@ebay/nice-modal-react';
 import type { FormikHelpers } from 'formik';
-import { useNavigate } from 'react-router-dom';
 
 import type { ApiError } from '@monetr/interface/api/client';
 import { Button } from '@monetr/interface/components/Button';
@@ -22,6 +21,8 @@ import type { APIError } from '@monetr/interface/util/request';
 import type { ExtractProps } from '@monetr/interface/util/typescriptEvils';
 import { useSnackbar } from '@monetr/notify';
 
+import { useLocation } from 'wouter';
+
 interface NewBankAccountValues {
   name: string;
   balance: number;
@@ -34,7 +35,7 @@ function NewBankAccountModal(): JSX.Element {
   const { enqueueSnackbar } = useSnackbar();
   const { data: selectedBankAccount, isLoading } = useSelectedBankAccount();
   const createBankAccount = useCreateBankAccount();
-  const navigate = useNavigate();
+  const [, navigate] = useLocation();
   const ref = useRef<MModalRef>(null);
 
   if (isLoading || !selectedBankAccount) {

--- a/interface/src/modals/NewBankAccountModal.tsx
+++ b/interface/src/modals/NewBankAccountModal.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useRef } from 'react';
 import NiceModal, { useModal } from '@ebay/nice-modal-react';
 import type { FormikHelpers } from 'formik';
+import { useLocation } from 'wouter';
 
 import type { ApiError } from '@monetr/interface/api/client';
 import { Button } from '@monetr/interface/components/Button';
@@ -20,8 +21,6 @@ import { BankAccountSubType, BankAccountType } from '@monetr/interface/models/Ba
 import type { APIError } from '@monetr/interface/util/request';
 import type { ExtractProps } from '@monetr/interface/util/typescriptEvils';
 import { useSnackbar } from '@monetr/notify';
-
-import { useLocation } from 'wouter';
 
 interface NewBankAccountValues {
   name: string;

--- a/interface/src/modals/RemoveLinkModal.tsx
+++ b/interface/src/modals/RemoveLinkModal.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import NiceModal, { useModal } from '@ebay/nice-modal-react';
 import { Trash } from 'lucide-react';
+import { useLocation } from 'wouter';
 
 import { Button } from '@monetr/interface/components/Button';
 import MModal, { type MModalRef } from '@monetr/interface/components/MModal';
@@ -9,8 +10,6 @@ import { useRemoveLink } from '@monetr/interface/hooks/useRemoveLink';
 import type Link from '@monetr/interface/models/Link';
 import type { ExtractProps } from '@monetr/interface/util/typescriptEvils';
 import { useSnackbar } from '@monetr/notify';
-
-import { useLocation } from 'wouter';
 
 export interface RemoveLinkModalProps {
   link: Link;

--- a/interface/src/modals/RemoveLinkModal.tsx
+++ b/interface/src/modals/RemoveLinkModal.tsx
@@ -1,7 +1,6 @@
 import { useRef, useState } from 'react';
 import NiceModal, { useModal } from '@ebay/nice-modal-react';
 import { Trash } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
 
 import { Button } from '@monetr/interface/components/Button';
 import MModal, { type MModalRef } from '@monetr/interface/components/MModal';
@@ -10,6 +9,8 @@ import { useRemoveLink } from '@monetr/interface/hooks/useRemoveLink';
 import type Link from '@monetr/interface/models/Link';
 import type { ExtractProps } from '@monetr/interface/util/typescriptEvils';
 import { useSnackbar } from '@monetr/notify';
+
+import { useLocation } from 'wouter';
 
 export interface RemoveLinkModalProps {
   link: Link;
@@ -21,7 +22,7 @@ function RemoveLinkModal(props: RemoveLinkModalProps): JSX.Element {
   const { enqueueSnackbar } = useSnackbar();
   const [submitting, setSubmitting] = useState(false);
   const removeLink = useRemoveLink();
-  const navigate = useNavigate();
+  const [, navigate] = useLocation();
 
   async function submit() {
     setSubmitting(true);

--- a/interface/src/monetr.tsx
+++ b/interface/src/monetr.tsx
@@ -1,6 +1,3 @@
-import { withSentryReactRouterV6Routing } from '@sentry/react';
-import { Navigate, Route, Routes } from 'react-router-dom';
-
 import BudgetingLayout from '@monetr/interface/components/Layout/BudgetLayout';
 import MobileSidebarContextProvider from '@monetr/interface/components/Layout/MobileSidebarContextProvider';
 import SettingsLayout from '@monetr/interface/components/Layout/SettingsLayout';
@@ -48,7 +45,7 @@ import VerifyEmail from '@monetr/interface/pages/verify/email';
 import ResendVerificationPage from '@monetr/interface/pages/verify/email/resend';
 import sortAccounts from '@monetr/interface/util/sortAccounts';
 
-const RoutesImpl = withSentryReactRouterV6Routing(Routes);
+import { Redirect, Route, Switch } from 'wouter';
 
 export default function Monetr(): JSX.Element {
   const { data: config, isLoading: configIsLoading, isError: configIsError } = useAppConfiguration();
@@ -75,103 +72,150 @@ export default function Monetr(): JSX.Element {
 
   if (!isAuthenticated) {
     return (
-      <RoutesImpl>
-        <Route element={<Login />} path='/login' />
-        <Route element={<LogoutPage />} path='/logout' />
-        {config?.allowSignUp && <Route element={<Register />} path='/register' />}
-        {config?.allowForgotPassword && <Route element={<ForgotPassword />} path='/password/forgot' />}
-        <Route element={<PasswordReset />} path='/password/reset' />
-        <Route element={<VerifyEmail />} path='/verify/email' />
-        <Route element={<ResendVerificationPage />} path='/verify/email/resend' />
-        <Route element={<Navigate replace to='/login' />} path='/' />
-        <Route element={<Navigate replace to='/login' />} path='*' />
-      </RoutesImpl>
+      <Switch>
+        <Route component={Login} path='/login' />
+        <Route component={LogoutPage} path='/logout' />
+        {config?.allowSignUp && <Route component={Register} path='/register' />}
+        {config?.allowForgotPassword && <Route component={ForgotPassword} path='/password/forgot' />}
+        <Route component={PasswordReset} path='/password/reset' />
+        <Route component={VerifyEmail} path='/verify/email' />
+        <Route component={ResendVerificationPage} path='/verify/email/resend' />
+        <Route path='/'>
+          <Redirect replace to='/login' />
+        </Route>
+        <Route path='*'>
+          <Redirect replace to='/login' />
+        </Route>
+      </Switch>
     );
   }
 
   // If the currently authenticated user requires MFA then only allow them to access the MFA pages.
   if (auth?.mfaPending) {
     return (
-      <RoutesImpl>
-        <Route element={<MultifactorAuthenticationPage />} path='/login/multifactor' />
-        <Route element={<LogoutPage />} path='/logout' />
-        <Route element={<Navigate replace to='/login/multifactor' />} path='*' />
-      </RoutesImpl>
+      <Switch>
+        <Route component={MultifactorAuthenticationPage} path='/login/multifactor' />
+        <Route component={LogoutPage} path='/logout' />
+        <Route path='*'>
+          <Redirect replace to='/login/multifactor' />
+        </Route>
+      </Switch>
     );
   }
 
   if (!auth?.isActive) {
     return (
-      <RoutesImpl>
-        <Route element={<LogoutPage />} path='/logout' />
-        <Route element={<SubscribePage />} path='/account/subscribe' />
-        <Route element={<AfterCheckoutPage />} path='/account/subscribe/after' />
-        <Route element={<Navigate replace to='/account/subscribe' />} path='*' />
-      </RoutesImpl>
+      <Switch>
+        <Route component={LogoutPage} path='/logout' />
+        <Route component={SubscribePage} path='/account/subscribe' />
+        <Route component={AfterCheckoutPage} path='/account/subscribe/after' />
+        <Route path='*'>
+          <Redirect replace to='/account/subscribe' />
+        </Route>
+      </Switch>
     );
   }
 
   const hasAnyLinks = links?.length > 0;
   if (!hasAnyLinks) {
     return (
-      <RoutesImpl>
-        <Route element={<LogoutPage />} path='/logout' />
-        <Route element={<SetupPage manualEnabled={config?.manualEnabled} />} path='/setup' />
-        <Route element={<PlaidSetup alreadyOnboarded />} path='/setup/plaid' />
-        <Route element={<SetupManualLinkPage />} path='/setup/manual' />
-        <Route element={<LunchFlowSetupIntro />} path='/setup/lunchflow' />
-        <Route element={<LunchFlowSetupAccounts />} path='/setup/lunchflow/:lunchFlowLinkId' />
-        <Route element={<OauthReturn />} path='/plaid/oauth-return' />
-        <Route element={<Navigate replace to='/setup' />} path='/account/subscribe/after' />
-        <Route element={<Navigate replace to='/setup' />} index path='*' />
-      </RoutesImpl>
+      <Switch>
+        <Route component={LogoutPage} path='/logout' />
+        <Route path='/setup'>{() => <SetupPage manualEnabled={config?.manualEnabled} />}</Route>
+        <Route path='/setup/plaid'>{() => <PlaidSetup alreadyOnboarded />}</Route>
+        <Route component={SetupManualLinkPage} path='/setup/manual' />
+        <Route component={LunchFlowSetupIntro} path='/setup/lunchflow' />
+        <Route component={LunchFlowSetupAccounts} path='/setup/lunchflow/:lunchFlowLinkId' />
+        <Route component={OauthReturn} path='/plaid/oauth-return' />
+        <Route path='/account/subscribe/after'>
+          <Redirect replace to='/setup' />
+        </Route>
+        <Route path='*'>
+          <Redirect replace to='/setup' />
+        </Route>
+      </Switch>
     );
   }
 
   return (
     <MobileSidebarContextProvider>
       <Sidebar />
-      <RoutesImpl>
-        <Route element={<BudgetingLayout />} path='/bank/:bankAccountId'>
-          <Route element={<BankAccountSettingsPage />} path='settings' />
-          <Route element={<Transactions />} path='transactions' />
-          <Route element={<TransactionDetails />} path='transactions/:transactionId/details' />
-          <Route element={<Expenses />} path='expenses' />
-          <Route element={<ExpenseDetails />} path='expenses/:spendingId/details' />
-          <Route element={<Goals />} path='goals' />
-          <Route element={<GoalDetails />} path='goals/:spendingId/details' />
-          <Route element={<Funding />} path='funding' />
-          <Route element={<FundingDetails />} path='funding/:fundingId/details' />
+      <Switch>
+        <Route path='/bank/:bankAccountId/*'>
+          <BudgetingLayout>
+            <Switch>
+              <Route component={BankAccountSettingsPage} path='/bank/:bankAccountId/settings' />
+              <Route component={Transactions} path='/bank/:bankAccountId/transactions' />
+              <Route component={TransactionDetails} path='/bank/:bankAccountId/transactions/:transactionId/details' />
+              <Route component={Expenses} path='/bank/:bankAccountId/expenses' />
+              <Route component={ExpenseDetails} path='/bank/:bankAccountId/expenses/:spendingId/details' />
+              <Route component={Goals} path='/bank/:bankAccountId/goals' />
+              <Route component={GoalDetails} path='/bank/:bankAccountId/goals/:spendingId/details' />
+              <Route component={Funding} path='/bank/:bankAccountId/funding' />
+              <Route component={FundingDetails} path='/bank/:bankAccountId/funding/:fundingId/details' />
+              <Route path='*'>
+                <Redirect replace to='/' />
+              </Route>
+            </Switch>
+          </BudgetingLayout>
         </Route>
-        <Route element={<SidebarPaddingLayout />}>
-          <Route element={<SettingsLayout />} path='/settings'>
-            <Route element={<Navigate replace to='/settings/overview' />} path='' />
-            <Route element={<SettingsOverview />} path='overview' />
-            <Route element={<SettingsSecurity />} path='security' />
-            {config?.billingEnabled && <Route element={<SettingsBilling />} path='billing' />}
-            <Route element={<SettingsAbout />} path='about' />
-          </Route>
-          <Route element={<LinkDetails />} path='/link/:linkId/details' />
-          <Route element={<LinkCreatePage />} path='/link/create' />
-          <Route element={<PlaidSetup alreadyOnboarded />} path='/link/create/plaid' />
-          <Route element={<CreateManualLinkPage />} path='/link/create/manual' />
-          <Route element={<LunchFlowSetupIntro />} path='/link/create/lunchflow' />
-          <Route element={<LunchFlowSetupAccounts />} path='/link/create/lunchflow/:lunchFlowLinkId' />
-          <Route element={<LunchFlowSetupSync />} path='/link/create/lunchflow/:linkId/sync' />
-          <Route element={<LogoutPage />} path='/logout' />
-          <Route element={<OauthReturn />} path='/plaid/oauth-return' />
-          <Route element={<SubscriptionPage />} path='/subscription' />
-          <Route element={<Navigate replace to='/' />} path='/account/subscribe' />
-          <Route element={<AfterCheckoutPage />} path='/account/subscribe/after' />
-          <Route element={<LunchFlowSetupAccounts />} path='/setup/lunchflow/:lunchFlowLinkId' />
+        <Route path='/setup'>
+          <Redirect replace to='/' />
         </Route>
-        <Route element={<Navigate replace to='/' />} path='/setup' />
-        <Route element={<Navigate replace to='/' />} path='/password/reset' />
-        <Route element={<Navigate replace to='/' />} path='/register' />
-        <Route element={<Navigate replace to='/' />} path='/login' />
-        <Route element={<Navigate replace to='/' />} path='/login/multifactor' />
-        <Route element={<RedirectToBank />} index path='/' />
-      </RoutesImpl>
+        <Route path='/password/reset'>
+          <Redirect replace to='/' />
+        </Route>
+        <Route path='/register'>
+          <Redirect replace to='/' />
+        </Route>
+        <Route path='/login/multifactor'>
+          <Redirect replace to='/' />
+        </Route>
+        <Route path='/login'>
+          <Redirect replace to='/' />
+        </Route>
+        <Route component={RedirectToBank} path='/' />
+        <Route path='*'>
+          <SidebarPaddingLayout>
+            <Switch>
+              <Route path='/settings'>
+                <Redirect replace to='/settings/overview' />
+              </Route>
+              <Route path='/settings/:rest*'>
+                <SettingsLayout>
+                  <Switch>
+                    <Route component={SettingsOverview} path='/settings/overview' />
+                    <Route component={SettingsSecurity} path='/settings/security' />
+                    {config?.billingEnabled && <Route component={SettingsBilling} path='/settings/billing' />}
+                    <Route component={SettingsAbout} path='/settings/about' />
+                    <Route path='*'>
+                      <Redirect replace to='/settings/overview' />
+                    </Route>
+                  </Switch>
+                </SettingsLayout>
+              </Route>
+              <Route component={LinkDetails} path='/link/:linkId/details' />
+              <Route component={LinkCreatePage} path='/link/create' />
+              <Route path='/link/create/plaid'>{() => <PlaidSetup alreadyOnboarded />}</Route>
+              <Route component={CreateManualLinkPage} path='/link/create/manual' />
+              <Route component={LunchFlowSetupIntro} path='/link/create/lunchflow' />
+              <Route component={LunchFlowSetupAccounts} path='/link/create/lunchflow/:lunchFlowLinkId' />
+              <Route component={LunchFlowSetupSync} path='/link/create/lunchflow/:linkId/sync' />
+              <Route component={LogoutPage} path='/logout' />
+              <Route component={OauthReturn} path='/plaid/oauth-return' />
+              <Route component={SubscriptionPage} path='/subscription' />
+              <Route path='/account/subscribe'>
+                <Redirect replace to='/' />
+              </Route>
+              <Route component={AfterCheckoutPage} path='/account/subscribe/after' />
+              <Route component={LunchFlowSetupAccounts} path='/setup/lunchflow/:lunchFlowLinkId' />
+              <Route path='*'>
+                <Redirect replace to='/' />
+              </Route>
+            </Switch>
+          </SidebarPaddingLayout>
+        </Route>
+      </Switch>
     </MobileSidebarContextProvider>
   );
 }
@@ -204,10 +248,10 @@ function RedirectToBank(): JSX.Element {
   const accounts = sortAccounts(Array.from(bankAccounts.values()).filter(account => account.linkId === link.linkId));
 
   if (accounts.length === 0) {
-    return <Navigate replace to='/link/create' />;
+    return <Redirect replace to='/link/create' />;
   }
 
   const account = accounts[0];
 
-  return <Navigate replace to={`/bank/${account.bankAccountId}/transactions`} />;
+  return <Redirect replace to={`/bank/${account.bankAccountId}/transactions`} />;
 }

--- a/interface/src/monetr.tsx
+++ b/interface/src/monetr.tsx
@@ -1,3 +1,5 @@
+import { Redirect, Route, Switch } from 'wouter';
+
 import BudgetingLayout from '@monetr/interface/components/Layout/BudgetLayout';
 import MobileSidebarContextProvider from '@monetr/interface/components/Layout/MobileSidebarContextProvider';
 import SettingsLayout from '@monetr/interface/components/Layout/SettingsLayout';
@@ -44,8 +46,6 @@ import Transactions from '@monetr/interface/pages/transactions';
 import VerifyEmail from '@monetr/interface/pages/verify/email';
 import ResendVerificationPage from '@monetr/interface/pages/verify/email/resend';
 import sortAccounts from '@monetr/interface/util/sortAccounts';
-
-import { Redirect, Route, Switch } from 'wouter';
 
 export default function Monetr(): JSX.Element {
   const { data: config, isLoading: configIsLoading, isError: configIsError } = useAppConfiguration();

--- a/interface/src/pages/account/subscribe/after.tsx
+++ b/interface/src/pages/account/subscribe/after.tsx
@@ -1,14 +1,15 @@
 import { useEffect } from 'react';
 import { LoaderCircle } from 'lucide-react';
-import { useLocation, useNavigate } from 'react-router-dom';
 
 import Logo from '@monetr/interface/assets/Logo';
 import Typography from '@monetr/interface/components/Typography';
 import { useAfterCheckout } from '@monetr/interface/hooks/useAfterCheckout';
 
+import { useLocation, useSearch } from 'wouter';
+
 export default function AfterCheckoutPage(): JSX.Element {
-  const { search } = useLocation();
-  const navigate = useNavigate();
+  const search = useSearch();
+  const [, navigate] = useLocation();
   const afterCheckout = useAfterCheckout();
 
   // As soon as the component mounts, call setup from checkout to get the subscription sorted out.

--- a/interface/src/pages/account/subscribe/after.tsx
+++ b/interface/src/pages/account/subscribe/after.tsx
@@ -1,11 +1,10 @@
 import { useEffect } from 'react';
 import { LoaderCircle } from 'lucide-react';
+import { useLocation, useSearch } from 'wouter';
 
 import Logo from '@monetr/interface/assets/Logo';
 import Typography from '@monetr/interface/components/Typography';
 import { useAfterCheckout } from '@monetr/interface/hooks/useAfterCheckout';
-
-import { useLocation, useSearch } from 'wouter';
 
 export default function AfterCheckoutPage(): JSX.Element {
   const search = useSearch();

--- a/interface/src/pages/bank/settings.tsx
+++ b/interface/src/pages/bank/settings.tsx
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
 import type { FormikHelpers } from 'formik';
 import { Archive, FlaskConical, HeartCrack, Save, Settings } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
 
 import type { ApiError } from '@monetr/interface/api/client';
 import { Button } from '@monetr/interface/components/Button';
@@ -18,6 +17,8 @@ import { useUpdateBankAccount } from '@monetr/interface/hooks/useUpdateBankAccou
 import type { APIError } from '@monetr/interface/util/request';
 import { useSnackbar } from '@monetr/notify';
 
+import { useLocation } from 'wouter';
+
 interface BankAccountValues {
   name: string;
   currency: string;
@@ -29,7 +30,7 @@ export default function BankAccountSettingsPage(): JSX.Element {
   const updateBankAccount = useUpdateBankAccount();
   const archiveBankAccount = useArchiveBankAccount();
   const { enqueueSnackbar } = useSnackbar();
-  const navigate = useNavigate();
+  const [, navigate] = useLocation();
 
   const archive = useCallback(async () => {
     if (!bankAccount) {

--- a/interface/src/pages/bank/settings.tsx
+++ b/interface/src/pages/bank/settings.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import type { FormikHelpers } from 'formik';
 import { Archive, FlaskConical, HeartCrack, Save, Settings } from 'lucide-react';
+import { useLocation } from 'wouter';
 
 import type { ApiError } from '@monetr/interface/api/client';
 import { Button } from '@monetr/interface/components/Button';
@@ -16,8 +17,6 @@ import { useSelectedBankAccount } from '@monetr/interface/hooks/useSelectedBankA
 import { useUpdateBankAccount } from '@monetr/interface/hooks/useUpdateBankAccount';
 import type { APIError } from '@monetr/interface/util/request';
 import { useSnackbar } from '@monetr/notify';
-
-import { useLocation } from 'wouter';
 
 interface BankAccountValues {
   name: string;

--- a/interface/src/pages/expense/details.tsx
+++ b/interface/src/pages/expense/details.tsx
@@ -1,7 +1,6 @@
 import { startOfDay, startOfTomorrow } from 'date-fns';
 import type { FormikHelpers } from 'formik';
 import { ArrowUpDown, HeartCrack, Receipt, Save, Trash } from 'lucide-react';
-import { useNavigate, useParams } from 'react-router-dom';
 
 import type { ApiError } from '@monetr/interface/api/client';
 import { Button } from '@monetr/interface/components/Button';
@@ -32,6 +31,8 @@ import { useSnackbar } from '@monetr/notify';
 
 import ExpenseTimeline from './ExpenseTimeline';
 
+import { useLocation, useParams } from 'wouter';
+
 interface ExpenseValues {
   name: string;
   amount: number;
@@ -46,8 +47,8 @@ export default function ExpenseDetails(): JSX.Element {
   const { data: locale } = useLocaleCurrency();
   const removeSpending = useRemoveSpending();
   const updateSpending = useUpdateSpending();
-  const navigate = useNavigate();
-  const { spendingId } = useParams();
+  const [, navigate] = useLocation();
+  const { spendingId } = useParams<{ spendingId: string }>();
   const { enqueueSnackbar } = useSnackbar();
   const { data: spending, isLoading, isError } = useSpending(spendingId);
   const { data: link } = useCurrentLink();

--- a/interface/src/pages/expense/details.tsx
+++ b/interface/src/pages/expense/details.tsx
@@ -1,6 +1,7 @@
 import { startOfDay, startOfTomorrow } from 'date-fns';
 import type { FormikHelpers } from 'formik';
 import { ArrowUpDown, HeartCrack, Receipt, Save, Trash } from 'lucide-react';
+import { useLocation, useParams } from 'wouter';
 
 import type { ApiError } from '@monetr/interface/api/client';
 import { Button } from '@monetr/interface/components/Button';
@@ -30,8 +31,6 @@ import type { APIError } from '@monetr/interface/util/request';
 import { useSnackbar } from '@monetr/notify';
 
 import ExpenseTimeline from './ExpenseTimeline';
-
-import { useLocation, useParams } from 'wouter';
 
 interface ExpenseValues {
   name: string;

--- a/interface/src/pages/expenses.tsx
+++ b/interface/src/pages/expenses.tsx
@@ -1,6 +1,5 @@
-import { Fragment, useCallback, useEffect, useRef } from 'react';
+import { Fragment } from 'react';
 import { HeartCrack, Plus, Receipt } from 'lucide-react';
-import { useNavigationType } from 'react-router-dom';
 
 import { Button } from '@monetr/interface/components/Button';
 import ExpenseItem from '@monetr/interface/components/expenses/ExpenseItem';
@@ -10,32 +9,8 @@ import { useSpendingFiltered } from '@monetr/interface/hooks/useSpendingFiltered
 import { showNewExpenseModal } from '@monetr/interface/modals/NewExpenseModal';
 import { SpendingType } from '@monetr/interface/models/Spending';
 
-let evilScrollPosition: number = 0;
-
 export default function Expenses(): JSX.Element {
   const { data: expenses, isError, isLoading } = useSpendingFiltered(SpendingType.Expense);
-
-  // Scroll restoration code.
-  const ref = useRef<HTMLDivElement>(null);
-  const navigationType = useNavigationType();
-  const onScroll = useCallback(() => {
-    evilScrollPosition = ref.current.scrollTop;
-  }, []);
-  useEffect(() => {
-    if (!ref.current) {
-      return undefined;
-    }
-
-    if (navigationType === 'POP') {
-      ref.current.scrollTop = evilScrollPosition;
-    }
-    const current = ref.current;
-    ref.current.addEventListener('scroll', onScroll);
-    return () => {
-      current.removeEventListener('scroll', onScroll);
-    };
-    // Fix bug with current impl.
-  }, [navigationType, onScroll]);
 
   if (isLoading) {
     return (
@@ -63,7 +38,7 @@ export default function Expenses(): JSX.Element {
           New Expense
         </Button>
       </MTopNavigation>
-      <div className='w-full flex grow flex-col min-w-0' ref={ref}>
+      <div className='w-full flex grow flex-col min-w-0'>
         {(expenses ?? []).length === 0 && <EmptyState />}
         {expenses?.length > 0 && (
           <ul className='w-full flex flex-col gap-2 py-2 pb-16'>

--- a/interface/src/pages/funding/details.tsx
+++ b/interface/src/pages/funding/details.tsx
@@ -2,6 +2,7 @@ import { useId } from 'react';
 import { format, isEqual, startOfDay, startOfTomorrow } from 'date-fns';
 import { type FormikErrors, type FormikHelpers, useFormikContext } from 'formik';
 import { CalendarSync, HeartCrack, Save, Trash } from 'lucide-react';
+import { useLocation, useRoute } from 'wouter';
 
 import type { ApiError } from '@monetr/interface/api/client';
 import { Button } from '@monetr/interface/components/Button';
@@ -25,8 +26,6 @@ import useTimezone from '@monetr/interface/hooks/useTimezone';
 import type FundingSchedule from '@monetr/interface/models/FundingSchedule';
 import type { APIError } from '@monetr/interface/util/request';
 import { useSnackbar } from '@monetr/notify';
-
-import { useLocation, useRoute } from 'wouter';
 
 interface FundingValues {
   name: string;

--- a/interface/src/pages/funding/details.tsx
+++ b/interface/src/pages/funding/details.tsx
@@ -2,7 +2,6 @@ import { useId } from 'react';
 import { format, isEqual, startOfDay, startOfTomorrow } from 'date-fns';
 import { type FormikErrors, type FormikHelpers, useFormikContext } from 'formik';
 import { CalendarSync, HeartCrack, Save, Trash } from 'lucide-react';
-import { useMatch, useNavigate } from 'react-router-dom';
 
 import type { ApiError } from '@monetr/interface/api/client';
 import { Button } from '@monetr/interface/components/Button';
@@ -27,6 +26,8 @@ import type FundingSchedule from '@monetr/interface/models/FundingSchedule';
 import type { APIError } from '@monetr/interface/util/request';
 import { useSnackbar } from '@monetr/notify';
 
+import { useLocation, useRoute } from 'wouter';
+
 interface FundingValues {
   name: string;
   nextRecurrence: Date;
@@ -42,12 +43,12 @@ export default function FundingDetails(): JSX.Element {
   const { data: locale } = useLocaleCurrency();
   // I don't want to do it this way, but it seems like it's the only way to do it for tests without having the entire
   // router also present in the test?
-  const match = useMatch('/bank/:bankId/funding/:fundingId/details');
-  const fundingId = match?.params?.fundingId || null;
+  const [, params] = useRoute<{ bankId: string; fundingId: string }>('/bank/:bankId/funding/:fundingId/details');
+  const fundingId = params?.fundingId || null;
   const { data: funding } = useFundingSchedule(fundingId);
   const { data: link } = useCurrentLink();
   const isManual = Boolean(link?.getIsManual());
-  const navigate = useNavigate();
+  const [, navigate] = useLocation();
   const patchFundingSchedule = usePatchFundingSchedule();
   const removeFundingSchedule = useRemoveFundingSchedule();
   const { enqueueSnackbar } = useSnackbar();

--- a/interface/src/pages/goals.tsx
+++ b/interface/src/pages/goals.tsx
@@ -1,6 +1,5 @@
-import { Fragment, useCallback, useEffect, useRef } from 'react';
+import { Fragment } from 'react';
 import { HeartCrack, PiggyBank, Plus } from 'lucide-react';
-import { useNavigationType } from 'react-router-dom';
 
 import { Button } from '@monetr/interface/components/Button';
 import GoalItem from '@monetr/interface/components/goals/GoalItem';
@@ -10,32 +9,8 @@ import { useSpendingFiltered } from '@monetr/interface/hooks/useSpendingFiltered
 import { showNewGoalModal } from '@monetr/interface/modals/NewGoalModal';
 import { SpendingType } from '@monetr/interface/models/Spending';
 
-let evilScrollPosition: number = 0;
-
 export default function Goals(): JSX.Element {
   const { data: goals, isError, isLoading } = useSpendingFiltered(SpendingType.Goal);
-
-  // Scroll restoration code.
-  const ref = useRef<HTMLDivElement>(null);
-  const navigationType = useNavigationType();
-  const onScroll = useCallback(() => {
-    evilScrollPosition = ref.current.scrollTop;
-  }, []);
-  useEffect(() => {
-    if (!ref.current) {
-      return undefined;
-    }
-
-    if (navigationType === 'POP') {
-      ref.current.scrollTop = evilScrollPosition;
-    }
-    const current = ref.current;
-    ref.current.addEventListener('scroll', onScroll);
-    return () => {
-      current.removeEventListener('scroll', onScroll);
-    };
-    // Fix bug with current impl.
-  }, [navigationType, onScroll]);
 
   if (isLoading) {
     return (
@@ -79,7 +54,7 @@ export default function Goals(): JSX.Element {
           New Goal
         </Button>
       </MTopNavigation>
-      <div className='w-full h-full overflow-y-auto min-w-0' ref={ref}>
+      <div className='w-full h-full overflow-y-auto min-w-0'>
         <ListContent />
       </div>
     </Fragment>

--- a/interface/src/pages/goals/details.tsx
+++ b/interface/src/pages/goals/details.tsx
@@ -1,6 +1,7 @@
 import { startOfDay, startOfTomorrow } from 'date-fns';
 import type { FormikHelpers } from 'formik';
 import { ArrowUpDown, HeartCrack, PiggyBank, Save, Trash } from 'lucide-react';
+import { useLocation, useParams } from 'wouter';
 
 import type { ApiError } from '@monetr/interface/api/client';
 import { Button } from '@monetr/interface/components/Button';
@@ -26,8 +27,6 @@ import Spending, { SpendingType } from '@monetr/interface/models/Spending';
 import { AmountType } from '@monetr/interface/util/amounts';
 import type { APIError } from '@monetr/interface/util/request';
 import { useSnackbar } from '@monetr/notify';
-
-import { useLocation, useParams } from 'wouter';
 
 interface GoalValues {
   name: string;

--- a/interface/src/pages/goals/details.tsx
+++ b/interface/src/pages/goals/details.tsx
@@ -1,7 +1,6 @@
 import { startOfDay, startOfTomorrow } from 'date-fns';
 import type { FormikHelpers } from 'formik';
 import { ArrowUpDown, HeartCrack, PiggyBank, Save, Trash } from 'lucide-react';
-import { useNavigate, useParams } from 'react-router-dom';
 
 import type { ApiError } from '@monetr/interface/api/client';
 import { Button } from '@monetr/interface/components/Button';
@@ -28,6 +27,8 @@ import { AmountType } from '@monetr/interface/util/amounts';
 import type { APIError } from '@monetr/interface/util/request';
 import { useSnackbar } from '@monetr/notify';
 
+import { useLocation, useParams } from 'wouter';
+
 interface GoalValues {
   name: string;
   amount: number;
@@ -41,8 +42,8 @@ export default function GoalDetails(): JSX.Element {
   const { data: locale } = useLocaleCurrency();
   const removeSpending = useRemoveSpending();
   const updateSpending = useUpdateSpending();
-  const navigate = useNavigate();
-  const { spendingId } = useParams();
+  const [, navigate] = useLocation();
+  const { spendingId } = useParams<{ spendingId: string }>();
   const { enqueueSnackbar } = useSnackbar();
   const { data: spending, isLoading, isError } = useSpending(spendingId);
 

--- a/interface/src/pages/link/details.tsx
+++ b/interface/src/pages/link/details.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { useCallback } from 'react';
 import type { FormikHelpers } from 'formik';
 import { ChevronRight, Landmark, Save, Trash } from 'lucide-react';
+import { Link, useParams } from 'wouter';
 
 import type { ApiError } from '@monetr/interface/api/client';
 import Badge from '@monetr/interface/components/Badge';
@@ -20,8 +21,6 @@ import type BankAccount from '@monetr/interface/models/BankAccount';
 import capitalize from '@monetr/interface/util/capitalize';
 import type { APIError } from '@monetr/interface/util/request';
 import { useSnackbar } from '@monetr/notify';
-
-import { Link, useParams } from 'wouter';
 
 interface LinkValues {
   institutionName: string;

--- a/interface/src/pages/link/details.tsx
+++ b/interface/src/pages/link/details.tsx
@@ -2,7 +2,6 @@ import type React from 'react';
 import { useCallback } from 'react';
 import type { FormikHelpers } from 'formik';
 import { ChevronRight, Landmark, Save, Trash } from 'lucide-react';
-import { Link, useParams } from 'react-router-dom';
 
 import type { ApiError } from '@monetr/interface/api/client';
 import Badge from '@monetr/interface/components/Badge';
@@ -22,13 +21,15 @@ import capitalize from '@monetr/interface/util/capitalize';
 import type { APIError } from '@monetr/interface/util/request';
 import { useSnackbar } from '@monetr/notify';
 
+import { Link, useParams } from 'wouter';
+
 interface LinkValues {
   institutionName: string;
 }
 
 export default function LinkDetails(): React.JSX.Element {
   const { enqueueSnackbar } = useSnackbar();
-  const { linkId } = useParams();
+  const { linkId } = useParams<{ linkId: string }>();
   const { data: link, isLoading: linkIsLoading } = useLink(linkId);
   const { data: bankAccounts, isLoading: bankAccountsLoading } = useBankAccountsForLink(linkId);
   const patchLink = usePatchLink();

--- a/interface/src/pages/login.spec.tsx
+++ b/interface/src/pages/login.spec.tsx
@@ -1,5 +1,4 @@
 import { rs } from '@rstest/core';
-import * as reactRouterDomActual from 'react-router-dom' with { rstest: 'importActual' };
 
 import { waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -8,10 +7,12 @@ import Login from '@monetr/interface/pages/login';
 import FetchMock from '@monetr/interface/testutils/fetchMock';
 import testRenderer from '@monetr/interface/testutils/renderer';
 
-const mockUseNavigate = rs.fn((_url: string) => {});
-rs.mock('react-router-dom', () => ({
-  ...reactRouterDomActual,
-  useNavigate: () => mockUseNavigate,
+import * as wouterActual from 'wouter' with { rstest: 'importActual' };
+
+const mockNavigate = rs.fn((_url: string) => {});
+rs.mock('wouter', () => ({
+  ...wouterActual,
+  useLocation: () => ['/login', mockNavigate],
 }));
 
 describe('login page', () => {
@@ -19,7 +20,7 @@ describe('login page', () => {
 
   beforeEach(() => {
     mockFetch = new FetchMock();
-    mockUseNavigate.mockReset();
+    mockNavigate.mockReset();
   });
   afterEach(() => {
     mockFetch.reset();
@@ -104,7 +105,7 @@ describe('login page', () => {
     await user.click(world.getByTestId('login-submit'));
 
     // When we login we should be redirected to this route.
-    await waitFor(() => expect(mockUseNavigate).toHaveBeenCalledWith('/'));
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/'));
   });
 
   test('will submit login and require subscription', async () => {
@@ -134,6 +135,6 @@ describe('login page', () => {
     await user.click(world.getByTestId('login-submit'));
 
     // When we login we should be redirected to this route.
-    await waitFor(() => expect(mockUseNavigate).toHaveBeenCalledWith('/account/subscribe'));
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/account/subscribe'));
   });
 });

--- a/interface/src/pages/login.spec.tsx
+++ b/interface/src/pages/login.spec.tsx
@@ -1,4 +1,5 @@
 import { rs } from '@rstest/core';
+import * as wouterActual from 'wouter' with { rstest: 'importActual' };
 
 import { waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -6,8 +7,6 @@ import userEvent from '@testing-library/user-event';
 import Login from '@monetr/interface/pages/login';
 import FetchMock from '@monetr/interface/testutils/fetchMock';
 import testRenderer from '@monetr/interface/testutils/renderer';
-
-import * as wouterActual from 'wouter' with { rstest: 'importActual' };
 
 const mockNavigate = rs.fn((_url: string) => {});
 rs.mock('wouter', () => ({

--- a/interface/src/pages/password/reset.tsx
+++ b/interface/src/pages/password/reset.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import type { FormikErrors, FormikHelpers } from 'formik';
+import { useLocation, useSearch } from 'wouter';
 
 import FormButton from '@monetr/interface/components/FormButton';
 import FormTextField from '@monetr/interface/components/FormTextField';
@@ -9,8 +10,6 @@ import MLogo from '@monetr/interface/components/MLogo';
 import Typography from '@monetr/interface/components/Typography';
 import useResetPassword from '@monetr/interface/hooks/useResetPassword';
 import { useSnackbar } from '@monetr/notify';
-
-import { useLocation, useSearch } from 'wouter';
 
 interface ResetPasswordValues {
   password: string;

--- a/interface/src/pages/password/reset.tsx
+++ b/interface/src/pages/password/reset.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import type { FormikErrors, FormikHelpers } from 'formik';
-import { useLocation, useNavigate } from 'react-router-dom';
 
 import FormButton from '@monetr/interface/components/FormButton';
 import FormTextField from '@monetr/interface/components/FormTextField';
@@ -10,6 +9,8 @@ import MLogo from '@monetr/interface/components/MLogo';
 import Typography from '@monetr/interface/components/Typography';
 import useResetPassword from '@monetr/interface/hooks/useResetPassword';
 import { useSnackbar } from '@monetr/notify';
+
+import { useLocation, useSearch } from 'wouter';
 
 interface ResetPasswordValues {
   password: string;
@@ -23,16 +24,19 @@ const initialValues: ResetPasswordValues = {
 
 export default function PasswordResetNew(): JSX.Element {
   const { enqueueSnackbar } = useSnackbar();
-  const location = useLocation();
-  const navigate = useNavigate();
+  const [pathname, navigate] = useLocation();
   const resetPassword = useResetPassword();
-  const { state: routeState } = useLocation();
-  const message = routeState?.message || 'Enter the new password you would like to use.';
-  const search = location.search;
-  const query = new URLSearchParams(search);
-  // The token is loaded from the route state (which is provided when a password reset is being forced) or from the
-  // URL query parameter (which is provided when the user is brought here from a link in their email).
-  const token = query.get('token') || routeState?.token;
+  const query = new URLSearchParams(useSearch());
+  // The reason indicates whether the user was forced here by a `PASSWORD_CHANGE_REQUIRED` login response (in which
+  // case we show a different message) or arrived via the password reset link in their email.
+  const reason = query.get('reason');
+  const message =
+    reason === 'password_change_required'
+      ? 'You are required to change your password before authenticating.'
+      : 'Enter the new password you would like to use.';
+  // The token is provided as a query parameter, either from the email link or from the login flow when a password
+  // change is required.
+  const token = query.get('token');
 
   useEffect(() => {
     if (!token) {
@@ -45,8 +49,8 @@ export default function PasswordResetNew(): JSX.Element {
 
     // Clear the URL so that the token is not shown. But also so that the user cannot accidentally navigate back to the
     // password reset page with the token still in place.
-    window.history.replaceState({}, document.title, !token ? '/login' : location.pathname);
-  }, [token, enqueueSnackbar, navigate, location.pathname]);
+    window.history.replaceState({}, document.title, !token ? '/login' : pathname);
+  }, [token, enqueueSnackbar, navigate, pathname]);
 
   async function submit(values: ResetPasswordValues, helpers: FormikHelpers<ResetPasswordValues>): Promise<void> {
     helpers.setSubmitting(true);

--- a/interface/src/pages/plaid/oauth-return.tsx
+++ b/interface/src/pages/plaid/oauth-return.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { captureEvent } from '@sentry/react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
 
 import MSpinner from '@monetr/interface/components/MSpinner';
 import { OAuthRedirectPlaidLink } from '@monetr/interface/components/Plaid/OAuthRedirectPlaidLink';
@@ -9,6 +8,7 @@ import Typography from '@monetr/interface/components/Typography';
 import request from '@monetr/interface/util/request';
 
 import type { PlaidLinkError, PlaidLinkOnExitMetadata, PlaidLinkOnSuccessMetadata } from 'react-plaid-link/src/types';
+import { useLocation } from 'wouter';
 
 interface State {
   loading: boolean;
@@ -40,7 +40,7 @@ export default function OauthReturn(): JSX.Element {
       );
   }, []);
 
-  const navigate = useNavigate();
+  const [, navigate] = useLocation();
 
   async function longPollSetup(): Promise<void> {
     setState(prevState => ({

--- a/interface/src/pages/plaid/oauth-return.tsx
+++ b/interface/src/pages/plaid/oauth-return.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { captureEvent } from '@sentry/react';
 import { useQueryClient } from '@tanstack/react-query';
+import { useLocation } from 'wouter';
 
 import MSpinner from '@monetr/interface/components/MSpinner';
 import { OAuthRedirectPlaidLink } from '@monetr/interface/components/Plaid/OAuthRedirectPlaidLink';
@@ -8,7 +9,6 @@ import Typography from '@monetr/interface/components/Typography';
 import request from '@monetr/interface/util/request';
 
 import type { PlaidLinkError, PlaidLinkOnExitMetadata, PlaidLinkOnSuccessMetadata } from 'react-plaid-link/src/types';
-import { useLocation } from 'wouter';
 
 interface State {
   loading: boolean;

--- a/interface/src/pages/register.tsx
+++ b/interface/src/pages/register.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import type { FormikErrors, FormikHelpers } from 'formik';
+import { useLocation } from 'wouter';
 
 import type { ApiError } from '@monetr/interface/api/client';
 import Flex from '@monetr/interface/components/Flex';
@@ -21,8 +22,6 @@ import verifyEmailAddress from '@monetr/interface/util/verifyEmailAddress';
 import { useSnackbar } from '@monetr/notify';
 
 import styles from './register.module.scss';
-
-import { useLocation } from 'wouter';
 
 interface RegisterValues {
   firstName: string;

--- a/interface/src/pages/register.tsx
+++ b/interface/src/pages/register.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import type { FormikErrors, FormikHelpers } from 'formik';
-import { useNavigate } from 'react-router-dom';
 
 import type { ApiError } from '@monetr/interface/api/client';
 import Flex from '@monetr/interface/components/Flex';
@@ -22,6 +21,8 @@ import verifyEmailAddress from '@monetr/interface/util/verifyEmailAddress';
 import { useSnackbar } from '@monetr/notify';
 
 import styles from './register.module.scss';
+
+import { useLocation } from 'wouter';
 
 interface RegisterValues {
   firstName: string;
@@ -98,7 +99,7 @@ export default function Register(): JSX.Element {
   const { enqueueSnackbar } = useSnackbar();
   const { data: config } = useAppConfiguration();
   const signUp = useSignUp();
-  const navigate = useNavigate();
+  const [, navigate] = useLocation();
   const queryClient = useQueryClient();
   const [successful, setSuccessful] = useState(false);
 

--- a/interface/src/pages/settings/billing.tsx
+++ b/interface/src/pages/settings/billing.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useState } from 'react';
 import { format, isFuture, isThisYear } from 'date-fns';
 import { Clock } from 'lucide-react';
-import { useLocation } from 'react-router-dom';
 
 import type { ApiResponse } from '@monetr/interface/api/client';
 import Badge from '@monetr/interface/components/Badge';
@@ -12,8 +11,10 @@ import { useAuthentication } from '@monetr/interface/hooks/useAuthentication';
 import request from '@monetr/interface/util/request';
 import { useSnackbar } from '@monetr/notify';
 
+import { useLocation } from 'wouter';
+
 export default function SettingsBilling(): JSX.Element {
-  const location = useLocation();
+  const [pathname] = useLocation();
   const { enqueueSnackbar } = useSnackbar();
   const [loading, setLoading] = useState(false);
   const { data: auth } = useAuthentication();
@@ -26,7 +27,7 @@ export default function SettingsBilling(): JSX.Element {
         url: '/api/billing/create_checkout',
         data: {
           // If the user backs out of the stripe checkout then return them to the current URL.
-          cancelPath: location.pathname,
+          cancelPath: pathname,
         },
       });
     } else {
@@ -44,7 +45,7 @@ export default function SettingsBilling(): JSX.Element {
           disableWindowBlurListener: true,
         });
       });
-  }, [enqueueSnackbar, auth, location]);
+  }, [enqueueSnackbar, auth, pathname]);
 
   const manageSubscriptionText = auth?.hasSubscription ? 'Manage Your Subscription' : 'Subscribe Early';
 

--- a/interface/src/pages/settings/billing.tsx
+++ b/interface/src/pages/settings/billing.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 import { format, isFuture, isThisYear } from 'date-fns';
 import { Clock } from 'lucide-react';
+import { useLocation } from 'wouter';
 
 import type { ApiResponse } from '@monetr/interface/api/client';
 import Badge from '@monetr/interface/components/Badge';
@@ -10,8 +11,6 @@ import Typography from '@monetr/interface/components/Typography';
 import { useAuthentication } from '@monetr/interface/hooks/useAuthentication';
 import request from '@monetr/interface/util/request';
 import { useSnackbar } from '@monetr/notify';
-
-import { useLocation } from 'wouter';
 
 export default function SettingsBilling(): JSX.Element {
   const [pathname] = useLocation();

--- a/interface/src/pages/setup.tsx
+++ b/interface/src/pages/setup.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { CircleCheck, Pencil } from 'lucide-react';
-import { Navigate } from 'react-router-dom';
 
 import Logo from '@monetr/interface/assets/Logo';
 import { Button } from '@monetr/interface/components/Button';
@@ -12,6 +11,8 @@ import SetupBillingButton from '@monetr/interface/components/setup/SetupBillingB
 import Typography from '@monetr/interface/components/Typography';
 import { useAppConfiguration } from '@monetr/interface/hooks/useAppConfiguration';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
+
+import { Redirect } from 'wouter';
 
 export interface SetupPageProps {
   // TODO Remove this prop and instead just use "does the user have any links". If they do then we can assume this is
@@ -34,11 +35,11 @@ export default function SetupPage(props: SetupPageProps): JSX.Element {
         <Greeting alreadyOnboarded={props.alreadyOnboarded} manualEnabled={props.manualEnabled} onContinue={setStep} />
       );
     case 'plaid':
-      return <Navigate to={plaidPath} />;
+      return <Redirect to={plaidPath} />;
     case 'lunchflow':
-      return <Navigate to={lunchFlowPath} />;
+      return <Redirect to={lunchFlowPath} />;
     case 'manual':
-      return <Navigate to={manualPath} />;
+      return <Redirect to={manualPath} />;
     default:
       return <h1>Something went wrong...</h1>;
   }

--- a/interface/src/pages/setup.tsx
+++ b/interface/src/pages/setup.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { CircleCheck, Pencil } from 'lucide-react';
+import { Redirect } from 'wouter';
 
 import Logo from '@monetr/interface/assets/Logo';
 import { Button } from '@monetr/interface/components/Button';
@@ -11,8 +12,6 @@ import SetupBillingButton from '@monetr/interface/components/setup/SetupBillingB
 import Typography from '@monetr/interface/components/Typography';
 import { useAppConfiguration } from '@monetr/interface/hooks/useAppConfiguration';
 import mergeTailwind from '@monetr/interface/util/mergeTailwind';
-
-import { Redirect } from 'wouter';
 
 export interface SetupPageProps {
   // TODO Remove this prop and instead just use "does the user have any links". If they do then we can assume this is

--- a/interface/src/pages/subscription.tsx
+++ b/interface/src/pages/subscription.tsx
@@ -1,5 +1,4 @@
 import { LoaderCircle } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
 
 import Logo from '@monetr/interface/assets/Logo';
 import Typography from '@monetr/interface/components/Typography';
@@ -7,11 +6,13 @@ import useMountEffect from '@monetr/interface/hooks/useMountEffect';
 import request from '@monetr/interface/util/request';
 import { useSnackbar } from '@monetr/notify';
 
+import { useLocation } from 'wouter';
+
 // SubscriptionPage is just used to redirect the user to the stripe billing portal. Upon mounting, it will make an API
 // call to start a billing portal session, and once it gets a response it will redirect the user there.
 export default function SubscriptionPage(): JSX.Element {
   const { enqueueSnackbar } = useSnackbar();
-  const navigate = useNavigate();
+  const [, navigate] = useLocation();
 
   useMountEffect(() => {
     request<{ url: string }>({ method: 'GET', url: '/api/billing/portal' })

--- a/interface/src/pages/subscription.tsx
+++ b/interface/src/pages/subscription.tsx
@@ -1,12 +1,11 @@
 import { LoaderCircle } from 'lucide-react';
+import { useLocation } from 'wouter';
 
 import Logo from '@monetr/interface/assets/Logo';
 import Typography from '@monetr/interface/components/Typography';
 import useMountEffect from '@monetr/interface/hooks/useMountEffect';
 import request from '@monetr/interface/util/request';
 import { useSnackbar } from '@monetr/notify';
-
-import { useLocation } from 'wouter';
 
 // SubscriptionPage is just used to redirect the user to the stripe billing portal. Upon mounting, it will make an API
 // call to start a billing portal session, and once it gets a response it will redirect the user there.

--- a/interface/src/pages/transaction/details.tsx
+++ b/interface/src/pages/transaction/details.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { startOfDay } from 'date-fns';
 import type { FormikHelpers } from 'formik';
 import { HeartCrack, Save, ShoppingCart } from 'lucide-react';
+import { useParams } from 'wouter';
 
 import type { ApiError } from '@monetr/interface/api/client';
 import Flex from '@monetr/interface/components/Flex';
@@ -27,8 +28,6 @@ import { useUpdateTransaction } from '@monetr/interface/hooks/useUpdateTransacti
 import Transaction from '@monetr/interface/models/Transaction';
 import type { APIError } from '@monetr/interface/util/request';
 import { useSnackbar } from '@monetr/notify';
-
-import { useParams } from 'wouter';
 
 interface TransactionValues {
   name: string;

--- a/interface/src/pages/transaction/details.tsx
+++ b/interface/src/pages/transaction/details.tsx
@@ -2,7 +2,6 @@ import { useCallback } from 'react';
 import { startOfDay } from 'date-fns';
 import type { FormikHelpers } from 'formik';
 import { HeartCrack, Save, ShoppingCart } from 'lucide-react';
-import { useParams } from 'react-router-dom';
 
 import type { ApiError } from '@monetr/interface/api/client';
 import Flex from '@monetr/interface/components/Flex';
@@ -29,6 +28,8 @@ import Transaction from '@monetr/interface/models/Transaction';
 import type { APIError } from '@monetr/interface/util/request';
 import { useSnackbar } from '@monetr/notify';
 
+import { useParams } from 'wouter';
+
 interface TransactionValues {
   name: string;
   originalName: string;
@@ -44,7 +45,7 @@ export default function TransactionDetails(): JSX.Element {
   const selectedBankAccountId = useSelectedBankAccountId();
   const { data: link, isLoading: linkIsLoading } = useCurrentLink();
   const { enqueueSnackbar } = useSnackbar();
-  const { transactionId: id } = useParams();
+  const { transactionId: id } = useParams<{ transactionId: string }>();
   const updateTransaction = useUpdateTransaction();
   const transactionId = id || null;
   const { data: transaction, isLoading, isError } = useTransaction(transactionId);

--- a/interface/src/pages/verify/email.tsx
+++ b/interface/src/pages/verify/email.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useEffect } from 'react';
+import { useLocation, useSearch } from 'wouter';
 
 import MLogo from '@monetr/interface/components/MLogo';
 import Typography from '@monetr/interface/components/Typography';
 import request from '@monetr/interface/util/request';
-
-import { useLocation, useSearch } from 'wouter';
 
 export default function VerifyEmail(): JSX.Element {
   const search = useSearch();

--- a/interface/src/pages/verify/email.tsx
+++ b/interface/src/pages/verify/email.tsx
@@ -1,13 +1,14 @@
 import { useCallback, useEffect } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
 
 import MLogo from '@monetr/interface/components/MLogo';
 import Typography from '@monetr/interface/components/Typography';
 import request from '@monetr/interface/util/request';
 
+import { useLocation, useSearch } from 'wouter';
+
 export default function VerifyEmail(): JSX.Element {
-  const location = useLocation();
-  const navigate = useNavigate();
+  const search = useSearch();
+  const [, navigate] = useLocation();
 
   const errorRedirect = useCallback(
     (message: string, nextUrl: string = '/login') => {
@@ -17,7 +18,6 @@ export default function VerifyEmail(): JSX.Element {
     [navigate],
   );
 
-  const search = location.search;
   const query = new URLSearchParams(search);
   const token = query.get('token');
 

--- a/interface/src/pages/verify/email/resend.spec.tsx
+++ b/interface/src/pages/verify/email/resend.spec.tsx
@@ -51,12 +51,7 @@ describe('resend verification email', () => {
     });
 
     const world = testRenderer(<ResendVerificationPage />, {
-      initialRoute: {
-        pathname: '/verify/email/resend',
-        state: {
-          emailAddress: 'email@test.com',
-        },
-      },
+      initialRoute: `/verify/email/resend?email=${encodeURIComponent('email@test.com')}`,
     });
 
     await waitFor(() => {

--- a/interface/src/pages/verify/email/resend.tsx
+++ b/interface/src/pages/verify/email/resend.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import type { FormikErrors, FormikHelpers } from 'formik';
+import { useSearch } from 'wouter';
 
 import type { ApiError } from '@monetr/interface/api/client';
 import FormButton from '@monetr/interface/components/FormButton';
@@ -13,8 +14,6 @@ import { useAppConfiguration } from '@monetr/interface/hooks/useAppConfiguration
 import request, { type APIError } from '@monetr/interface/util/request';
 import verifyEmailAddress from '@monetr/interface/util/verifyEmailAddress';
 import { useSnackbar } from '@monetr/notify';
-
-import { useSearch } from 'wouter';
 
 interface ResendValues {
   email: string | null;

--- a/interface/src/pages/verify/email/resend.tsx
+++ b/interface/src/pages/verify/email/resend.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useState } from 'react';
 import type { FormikErrors, FormikHelpers } from 'formik';
-import { useLocation } from 'react-router-dom';
 
 import type { ApiError } from '@monetr/interface/api/client';
 import FormButton from '@monetr/interface/components/FormButton';
@@ -15,6 +14,8 @@ import request, { type APIError } from '@monetr/interface/util/request';
 import verifyEmailAddress from '@monetr/interface/util/verifyEmailAddress';
 import { useSnackbar } from '@monetr/notify';
 
+import { useSearch } from 'wouter';
+
 interface ResendValues {
   email: string | null;
   captcha: string | null;
@@ -23,7 +24,7 @@ interface ResendValues {
 export default function ResendVerificationPage(): JSX.Element {
   const { enqueueSnackbar } = useSnackbar();
   const { data: config } = useAppConfiguration();
-  const { state: routeState } = useLocation();
+  const emailFromQuery = new URLSearchParams(useSearch()).get('email');
   const [done, setDone] = useState(false);
 
   const resendVerification = useCallback(
@@ -69,7 +70,7 @@ export default function ResendVerificationPage(): JSX.Element {
   );
 
   const initialValues: ResendValues = {
-    email: routeState?.emailAddress || undefined,
+    email: emailFromQuery || undefined,
     captcha: null,
   };
 
@@ -86,7 +87,7 @@ export default function ResendVerificationPage(): JSX.Element {
     >
       <div className='max-w-xs flex flex-col items-center gap-2'>
         <MLogo className='h-24 w-24' />
-        <RouteStateMessage />
+        <RouteStateMessage hasEmail={Boolean(emailFromQuery)} />
         <FormTextField
           autoComplete='username'
           autoFocus
@@ -135,9 +136,12 @@ export function AfterEmailVerificationSent(): JSX.Element {
   );
 }
 
-function RouteStateMessage(): JSX.Element {
-  const { state: routeState } = useLocation();
-  if (routeState) {
+interface RouteStateMessageProps {
+  hasEmail: boolean;
+}
+
+function RouteStateMessage(props: RouteStateMessageProps): JSX.Element {
+  if (props.hasEmail) {
     return (
       <Typography align='center' data-testid='resend-email-included' size='sm'>
         It looks like your email address has not been verified. Do you want to resend the email verification link?

--- a/interface/src/testutils/hooks.tsx
+++ b/interface/src/testutils/hooks.tsx
@@ -1,12 +1,12 @@
 import type React from 'react';
 import NiceModal from '@ebay/nice-modal-react';
+import { Router } from 'wouter';
 
 import { type RenderHookResult, renderHook } from '@testing-library/react';
 
 import MQueryClient from '@monetr/interface/components/MQueryClient';
 import MSnackbarProvider from '@monetr/interface/components/MSnackbarProvider';
 
-import { Router } from 'wouter';
 import { memoryLocation } from 'wouter/memory-location';
 
 export interface HooksOptions<TProps> {

--- a/interface/src/testutils/hooks.tsx
+++ b/interface/src/testutils/hooks.tsx
@@ -1,11 +1,13 @@
 import type React from 'react';
 import NiceModal from '@ebay/nice-modal-react';
-import { MemoryRouter } from 'react-router-dom';
 
 import { type RenderHookResult, renderHook } from '@testing-library/react';
 
 import MQueryClient from '@monetr/interface/components/MQueryClient';
 import MSnackbarProvider from '@monetr/interface/components/MSnackbarProvider';
+
+import { Router } from 'wouter';
+import { memoryLocation } from 'wouter/memory-location';
 
 export interface HooksOptions<TProps> {
   initialRoute: string;
@@ -16,18 +18,16 @@ function testRenderHook<TProps, TResult>(
   callback: (props: TProps) => TResult,
   options?: HooksOptions<TProps>,
 ): RenderHookResult<TResult, TProps> {
+  const { hook } = memoryLocation({ path: options.initialRoute });
   const Wrapper: React.FC<React.PropsWithChildren> = props => {
     return (
-      <MemoryRouter
-        future={{ v7_startTransition: false, v7_relativeSplatPath: false }}
-        initialEntries={[options.initialRoute]}
-      >
+      <Router hook={hook}>
         <MQueryClient>
           <MSnackbarProvider>
             <NiceModal.Provider>{props.children}</NiceModal.Provider>
           </MSnackbarProvider>
         </MQueryClient>
-      </MemoryRouter>
+      </Router>
     );
   };
 

--- a/interface/src/testutils/renderer.tsx
+++ b/interface/src/testutils/renderer.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
 import NiceModal from '@ebay/nice-modal-react';
+import { Router } from 'wouter';
 
 import { type Queries, type queries, type RenderOptions, type RenderResult, render } from '@testing-library/react';
 
@@ -7,7 +8,6 @@ import MQueryClient from '@monetr/interface/components/MQueryClient';
 import MSnackbarProvider from '@monetr/interface/components/MSnackbarProvider';
 import { TooltipProvider } from '@monetr/interface/components/Tooltip';
 
-import { Router } from 'wouter';
 import { memoryLocation } from 'wouter/memory-location';
 
 export interface Options<Q extends Queries = typeof queries, Container extends Element | DocumentFragment = HTMLElement>

--- a/interface/src/testutils/renderer.tsx
+++ b/interface/src/testutils/renderer.tsx
@@ -1,6 +1,5 @@
 import type React from 'react';
 import NiceModal from '@ebay/nice-modal-react';
-import { type Location, MemoryRouter } from 'react-router-dom';
 
 import { type Queries, type queries, type RenderOptions, type RenderResult, render } from '@testing-library/react';
 
@@ -8,21 +7,22 @@ import MQueryClient from '@monetr/interface/components/MQueryClient';
 import MSnackbarProvider from '@monetr/interface/components/MSnackbarProvider';
 import { TooltipProvider } from '@monetr/interface/components/Tooltip';
 
+import { Router } from 'wouter';
+import { memoryLocation } from 'wouter/memory-location';
+
 export interface Options<Q extends Queries = typeof queries, Container extends Element | DocumentFragment = HTMLElement>
   extends RenderOptions<Q, Container> {
-  initialRoute: string | Partial<Location>;
+  initialRoute: string;
 }
 
 function testRenderer<Q extends Queries = typeof queries, Container extends Element | DocumentFragment = HTMLElement>(
   ui: React.ReactElement,
   options?: Options<Q, Container>,
 ): RenderResult<Q, Container> {
+  const { hook } = memoryLocation({ path: options.initialRoute });
   const Wrapper = (props: React.PropsWithChildren<unknown>) => {
     return (
-      <MemoryRouter
-        future={{ v7_startTransition: false, v7_relativeSplatPath: false }}
-        initialEntries={[options.initialRoute]}
-      >
+      <Router hook={hook}>
         <MQueryClient>
           <MSnackbarProvider>
             <TooltipProvider>
@@ -30,7 +30,7 @@ function testRenderer<Q extends Queries = typeof queries, Container extends Elem
             </TooltipProvider>
           </MSnackbarProvider>
         </MQueryClient>
-      </MemoryRouter>
+      </Router>
     );
   };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,9 +246,6 @@ importers:
       react-qr-code:
         specifier: 2.0.21
         version: 2.0.21(react@18.3.1)
-      react-router-dom:
-        specifier: 6.30.3
-        version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rrule:
         specifier: 2.8.1
         version: 2.8.1
@@ -261,6 +258,9 @@ importers:
       tailwindcss-animate:
         specifier: 1.0.7
         version: 1.0.7(tailwindcss@3.4.19(ts-node@10.9.1(@swc/core@1.15.21(@swc/helpers@0.5.21))(@types/node@20.19.23)(typescript@5.9.3)))
+      wouter:
+        specifier: 3.9.0
+        version: 3.9.0(react@18.3.1)
     devDependencies:
       '@imagemagick/magick-wasm':
         specifier: 0.0.40
@@ -1209,10 +1209,6 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
-  '@remix-run/router@1.23.2':
-    resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
-    engines: {node: '>=14.0.0'}
-
   '@rsbuild/core@2.0.2':
     resolution: {integrity: sha512-0Vo1W0ZekQ6jTIaSqiG/dgMrYXcKP/eUDNad87NhxfMfu/S5xZT8fk0AEMMk49IyvIIE56uw2Ua6rw8mnZtM+Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1271,7 +1267,6 @@ packages:
     resolution: {integrity: sha512-1ZD4YFhG1rmgqj+W8hfwHyKV8xDxGsc/3KgU0FwmiVEX7JfzhCkgBO/xlCG79kRKSrzuVzt4icO/G3cCKn0pag==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rspack/binding-linux-arm64-musl@2.0.2':
     resolution: {integrity: sha512-/PtTkM/DsDLjeuXTmeJeRfbjCDbcL9jvoVgZrgxYFZ28y2cdLvbChbW9uigOzs5dQEs1CIBQXMTTj7KhdBTuQg==}
@@ -1283,7 +1278,6 @@ packages:
     resolution: {integrity: sha512-bBjsZxMHRaPo6X9SokApm6ucs+UhXtAJFyJJyuk2BH4XJsLeCU9Dz1vMwioeohFbJUUeTASVPm6/BL+RhSaunw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rspack/binding-linux-x64-musl@2.0.2':
     resolution: {integrity: sha512-HjlpInqzabDNkhVsUJpsHPqa9QYVWBViJoyWNjzXCAW0vKMDvwaphyUvokSinX8FGTlZi/sr5UEaHJo6XtQ35g==}
@@ -2980,6 +2974,9 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
@@ -3451,25 +3448,12 @@ packages:
     peerDependencies:
       react: '>=19'
 
-  react-router-dom@6.30.3:
-    resolution: {integrity: sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-
   react-router-dom@7.14.0:
     resolution: {integrity: sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
-
-  react-router@6.30.3:
-    resolution: {integrity: sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
 
   react-router@7.14.0:
     resolution: {integrity: sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==}
@@ -3540,6 +3524,10 @@ packages:
 
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  regexparam@3.0.0:
+    resolution: {integrity: sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==}
+    engines: {node: '>=8'}
 
   rehype-external-links@3.0.0:
     resolution: {integrity: sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==}
@@ -3708,7 +3696,6 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: glibc
 
   sass-embedded-linux-arm@1.99.0:
     resolution: {integrity: sha512-d4IjJZrX2+AwB2YCy1JySwdptJECNP/WfAQLUl8txI3ka8/d3TUI155GtelnoZUkio211PwIeFvvAeZ9RXPQnw==}
@@ -3757,7 +3744,6 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: glibc
 
   sass-embedded-unknown-all@1.99.0:
     resolution: {integrity: sha512-P7MxiUtL/XzGo3PX0CaB8lNNEFLQWKikPA8pbKytx9ZCLZSDkt2NJcdAbblB/sqMs4AV3EK2NadV8rI/diq3xg==}
@@ -4208,6 +4194,11 @@ packages:
   wordwrapjs@5.1.1:
     resolution: {integrity: sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==}
     engines: {node: '>=12.17'}
+
+  wouter@3.9.0:
+    resolution: {integrity: sha512-sF/od/PIgqEQBQcrN7a2x3MX6MQE6nW0ygCfy9hQuUkuB28wEZuu/6M5GyqkrrEu9M6jxdkgE12yDFsQMKos4Q==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -5173,8 +5164,6 @@ snapshots:
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
   '@radix-ui/rect@1.1.1': {}
-
-  '@remix-run/router@1.23.2': {}
 
   '@rsbuild/core@2.0.2(core-js@3.47.0)':
     dependencies:
@@ -7438,6 +7427,8 @@ snapshots:
 
   minipass@7.1.2: {}
 
+  mitt@3.0.1: {}
+
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
@@ -7916,23 +7907,11 @@ snapshots:
       react: 19.2.5
       react-reconciler: 0.33.0(react@19.2.5)
 
-  react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@remix-run/router': 1.23.2
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.30.3(react@18.3.1)
-
   react-router-dom@7.14.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       react-router: 7.14.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-
-  react-router@6.30.3(react@18.3.1):
-    dependencies:
-      '@remix-run/router': 1.23.2
-      react: 18.3.1
 
   react-router@7.14.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -8014,6 +7993,8 @@ snapshots:
   regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
+
+  regexparam@3.0.0: {}
 
   rehype-external-links@3.0.0:
     dependencies:
@@ -8874,6 +8855,13 @@ snapshots:
       isexe: 2.0.0
 
   wordwrapjs@5.1.1: {}
+
+  wouter@3.9.0(react@18.3.1):
+    dependencies:
+      mitt: 3.0.1
+      react: 18.3.1
+      regexparam: 3.0.0
+      use-sync-external-store: 1.5.0(react@18.3.1)
 
   wrap-ansi@7.0.0:
     dependencies:


### PR DESCRIPTION
I don't need all the fancy things that react router might have to offer,
or the large bundle size. This is a migration to wouter which is
significantly smaller and simpler.
