### PR TITLE
refactor(api): Improving transaction validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/jarcoal/httpmock v1.4.1
 	github.com/labstack/echo/v4 v4.15.2
 	github.com/monetr/devslog v0.0.17
-	github.com/monetr/validation v1.0.6
+	github.com/monetr/validation v1.1.0
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/openbao/openbao/api/v2 v2.5.1
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -344,8 +344,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/monetr/devslog v0.0.17 h1:BHpYtqWBGVQawkEyfhgFwqnhQtPBxg4bPMD2tMxsgow=
 github.com/monetr/devslog v0.0.17/go.mod h1:nzUwy/SXXIzjEmPSWWSzm14ytUBh1d9RGr2mxSDZ3Iw=
-github.com/monetr/validation v1.0.6 h1:oDKWmToIbWrujWNR+uWxcRFGUa9B8DIktWWTpkhMnjE=
-github.com/monetr/validation v1.0.6/go.mod h1:mFBjreq4v2Z/K1PAJSGmRgVfcjdezcptqYe+9gSu2oc=
+github.com/monetr/validation v1.1.0 h1:Iygfdzos66rIIglhCrQriw87wHt+pUkOfL+Csgi8k0k=
+github.com/monetr/validation v1.1.0/go.mod h1:mFBjreq4v2Z/K1PAJSGmRgVfcjdezcptqYe+9gSu2oc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=

--- a/interface/src/hooks/useCreateTransaction.ts
+++ b/interface/src/hooks/useCreateTransaction.ts
@@ -3,16 +3,18 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import Balance from '@monetr/interface/models/Balance';
 import type Spending from '@monetr/interface/models/Spending';
 import type Transaction from '@monetr/interface/models/Transaction';
-import request from '@monetr/interface/util/request';
+import request, { type ApiError } from '@monetr/interface/util/request';
 
 export interface CreateTransactionRequest {
   name: string;
-  bankAccountId: string;
   amount: number;
   spendingId: string | null;
   date: Date;
   merchantName: string | null;
   isPending: boolean;
+
+  // These are auxilary fields
+  bankAccountId: string;
   adjustsBalance: boolean;
 }
 
@@ -22,15 +24,30 @@ export interface CreateTransactionResponse {
   spending: Partial<Spending> | null;
 }
 
-export function useCreateTransaction(): (_: CreateTransactionRequest) => Promise<CreateTransactionResponse> {
+export type CreateTransactionError =
+  | { error: string; problems: never }
+  | { error: string; problems: { [K in keyof CreateTransactionRequest]: string } };
+
+export function useCreateTransaction(): (
+  _: CreateTransactionRequest,
+) => Promise<CreateTransactionResponse | CreateTransactionError> {
   const queryClient = useQueryClient();
 
-  async function createTransaction(transaction: CreateTransactionRequest): Promise<CreateTransactionResponse> {
+  async function createTransaction({
+    // The bank account Id field is dropped by the controller, the path value is authoritative here so even thoguh this
+    // does kind of betray the typing of [CreateTransactionError] this is correct.
+    bankAccountId,
+    ...transaction
+  }: CreateTransactionRequest): Promise<CreateTransactionResponse> {
     return request<CreateTransactionResponse>({
       method: 'POST',
-      url: `/api/bank_accounts/${transaction.bankAccountId}/transactions`,
+      url: `/api/bank_accounts/${bankAccountId}/transactions`,
       data: transaction,
-    }).then(result => result.data);
+    })
+      .then(result => result.data)
+      .catch((error: ApiError<CreateTransactionError>) => {
+        throw error.response.data;
+      });
   }
 
   const { mutateAsync } = useMutation({

--- a/interface/src/modals/NewTransactionModal.tsx
+++ b/interface/src/modals/NewTransactionModal.tsx
@@ -3,7 +3,6 @@ import NiceModal, { useModal } from '@ebay/nice-modal-react';
 import { startOfDay, startOfToday } from 'date-fns';
 import type { FormikHelpers } from 'formik';
 
-import type { ApiError } from '@monetr/interface/api/client';
 import { Button } from '@monetr/interface/components/Button';
 import FormAmountField from '@monetr/interface/components/FormAmountField';
 import FormButton from '@monetr/interface/components/FormButton';
@@ -15,11 +14,14 @@ import MSelectSpending from '@monetr/interface/components/MSelectSpending';
 import { Switch } from '@monetr/interface/components/Switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@monetr/interface/components/Tabs';
 import Typography from '@monetr/interface/components/Typography';
-import { type CreateTransactionRequest, useCreateTransaction } from '@monetr/interface/hooks/useCreateTransaction';
+import {
+  type CreateTransactionError,
+  type CreateTransactionRequest,
+  useCreateTransaction,
+} from '@monetr/interface/hooks/useCreateTransaction';
 import useLocaleCurrency from '@monetr/interface/hooks/useLocaleCurrency';
 import { useSelectedBankAccount } from '@monetr/interface/hooks/useSelectedBankAccount';
 import useTimezone from '@monetr/interface/hooks/useTimezone';
-import type { APIError } from '@monetr/interface/util/request';
 import type { ExtractProps } from '@monetr/interface/util/typescriptEvils';
 import { useSnackbar } from '@monetr/notify';
 
@@ -78,13 +80,15 @@ function NewTransactionModal(): JSX.Element {
       createTransaction(newTransactionRequest)
         // TODO Show toast that the transaction was created, include button to "view transaction".
         .then(() => modal.remove())
-        .catch(
-          (error: ApiError<APIError>) =>
-            void enqueueSnackbar(error.response.data.error, {
-              variant: 'error',
-              disableWindowBlurListener: true,
-            }),
-        )
+        .catch((result: CreateTransactionError) => {
+          if (result.problems) {
+            helper.setErrors(result.problems);
+          }
+          enqueueSnackbar(result.error, {
+            variant: 'error',
+            disableWindowBlurListener: true,
+          });
+        })
         .finally(() => helper.setSubmitting(false))
     );
   }

--- a/interface/tsconfig.json
+++ b/interface/tsconfig.json
@@ -9,6 +9,7 @@
     "moduleResolution": "node",
     "noImplicitAny": false,
     "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true,
     "allowImportingTsExtensions": true,
     "outDir": "../server/ui/static",
     "sourceMap": true,

--- a/server/controller/funding_schedules.go
+++ b/server/controller/funding_schedules.go
@@ -9,6 +9,7 @@ import (
 	"github.com/monetr/monetr/server/crumbs"
 	. "github.com/monetr/monetr/server/models"
 	"github.com/monetr/monetr/server/repository"
+	"github.com/monetr/monetr/server/schemas"
 	"github.com/monetr/validation"
 	"github.com/pkg/errors"
 )
@@ -64,13 +65,14 @@ func (c *Controller) postFundingSchedules(ctx echo.Context) error {
 		return c.badRequest(ctx, "must specify a valid bank account Id")
 	}
 
-	var fundingSchedule FundingSchedule
-	fundingSchedule.BankAccountId = bankAccountId
+	fundingSchedule := &FundingSchedule{
+		BankAccountId: bankAccountId,
+	}
 	fundingSchedule, err = parse(
 		c,
 		ctx,
-		&fundingSchedule,
-		validation.Map(fundingSchedule.CreateValidators()...),
+		fundingSchedule,
+		schemas.CreateFundingSchedule,
 	)
 	if err != nil {
 		return err
@@ -97,13 +99,14 @@ func (c *Controller) postFundingSchedules(ctx echo.Context) error {
 		}
 	}
 
-	// Set the next occurrence based on the provided rule.
-
-	// If the next occurrence is not specified then assume that the rule is relative to now. If it is specified though
-	// then do nothing, and the subsequent occurrence will be calculated relative to the provided date.
-	// We also calculate the next occurrence if the provided occurrence is in the past. This technically should not
-	// happen via the UI. But it is currently possible for someone to select the current day in the UI. Which then gets
-	// adjusted for midnight that day, which will always be in the past for the user.
+	// Set the next occurrence based on the provided rule. If the next occurrence
+	// is not specified then assume that the rule is relative to now. If it is
+	// specified though then do nothing, and the subsequent occurrence will be
+	// calculated relative to the provided date. We also calculate the next
+	// occurrence if the provided occurrence is in the past. This technically
+	// should not happen via the UI. But it is currently possible for someone to
+	// select the current day in the UI. Which then gets adjusted for midnight
+	// that day, which will always be in the past for the user.
 	if fundingSchedule.NextRecurrence.IsZero() || c.Clock.Now().After(fundingSchedule.NextRecurrence) {
 		fundingSchedule.CalculateNextOccurrence(
 			c.getContext(ctx),
@@ -117,7 +120,7 @@ func (c *Controller) postFundingSchedules(ctx echo.Context) error {
 	// It has never occurred so this needs to be nil.
 	fundingSchedule.LastRecurrence = nil
 
-	if err = repo.CreateFundingSchedule(c.getContext(ctx), &fundingSchedule); err != nil {
+	if err = repo.CreateFundingSchedule(c.getContext(ctx), fundingSchedule); err != nil {
 		return c.wrapPgError(ctx, err, "failed to create funding schedule")
 	}
 

--- a/server/controller/funding_schedules_test.go
+++ b/server/controller/funding_schedules_test.go
@@ -233,7 +233,7 @@ func TestPostFundingSchedules(t *testing.T) {
 			Expect()
 
 		response.Status(http.StatusBadRequest)
-		response.JSON().Path("$.error").IsEqual("invalid JSON body")
+		response.JSON().Path("$.error").IsEqual("failed to parse request")
 	})
 
 	t.Run("cant create funding schedule for someone elses bank account", func(t *testing.T) {

--- a/server/controller/helpers.go
+++ b/server/controller/helpers.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"encoding/json"
-	"net/http"
 	"strings"
 	"time"
 
@@ -14,8 +13,6 @@ import (
 	"github.com/monetr/monetr/server/repository"
 	"github.com/monetr/monetr/server/security"
 	"github.com/monetr/monetr/server/util"
-	"github.com/monetr/monetr/server/validators"
-	"github.com/monetr/validation"
 	"github.com/pkg/errors"
 )
 
@@ -311,41 +308,4 @@ func enqueueJob[T any](
 		job,
 		args,
 	)
-}
-
-func parse[T any](
-	c *Controller,
-	ctx echo.Context,
-	existing *T,
-	schemas ...validation.MapRule[string],
-) (T, error) {
-	if existing == nil {
-		existing = new(T)
-	}
-
-	rawData := map[string]any{}
-	decoder := json.NewDecoder(ctx.Request().Body)
-	decoder.UseNumber()
-	if err := decoder.Decode(&rawData); err != nil {
-		return *existing, c.invalidJsonError(ctx, err)
-	}
-
-	output, err := validators.OneOf(
-		c.getContext(ctx),
-		existing,
-		rawData,
-		schemas...,
-	)
-	switch errors.Cause(err).(type) {
-	case validators.OneOfError:
-		return output, c.jsonError(ctx, http.StatusBadRequest, map[string]any{
-			"error":    "Invalid request",
-			"problems": validators.MarshalErrorTree(err),
-		})
-	case nil:
-	default:
-		return output, c.badRequestError(ctx, err, "failed to parse request")
-	}
-
-	return output, nil
 }

--- a/server/controller/routes.go
+++ b/server/controller/routes.go
@@ -201,12 +201,14 @@ func (c *Controller) RegisterRoutes(app *echo.Echo) {
 						return ctx.JSON(actualError.Code, internalError)
 					}
 				default:
-					if body, ok := actualError.Message.(map[string]any); ok {
-						return ctx.JSON(actualError.Code, body)
+					switch errorBody := actualError.Message.(type) {
+					case map[string]any:
+						return ctx.JSON(actualError.Code, errorBody)
+					default:
+						return ctx.JSON(actualError.Code, map[string]any{
+							"error": actualError.Message,
+						})
 					}
-					return ctx.JSON(actualError.Code, map[string]any{
-						"error": actualError.Message,
-					})
 				}
 			case nil:
 				return err

--- a/server/controller/schemas.go
+++ b/server/controller/schemas.go
@@ -1,0 +1,41 @@
+package controller
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/monetr/monetr/server/schemas"
+	"github.com/monetr/monetr/server/validators"
+	"github.com/monetr/validation"
+)
+
+func parse[T any](
+	c *Controller,
+	ctx echo.Context,
+	input *T,
+	schema validation.Rule,
+) (*T, error) {
+	result, err := schemas.Parse(
+		c.getContext(ctx),
+		ctx.Request().Body,
+		input,
+		schema,
+	)
+	switch err := err.(type) {
+	case validation.Errors, validation.OneOfError:
+		return nil, echo.NewHTTPError(
+			http.StatusBadRequest,
+			map[string]any{
+				"error":    "Invalid request",
+				"problems": validators.MarshalErrorTree(err),
+			},
+		).WithInternal(err)
+	case *json.SyntaxError:
+		return nil, c.invalidJsonError(ctx, err)
+	case nil:
+		return result, nil
+	default:
+		return nil, c.badRequestError(ctx, err, "failed to parse request")
+	}
+}

--- a/server/controller/spending_test.go
+++ b/server/controller/spending_test.go
@@ -1348,7 +1348,6 @@ func TestPostSpendingTransfer(t *testing.T) {
 				WithPath("bankAccountId", bank.BankAccountId).
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
-					"bankAccountId":  bank.BankAccountId,
 					"amount":         -10000, // $100
 					"isPending":      false,
 					"name":           "Deposit",
@@ -1521,7 +1520,6 @@ func TestPostSpendingTransfer(t *testing.T) {
 				WithPath("bankAccountId", bank.BankAccountId).
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
-					"bankAccountId":  bank.BankAccountId,
 					"amount":         -10000, // $100
 					"isPending":      false,
 					"name":           "Deposit",
@@ -1708,7 +1706,6 @@ func TestPostSpendingTransfer(t *testing.T) {
 				WithPath("bankAccountId", bank.BankAccountId).
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
-					"bankAccountId":  bank.BankAccountId,
 					"amount":         -10000, // $100
 					"isPending":      false,
 					"name":           "Deposit",
@@ -2400,7 +2397,6 @@ func TestDeleteSpending(t *testing.T) {
 				WithPath("bankAccountId", bank.BankAccountId).
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
-					"bankAccountId":  bank.BankAccountId,
 					"amount":         -10000, // $100
 					"isPending":      false,
 					"name":           "Deposit",
@@ -2551,7 +2547,6 @@ func TestDeleteSpending(t *testing.T) {
 				WithPath("bankAccountId", bank.BankAccountId).
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
-					"bankAccountId":  bank.BankAccountId,
 					"amount":         -10000, // $100
 					"isPending":      false,
 					"name":           "Deposit",
@@ -2618,7 +2613,6 @@ func TestDeleteSpending(t *testing.T) {
 				WithPath("bankAccountId", bank.BankAccountId).
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
-					"bankAccountId":  bank.BankAccountId,
 					"amount":         1000, // $100
 					"isPending":      false,
 					"name":           "Spending from my budget",

--- a/server/controller/transaction_imports.go
+++ b/server/controller/transaction_imports.go
@@ -9,6 +9,7 @@ import (
 	"github.com/monetr/monetr/server/datasources/csv"
 	"github.com/monetr/monetr/server/datasources/csv/csv_jobs"
 	. "github.com/monetr/monetr/server/models"
+	"github.com/monetr/monetr/server/schemas"
 )
 
 func (c *Controller) postTransactionImport(ctx echo.Context) error {
@@ -171,7 +172,7 @@ func (c *Controller) patchTransactionImport(ctx echo.Context) error {
 		c,
 		ctx,
 		existing,
-		existing.PatchSchemas()...,
+		schemas.PatchTransactionImport,
 	)
 	if err != nil {
 		return err
@@ -194,7 +195,7 @@ func (c *Controller) patchTransactionImport(ctx echo.Context) error {
 	if err = repo.UpdateTransactionImport(
 		c.getContext(ctx),
 		bankAccountId,
-		&transactionImport,
+		transactionImport,
 	); err != nil {
 		return c.wrapPgError(ctx, err, "failed to update transaction import")
 	}

--- a/server/controller/transactions.go
+++ b/server/controller/transactions.go
@@ -141,7 +141,7 @@ func (c *Controller) postTransactions(ctx echo.Context) error {
 		return c.invalidJsonError(ctx, err)
 	case nil:
 	default:
-		return c.wrapAndReturnError(ctx, err, http.StatusBadRequest, "failed to parse patch request")
+		return c.badRequestError(ctx, err, "failed to parse request")
 	}
 
 	request.TransactionId = ""
@@ -154,32 +154,6 @@ func (c *Controller) postTransactions(ctx echo.Context) error {
 	request.Category = nil
 	request.Source = TransactionSourceManual
 
-	request.Name, err = c.cleanString(ctx, "Name", request.Name)
-	if err != nil {
-		return err
-	}
-	if request.Name == "" {
-		return c.badRequest(ctx, "Transaction must have a name")
-	}
-
-	request.MerchantName, err = c.cleanString(ctx, "MerchantName", request.MerchantName)
-	if err != nil {
-		return err
-	}
-
-	request.OriginalName, err = c.cleanString(ctx, "OriginalName", request.OriginalName)
-	if err != nil {
-		return err
-	}
-
-	if request.Date.IsZero() {
-		return c.badRequest(ctx, "Transaction must have a date")
-	}
-
-	if request.Amount == 0 {
-		return c.badRequest(ctx, "Transaction must have a non-zero amount")
-	}
-
 	var updatedSpending *Spending
 	if request.SpendingId != nil && !request.SpendingId.IsZero() {
 		updatedSpending, err = repo.GetSpendingById(
@@ -188,7 +162,11 @@ func (c *Controller) postTransactions(ctx echo.Context) error {
 			*request.SpendingId,
 		)
 		if err != nil {
-			return c.wrapPgError(ctx, err, "Could not get spending provided for transaction")
+			return c.wrapPgError(
+				ctx,
+				err,
+				"Could not get spending provided for transaction",
+			)
 		}
 
 		if err = repo.AddExpenseToTransaction(
@@ -196,7 +174,12 @@ func (c *Controller) postTransactions(ctx echo.Context) error {
 			&request.Transaction,
 			updatedSpending,
 		); err != nil {
-			return c.wrapAndReturnError(ctx, err, http.StatusInternalServerError, "failed to add expense to transaction")
+			return c.wrapAndReturnError(
+				ctx,
+				err,
+				http.StatusInternalServerError,
+				"failed to add expense to transaction",
+			)
 		}
 
 		if err = repo.UpdateSpending(c.getContext(ctx), bankAccountId, []Spending{
@@ -229,8 +212,15 @@ func (c *Controller) postTransactions(ctx echo.Context) error {
 		// Note, if balance is ever something monetr has to rely on for ANYTHING
 		// IMPORTANT; then this should be done in a serializable transaction to make
 		// sure that we are properly handling concurrency.
-		if err := repo.UpdateBankAccount(c.getContext(ctx), bankAccount); err != nil {
-			return c.wrapPgError(ctx, err, "could not update bank account balance for transaction")
+		if err := repo.UpdateBankAccount(
+			c.getContext(ctx),
+			bankAccount,
+		); err != nil {
+			return c.wrapPgError(
+				ctx,
+				err,
+				"could not update bank account balance for transaction",
+			)
 		}
 	}
 

--- a/server/controller/transactions.go
+++ b/server/controller/transactions.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"encoding/json"
 	"log/slog"
 	"math"
 	"net/http"
@@ -10,7 +9,6 @@ import (
 	"github.com/labstack/echo/v4"
 	. "github.com/monetr/monetr/server/models"
 	"github.com/monetr/monetr/server/schemas"
-	"github.com/monetr/validation"
 )
 
 func (c *Controller) getTransactions(ctx echo.Context) error {
@@ -125,23 +123,9 @@ func (c *Controller) postTransactions(ctx echo.Context) error {
 		AdjustsBalance bool `json:"adjustsBalance"`
 	}
 
-	request, err = schemas.Parse(
-		c.getContext(ctx),
-		ctx.Request().Body,
-		request,
-		schemas.CreateTransactionSchema,
-	)
-	switch err := err.(type) {
-	case validation.Errors, validation.OneOfError:
-		return ctx.JSON(http.StatusBadRequest, map[string]any{
-			"error":    "Invalid request",
-			"problems": err,
-		})
-	case *json.SyntaxError:
-		return c.invalidJsonError(ctx, err)
-	case nil:
-	default:
-		return c.badRequestError(ctx, err, "failed to parse request")
+	request, err = parse(c, ctx, request, schemas.CreateTransactionSchema)
+	if err != nil {
+		return err
 	}
 
 	request.TransactionId = ""

--- a/server/controller/transactions.go
+++ b/server/controller/transactions.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"encoding/json"
 	"log/slog"
 	"math"
 	"net/http"
@@ -8,6 +9,8 @@ import (
 
 	"github.com/labstack/echo/v4"
 	. "github.com/monetr/monetr/server/models"
+	"github.com/monetr/monetr/server/schemas"
+	"github.com/monetr/validation"
 )
 
 func (c *Controller) getTransactions(ctx echo.Context) error {
@@ -115,14 +118,30 @@ func (c *Controller) postTransactions(ctx echo.Context) error {
 		return c.badRequest(ctx, "Cannot create transactions for non-manual links")
 	}
 
-	var request struct {
+	var request *struct {
 		// Inherit all the fields from the transaction object
 		Transaction
 
 		AdjustsBalance bool `json:"adjustsBalance"`
 	}
-	if err = ctx.Bind(&request); err != nil {
-		return c.invalidJson(ctx)
+
+	request, err = schemas.Parse(
+		c.getContext(ctx),
+		ctx.Request().Body,
+		request,
+		schemas.CreateTransactionSchema,
+	)
+	switch err := err.(type) {
+	case validation.Errors, validation.OneOfError:
+		return ctx.JSON(http.StatusBadRequest, map[string]any{
+			"error":    "Invalid request",
+			"problems": err,
+		})
+	case *json.SyntaxError:
+		return c.invalidJsonError(ctx, err)
+	case nil:
+	default:
+		return c.wrapAndReturnError(ctx, err, http.StatusBadRequest, "failed to parse patch request")
 	}
 
 	request.TransactionId = ""

--- a/server/controller/transactions_test.go
+++ b/server/controller/transactions_test.go
@@ -152,11 +152,17 @@ func TestPostTransactions(t *testing.T) {
 			WithCookie(TestCookieName, token).
 			WithJSON(map[string]any{
 				"amount": 1200,
+				"date":   app.Clock.Now(),
 			}).
 			Expect()
 
 		response.Status(http.StatusBadRequest)
-		response.JSON().Path("$.error").IsEqual("Transaction must have a name")
+		response.JSON().IsEqual(map[string]any{
+			"error": "Invalid request",
+			"problems": map[string]any{
+				"name": "required key is missing",
+			},
+		})
 	})
 
 	t.Run("date is required", func(t *testing.T) {
@@ -171,12 +177,18 @@ func TestPostTransactions(t *testing.T) {
 			WithPath("bankAccountId", bank.BankAccountId).
 			WithCookie(TestCookieName, token).
 			WithJSON(map[string]any{
-				"name": "Foobar",
+				"name":   "Foobar",
+				"amount": 100,
 			}).
 			Expect()
 
 		response.Status(http.StatusBadRequest)
-		response.JSON().Path("$.error").IsEqual("Transaction must have a date")
+		response.JSON().IsEqual(map[string]any{
+			"error": "Invalid request",
+			"problems": map[string]any{
+				"date": "required key is missing",
+			},
+		})
 	})
 
 	t.Run("amount is required", func(t *testing.T) {
@@ -197,7 +209,12 @@ func TestPostTransactions(t *testing.T) {
 			Expect()
 
 		response.Status(http.StatusBadRequest)
-		response.JSON().Path("$.error").IsEqual("Transaction must have a non-zero amount")
+		response.JSON().IsEqual(map[string]any{
+			"error": "Invalid request",
+			"problems": map[string]any{
+				"amount": "required key is missing",
+			},
+		})
 	})
 
 	t.Run("bogus spending object", func(t *testing.T) {
@@ -254,7 +271,6 @@ func TestPostTransactions(t *testing.T) {
 				WithPath("bankAccountId", bank.BankAccountId).
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
-					"bankAccountId":  bank.BankAccountId,
 					"amount":         100, // $1
 					"isPending":      false,
 					"name":           "I spent some money",
@@ -274,7 +290,6 @@ func TestPostTransactions(t *testing.T) {
 				WithPath("bankAccountId", bank.BankAccountId).
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
-					"bankAccountId":  bank.BankAccountId,
 					"amount":         -200, // Earned $2
 					"isPending":      false,
 					"name":           "I earned some money",
@@ -323,7 +338,6 @@ func TestPostTransactions(t *testing.T) {
 				WithPath("bankAccountId", bank.BankAccountId).
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
-					"bankAccountId":  bank.BankAccountId,
 					"amount":         100, // $1
 					"isPending":      false,
 					"name":           "I spent some money",
@@ -360,7 +374,6 @@ func TestPostTransactions(t *testing.T) {
 				WithPath("bankAccountId", bank.BankAccountId).
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
-					"bankAccountId":  bank.BankAccountId,
 					"amount":         100, // $1
 					"isPending":      false,
 					"name":           "I spent some money",
@@ -371,6 +384,41 @@ func TestPostTransactions(t *testing.T) {
 
 			response.Status(http.StatusBadRequest)
 			response.JSON().Path("$.error").IsEqual("Cannot create transactions for non-manual links")
+		}
+	})
+
+	t.Run("nil fields", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		var token string
+		var bank BankAccount
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+
+		{ // Seed the data for the test.
+			link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+			bank = fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+			fixtures.GivenIHaveNTransactions(t, app.Clock, bank, 10)
+
+			token = GivenILogin(t, e, user.Login.Email, password)
+		}
+
+		{ // Now create our transaction and have it linked to our expense
+			response := e.POST("/api/bank_accounts/{bankAccountId}/transactions").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithCookie(TestCookieName, token).
+				WithJSON(map[string]any{
+					"amount":         100, // $1
+					"isPending":      false,
+					"name":           "I spent some money",
+					"date":           app.Clock.Now(), // Should use midnight, but idc
+					"adjustsBalance": false,
+					"spendingId":     nil,
+					"merchantName":   nil,
+				}).
+				Expect()
+
+			response.Status(http.StatusOK)
+			response.JSON().Path("$.transaction.transactionId").String().NotEmpty()
+			response.JSON().Object().Keys().IsEqual([]string{"balance", "transaction"})
 		}
 	})
 
@@ -443,7 +491,6 @@ func TestPostTransactions(t *testing.T) {
 				WithPath("bankAccountId", bank.BankAccountId).
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
-					"bankAccountId":  bank.BankAccountId,
 					"amount":         100, // $1
 					"isPending":      false,
 					"name":           "I spent some money",
@@ -539,7 +586,6 @@ func TestPostTransactions(t *testing.T) {
 				WithPath("bankAccountId", bankAccountId).
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
-					"bankAccountId":  bankAccountId,
 					"amount":         100, // $1
 					"isPending":      false,
 					"name":           "I spent some money",
@@ -973,7 +1019,6 @@ func TestDeleteTransactions(t *testing.T) {
 				WithPath("bankAccountId", bank.BankAccountId).
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
-					"bankAccountId":  bank.BankAccountId,
 					"amount":         200, // Spent $2
 					"isPending":      false,
 					"name":           "I spent money",
@@ -1064,7 +1109,6 @@ func TestDeleteTransactions(t *testing.T) {
 				WithPath("bankAccountId", bank.BankAccountId).
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
-					"bankAccountId":  bank.BankAccountId,
 					"amount":         200, // Spent $2
 					"isPending":      false,
 					"name":           "I spent money",
@@ -1222,7 +1266,6 @@ func TestDeleteTransactions(t *testing.T) {
 				WithPath("bankAccountId", bank.BankAccountId).
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
-					"bankAccountId":  bank.BankAccountId,
 					"amount":         200, // Spent $2
 					"isPending":      false,
 					"name":           "I spent money",
@@ -1404,7 +1447,6 @@ func TestDeleteTransactions(t *testing.T) {
 				WithPath("bankAccountId", bank.BankAccountId).
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
-					"bankAccountId":  bank.BankAccountId,
 					"amount":         200, // Spent $2
 					"isPending":      false,
 					"name":           "I spent money",

--- a/server/datasources/table/amount.go
+++ b/server/datasources/table/amount.go
@@ -72,7 +72,7 @@ func (s *AmountSpec) Validate(ctx context.Context) error {
 			validation.Field(
 				&s.Fields,
 				validation.Each(
-					validators.By(func(ctx context.Context, field FieldRef) error {
+					validators.By(func(ctx context.Context, field *FieldRef) error {
 						return field.Validate(ctx)
 					}),
 				),
@@ -105,7 +105,7 @@ func (s *AmountSpec) Validate(ctx context.Context) error {
 			validation.Field(
 				&s.Fields,
 				validation.Each(
-					validators.By(func(ctx context.Context, field FieldRef) error {
+					validators.By(func(ctx context.Context, field *FieldRef) error {
 						return field.Validate(ctx)
 					}),
 				),
@@ -144,7 +144,7 @@ func (s *AmountSpec) Validate(ctx context.Context) error {
 			validation.Field(
 				&s.Fields,
 				validation.Each(
-					validators.By(func(ctx context.Context, field FieldRef) error {
+					validators.By(func(ctx context.Context, field *FieldRef) error {
 						return field.Validate(ctx)
 					}),
 				),

--- a/server/datasources/table/balance.go
+++ b/server/datasources/table/balance.go
@@ -63,7 +63,7 @@ func (s *BalanceSpec) Validate(ctx context.Context) error {
 			validation.Field(
 				&s.Fields,
 				validation.Each(
-					validators.By(func(ctx context.Context, field FieldRef) error {
+					validators.By(func(ctx context.Context, field *FieldRef) error {
 						return field.Validate(ctx)
 					}),
 				),

--- a/server/datasources/table/date.go
+++ b/server/datasources/table/date.go
@@ -27,7 +27,7 @@ func (s *DateSpec) Validate(ctx context.Context) error {
 			validation.Field(
 				&s.Fields,
 				validation.Each(
-					validators.By(func(ctx context.Context, field FieldRef) error {
+					validators.By(func(ctx context.Context, field *FieldRef) error {
 						return field.Validate(ctx)
 					}),
 				),

--- a/server/datasources/table/id.go
+++ b/server/datasources/table/id.go
@@ -48,7 +48,7 @@ func (s *IDSpec) Validate(ctx context.Context) error {
 			validation.Field(
 				&s.Fields,
 				validation.Each(
-					validators.By(func(ctx context.Context, field FieldRef) error {
+					validators.By(func(ctx context.Context, field *FieldRef) error {
 						return field.Validate(ctx)
 					}),
 				),

--- a/server/datasources/table/mapping.go
+++ b/server/datasources/table/mapping.go
@@ -38,21 +38,21 @@ func (m *Mapping) Validate(ctx context.Context) error {
 			m,
 			validation.Field(
 				&m.ID,
-				validators.By(func(ctx context.Context, field IDSpec) error {
+				validators.By(func(ctx context.Context, field *IDSpec) error {
 					return field.Validate(ctx)
 				}),
 				validation.Required,
 			),
 			validation.Field(
 				&m.Amount,
-				validators.By(func(ctx context.Context, field AmountSpec) error {
+				validators.By(func(ctx context.Context, field *AmountSpec) error {
 					return field.Validate(ctx)
 				}),
 				validation.Required,
 			),
 			validation.Field(
 				&m.Memo,
-				validators.By(func(ctx context.Context, field FieldRef) error {
+				validators.By(func(ctx context.Context, field *FieldRef) error {
 					return field.Validate(ctx)
 				}),
 				validation.Required,
@@ -68,7 +68,7 @@ func (m *Mapping) Validate(ctx context.Context) error {
 			),
 			validation.Field(
 				&m.Date,
-				validators.By(func(ctx context.Context, field DateSpec) error {
+				validators.By(func(ctx context.Context, field *DateSpec) error {
 					return field.Validate(ctx)
 				}),
 				validation.Required,
@@ -84,7 +84,7 @@ func (m *Mapping) Validate(ctx context.Context) error {
 			),
 			validation.Field(
 				&m.Balance,
-				validators.By(func(ctx context.Context, field BalanceSpec) error {
+				validators.By(func(ctx context.Context, field *BalanceSpec) error {
 					return field.Validate(ctx)
 				}),
 				validation.Required,

--- a/server/datasources/table/mapping_test.go
+++ b/server/datasources/table/mapping_test.go
@@ -230,7 +230,7 @@ func TestMapping_Validate(t *testing.T) {
 			if tc.wantErr == "" {
 				assert.NoError(t, err, "Mapping must be accepted")
 			} else {
-				assert.EqualError(t, err, tc.wantErr, "Mapping must be rejected with the expected message")
+				assert.EqualErrorf(t, err, tc.wantErr, "Mapping must be rejected with the expected message, wanted: %s", tc.wantErr)
 			}
 		})
 	}

--- a/server/datasources/table/posted.go
+++ b/server/datasources/table/posted.go
@@ -28,7 +28,7 @@ func (s *PostedSpec) Validate(ctx context.Context) error {
 			validation.Field(
 				&s.Fields,
 				validation.Each(
-					validators.By(func(ctx context.Context, field FieldRef) error {
+					validators.By(func(ctx context.Context, field *FieldRef) error {
 						return field.Validate(ctx)
 					}),
 				),

--- a/server/merge/merge.go
+++ b/server/merge/merge.go
@@ -40,32 +40,47 @@ func Merge[T any](dst *T, src map[string]any, options ...MergeOption) error {
 }
 
 type mergeContext struct {
-	dst        reflect.Value
-	src        map[string]any
-	options    MergeOption
-	fields     []reflect.Value
-	fieldsFold map[string]int
+	dst     reflect.Value
+	src     map[string]any
+	options MergeOption
+	fields  map[string]reflect.Value
 }
 
 func (m *mergeContext) buildFieldMap(dst reflect.Value) error {
 	switch dst.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		// Most likely this will be a pointer first, so we go down a level in order
 		// to work with the actual underlying type. Which _should_ be a struct in
 		// this case.
 		return m.buildFieldMap(dst.Elem())
 	case reflect.Struct:
-		numField := dst.NumField()
-		m.fields = make([]reflect.Value, numField)
-		m.fieldsFold = make(map[string]int, numField)
-		for i := range numField {
-			field := dst.Field(i)
-			name := dst.Type().Field(i).Name
-			m.fields[i] = field
-			m.fieldsFold[strings.ToLower(name)] = i
-		}
+		return m.mapStruct(dst)
 	default:
 		return errors.Errorf("cannot build field map for destination of type: %s", dst.Type())
+	}
+}
+
+func (m *mergeContext) mapStruct(dst reflect.Value) error {
+	numField := dst.NumField()
+	for i := range numField {
+		field := dst.Field(i)
+		structField := dst.Type().Field(i)
+
+		// If the field is a nested/embedded struct then recursively add those
+		// fields to the map
+		if structField.Anonymous && structField.Type.Kind() == reflect.Struct {
+			if err := m.mapStruct(field); err != nil {
+				return err
+			}
+			continue
+		}
+
+		name := strings.ToLower(structField.Name)
+		if _, ok := m.fields[name]; ok {
+			return errors.Errorf("duplicate field in destination struct: %s", structField.Name)
+		}
+
+		m.fields[name] = field
 	}
 	return nil
 }
@@ -77,17 +92,17 @@ func (m *mergeContext) merge() error {
 
 	// Before we do anything we need to build our field map so we have something
 	// to work with.
+	m.fields = make(map[string]reflect.Value)
 	if err := m.buildFieldMap(m.dst); err != nil {
 		return err
 	}
 
 	for key, value := range m.src {
 		keyFold := strings.ToLower(key)
-		dstFieldIndex, ok := m.fieldsFold[keyFold]
+		dstField, ok := m.fields[keyFold]
 		if !ok && m.options&ErrorOnUnknownField > 0 {
 			return errors.Errorf("cannot assign field '%s' to destination", key)
 		}
-		dstField := m.fields[dstFieldIndex]
 
 		srcValue := reflect.ValueOf(value)
 
@@ -125,7 +140,7 @@ func (m *mergeContext) merge() error {
 			// If the destination is a pointer then we need to set the inner value
 			// instead of the value of the pointer.
 			if dstField.Kind() == reflect.Pointer {
-				newValue := reflect.New(reflect.TypeOf(value))
+				newValue := reflect.New(reflect.TypeFor[int64]())
 				newValue.Elem().Set(reflect.ValueOf(value))
 				dstField.Set(newValue)
 			} else {

--- a/server/merge/merge_test.go
+++ b/server/merge/merge_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/teambition/rrule-go"
 )
 
+type Embedded struct {
+	Name   string `json:"name"`
+	Amount int64  `json:"amount"`
+}
+
 func TestMerge(t *testing.T) {
 	t.Run("cannot merge into a non struct", func(t *testing.T) {
 		var dst int
@@ -63,6 +68,48 @@ func TestMerge(t *testing.T) {
 		err := merge.Merge(&dst, src)
 		assert.NoError(t, err, "Must be able to merge with pointers in the struct")
 		assert.Equal(t, src["bar"], *dst.Bar, "the source and destination fields should now match!")
+	})
+
+	t.Run("merge embedded struct fields", func(t *testing.T) {
+		type Foo struct {
+			Embedded
+
+			AdjustsBalance bool `json:"adjustsBalance"`
+		}
+
+		dst := Foo{}
+		src := map[string]any{
+			"name":           "this is a string",
+			"amount":         json.Number("12345"),
+			"adjustsBalance": true,
+		}
+
+		err := merge.Merge(&dst, src)
+		assert.NoError(t, err, "Must be able to merge into the promoted fields of an embedded struct")
+		assert.Equal(t, src["name"], dst.Name, "the promoted name field should be merged")
+		assert.EqualValues(t, 12345, dst.Amount, "the promoted amount field should be merged")
+		assert.True(t, dst.AdjustsBalance, "the wrapper's own field should be merged")
+	})
+
+	t.Run("merge embedded struct fields handle duplicate", func(t *testing.T) {
+		type Foo struct {
+			Embedded
+
+			// Duplicate of field on embedded
+			Name           string
+			AdjustsBalance bool `json:"adjustsBalance"`
+		}
+
+		dst := Foo{}
+		src := map[string]any{
+			"name":           "this is a string",
+			"amount":         json.Number("12345"),
+			"adjustsBalance": true,
+		}
+
+		err := merge.Merge(&dst, src)
+		assert.EqualError(t, err, "duplicate field in destination struct: Name")
+		assert.Empty(t, dst)
 	})
 
 	t.Run("merge using json.Unmarshaller", func(t *testing.T) {

--- a/server/models/funding_schedule.go
+++ b/server/models/funding_schedule.go
@@ -191,42 +191,6 @@ func (o *FundingSchedule) CalculateNextOccurrence(
 	return true
 }
 
-func (FundingSchedule) CreateValidators() []*validation.KeyRules[string] {
-	return []*validation.KeyRules[string]{
-		// validation.Key(
-		// 	"bankAccountId",
-		// 	validation.Required.Error("Must specify a bank account ID"),
-		// 	ValidID[BankAccount]().Error("Bank account ID specified is not valid"),
-		// ).Required(validators.Optional),
-		validators.Name(validators.Require),
-		validators.Description(),
-		validation.Key(
-			"ruleset",
-			validation.Required.Error("Ruleset must be specified for funding schedules"),
-			validation.NewStringRule(func(input string) bool {
-				_, err := NewRuleSet(input)
-				return err == nil
-			}, "Ruleset must be valid"),
-		).Required(validators.Require),
-		validation.Key(
-			"excludeWeekends",
-			validation.In(true, false).Error("Exclude weekends must be a valid boolean"),
-		).Required(validators.Optional),
-		validation.Key(
-			"autoCreateTransaction",
-			validation.In(true, false).Error("Auto create transaction must be a valid boolean"),
-		).Required(validators.Optional),
-		validation.Key(
-			"estimatedDeposit",
-			validation.Min(float64(0)).Error("Estimated deposit cannot be less than 0"),
-		).Required(validators.Optional),
-		validation.Key(
-			"nextRecurrence",
-			validation.Date(time.RFC3339).Min(time.Now()).Error("Next recurrence must be in the future"),
-		).Required(validators.Optional),
-	}
-}
-
 func (FundingSchedule) UpdateValidators() []*validation.KeyRules[string] {
 	return []*validation.KeyRules[string]{
 		validators.Name(validators.Optional),

--- a/server/models/transaction_imports.go
+++ b/server/models/transaction_imports.go
@@ -5,8 +5,6 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
-	"github.com/monetr/monetr/server/validators"
-	"github.com/monetr/validation"
 )
 
 // TransactionImportStatus covers all of the different states of a transaction
@@ -85,31 +83,4 @@ func (o *TransactionImport) BeforeInsert(ctx context.Context) (context.Context, 
 	}
 
 	return ctx, nil
-}
-
-func (TransactionImport) PatchSchemas() []validation.MapRule[string] {
-	return []validation.MapRule[string]{
-		// When we do not yet have a mapping then they must specify a new mapping ID
-		// and say that we are moving to the pending preview status.
-		validation.Map(
-			validation.Key(
-				"transactionImportMappingId",
-				ValidID[TransactionImportMapping]().Error("Transaction import mapping ID must be valid if provided"),
-				validation.Required,
-			),
-			validation.Key(
-				"status",
-				validators.In(string(TransactionImportStatusPendingPreview)),
-				validation.Required,
-			),
-		),
-		// Otherwise the user can only progress the import to pending processing.
-		validation.Map(
-			validation.Key(
-				"status",
-				validators.In(string(TransactionImportStatusPendingProcessing)),
-				validation.Required,
-			),
-		),
-	}
 }

--- a/server/schemas/amount.go
+++ b/server/schemas/amount.go
@@ -34,22 +34,22 @@ func Amount() validation.Rule {
 	})
 }
 
-func PositiveAmount() validation.Rule {
+func PositiveAmount(prefix string) validation.Rule {
 	return validators.By[any](func(ctx context.Context, value *any) error {
 		if value == nil {
-			return errors.New("amount is not a valid integer")
+			return errors.Errorf("%s is not a valid integer", prefix)
 		}
 		switch value := (*value).(type) {
 		case json.Number:
 			if jint, err := value.Int64(); err != nil {
-				return errors.New("amount is not a valid integer")
+				return errors.Errorf("%s is not a valid integer", prefix)
 			} else if jint <= 0 {
-				return errors.New("amount must be greater than zero")
+				return errors.Errorf("%s must be greater than zero", prefix)
 			}
 
 			return nil
 		default:
-			return errors.New("amount is not a valid integer")
+			return errors.Errorf("%s is not a valid integer", prefix)
 		}
 	})
 }

--- a/server/schemas/amount.go
+++ b/server/schemas/amount.go
@@ -1,0 +1,55 @@
+package schemas
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/monetr/monetr/server/validators"
+	"github.com/monetr/validation"
+	"github.com/pkg/errors"
+)
+
+func Amount() validation.Rule {
+	return validators.By[any](func(ctx context.Context, value *any) error {
+		if value == nil {
+			return errors.New("Amount is not a valid integer")
+		}
+		switch value := (*value).(type) {
+		case json.Number:
+			if jint, err := value.Int64(); err != nil {
+				return errors.New("Amount is not a valid integer")
+			} else if jint == 0 {
+				return errors.New("Amount cannot be zero")
+			}
+
+			return nil
+		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+			if value == 0 {
+				return errors.New("Amount cannot be zero")
+			}
+			return nil
+		default:
+			return errors.New("Amount is not a valid integer")
+		}
+	})
+}
+
+func PositiveAmount() validation.Rule {
+	return validators.By[any](func(ctx context.Context, value *any) error {
+		if value == nil {
+			return errors.New("amount is not a valid integer")
+		}
+		switch value := (*value).(type) {
+		case json.Number:
+			if jint, err := value.Int64(); err != nil {
+				return errors.New("amount is not a valid integer")
+			} else if jint <= 0 {
+				return errors.New("amount must be greater than zero")
+			}
+
+			return nil
+		default:
+			return errors.New("amount is not a valid integer")
+		}
+	})
+}

--- a/server/schemas/funding_schedule.go
+++ b/server/schemas/funding_schedule.go
@@ -1,0 +1,41 @@
+package schemas
+
+import (
+	"time"
+
+	"github.com/monetr/monetr/server/models"
+	"github.com/monetr/monetr/server/validators"
+	"github.com/monetr/validation"
+)
+
+var (
+	CreateFundingSchedule = validation.Map(
+		validators.Name(validators.Require),
+		validators.Description(),
+		validation.Key(
+			"ruleset",
+			validation.Required.Error("Ruleset must be specified for funding schedules"),
+			validation.NewStringRule(func(input string) bool {
+				_, err := models.NewRuleSet(input)
+				return err == nil
+			}, "Ruleset must be valid"),
+		).Required(validators.Require),
+		validation.Key(
+			"excludeWeekends",
+			validation.In(true, false).Error("Exclude weekends must be a valid boolean"),
+		).Required(validators.Optional),
+		validation.Key(
+			"autoCreateTransaction",
+			validation.In(true, false).Error("Auto create transaction must be a valid boolean"),
+		).Required(validators.Optional),
+		validation.Key(
+			"estimatedDeposit",
+			PositiveAmount("Estimated deposit"),
+			validation.Min(float64(0)).Error("Estimated deposit cannot be less than 0"),
+		).Required(validators.Optional),
+		validation.Key(
+			"nextRecurrence",
+			validation.Date(time.RFC3339).Error("Next recurrence must be in the future"),
+		).Required(validators.Optional),
+	)
+)

--- a/server/schemas/id.go
+++ b/server/schemas/id.go
@@ -1,0 +1,30 @@
+package schemas
+
+import (
+	"context"
+
+	"github.com/monetr/monetr/server/models"
+	"github.com/monetr/monetr/server/validators"
+	"github.com/monetr/validation"
+	"github.com/pkg/errors"
+)
+
+func ValidID[T models.Identifiable]() validation.Rule {
+	prefix := (*new(T)).IdentityPrefix()
+	return validators.By(func(ctx context.Context, value *any) error {
+		if value == nil {
+			return errors.Errorf("id does not match format %s_...", prefix)
+		}
+		switch value := (*value).(type) {
+		case string:
+			_, err := models.ParseID[T](value)
+			if err != nil {
+				return errors.Errorf("id does not match format %s_...", prefix)
+			}
+
+			return nil
+		default:
+			return errors.Errorf("id does not match format %s_...", prefix)
+		}
+	})
+}

--- a/server/schemas/login.go
+++ b/server/schemas/login.go
@@ -1,0 +1,20 @@
+package schemas
+
+import (
+	"github.com/monetr/validation"
+	"github.com/monetr/validation/is"
+)
+
+var (
+	LoginSchema = validation.Map(
+		validation.Key("email",
+			is.EmailFormat.Error("Email address is not valid"),
+			validation.Required,
+		),
+		validation.Key("password",
+			is.PrintableUnicode.Error("Password must be printable characters"),
+			validation.Length(8, 72).Error("Password must be between 8 and 72 characters"),
+			validation.Required,
+		),
+	)
+)

--- a/server/schemas/schemas.go
+++ b/server/schemas/schemas.go
@@ -1,0 +1,45 @@
+package schemas
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+
+	"github.com/monetr/monetr/server/merge"
+	"github.com/monetr/validation"
+	"github.com/pkg/errors"
+)
+
+func Parse[T any](
+	ctx context.Context,
+	reader io.Reader,
+	baseData *T,
+	schema validation.Rule,
+) (*T, error) {
+	rawData := map[string]any{}
+	decoder := json.NewDecoder(reader)
+	decoder.UseNumber()
+	if err := decoder.Decode(&rawData); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	if err := validation.ValidateWithContext(
+		ctx,
+		&rawData,
+		schema,
+	); err != nil {
+		return nil, err
+	}
+
+	var output T
+	if baseData != nil {
+		output = *baseData
+	}
+	if err := merge.Merge(
+		&output, rawData, merge.ErrorOnUnknownField,
+	); err != nil {
+		return nil, errors.Wrap(err, "failed to merge patched data")
+	}
+
+	return &output, nil
+}

--- a/server/schemas/transaction.go
+++ b/server/schemas/transaction.go
@@ -1,0 +1,47 @@
+package schemas
+
+import (
+	"time"
+
+	"github.com/monetr/monetr/server/models"
+	"github.com/monetr/validation"
+	"github.com/monetr/validation/is"
+)
+
+var (
+	CreateTransactionSchema = validation.Map(
+		validation.Key("name",
+			is.PrintableUnicode.Error("Name must be printable unicode"),
+			validation.Length(1, 300).Error("Name cannot be longer than 300 characters"),
+			validation.Required.Error("Name is required"),
+		),
+		validation.Key("merchantName",
+			is.PrintableUnicode.Error("Merchant name must be printable unicode"),
+			validation.Length(0, 300).Error("Merchant name cannot be longer than 300 characters"),
+		).Required(false),
+		validation.Key("date",
+			validation.Date(time.RFC3339).Error("Date must be in a valid format"),
+			validation.Required.Error("Date is required"),
+		),
+		validation.Key("amount",
+			Amount(),
+			validation.NotEq(0).Error("Amount cannot be 0"),
+			validation.Required.Error("Amount is required"),
+		),
+		validation.Key("spendingId",
+			validation.OneOf(
+				ValidID[models.Spending](),
+				validation.Nil,
+			),
+		).Required(false),
+		validation.Key("adjustsBalance",
+			validation.OneOf(
+				validation.In(true, false).Error("Adjusts balance must be a valid boolean if specified"),
+				validation.Never.Error("Validation must be not be specified or must be a valid boolean"),
+			),
+		).Required(false),
+		validation.Key("isPending",
+			validation.In(true, false).Error("Is pending must be a valid boolean if provided"),
+		).Required(false),
+	)
+)

--- a/server/schemas/transaction_import.go
+++ b/server/schemas/transaction_import.go
@@ -1,0 +1,34 @@
+package schemas
+
+import (
+	"github.com/monetr/monetr/server/models"
+	"github.com/monetr/monetr/server/validators"
+	"github.com/monetr/validation"
+)
+
+var (
+	PatchTransactionImport = validation.OneOf(
+		// When we do not yet have a mapping then they must specify a new mapping ID
+		// and say that we are moving to the pending preview status.
+		validation.Map(
+			validation.Key(
+				"transactionImportMappingId",
+				ValidID[models.TransactionImportMapping](),
+				validation.Required,
+			),
+			validation.Key(
+				"status",
+				validators.In(string(models.TransactionImportStatusPendingPreview)),
+				validation.Required,
+			),
+		),
+		// Otherwise the user can only progress the import to pending processing.
+		validation.Map(
+			validation.Key(
+				"status",
+				validators.In(string(models.TransactionImportStatusPendingProcessing)),
+				validation.Required,
+			),
+		),
+	)
+)

--- a/server/validators/custom.go
+++ b/server/validators/custom.go
@@ -8,29 +8,37 @@ import (
 )
 
 type inlineRule[T any] struct {
-	f func(ctx context.Context, value T) error
+	f func(ctx context.Context, value *T) error
 }
 
 // ValidateWithContext implements [validation.Rule].
 func (i *inlineRule[T]) Validate(value any) error {
-	return i.f(context.Background(), value.(T))
+	return i.ValidateWithContext(context.Background(), value)
 }
 
 // ValidateWithContext implements [validation.RuleWithContext].
 func (i *inlineRule[T]) ValidateWithContext(ctx context.Context, value any) error {
-	return i.f(ctx, value.(T))
+	val, ok := value.(T)
+	if !ok {
+		return i.f(ctx, nil)
+	}
+
+	return i.f(ctx, &val)
 }
 
-func By[T any](callback func(ctx context.Context, value T) error) validation.Rule {
+func By[T any](callback func(ctx context.Context, value *T) error) validation.Rule {
 	return &inlineRule[T]{
 		f: callback,
 	}
 }
 
 func Unique[T comparable]() validation.Rule {
-	return By(func(ctx context.Context, fields []T) error {
-		seen := make(map[T]struct{}, len(fields))
-		for i, f := range fields {
+	return By(func(ctx context.Context, fields *[]T) error {
+		if fields == nil {
+			return nil
+		}
+		seen := make(map[T]struct{}, len(*fields))
+		for i, f := range *fields {
 			if _, dup := seen[f]; dup {
 				return errors.Errorf("fields[%d] is a duplicate of an earlier entry", i)
 			}

--- a/server/validators/custom.go
+++ b/server/validators/custom.go
@@ -18,12 +18,17 @@ func (i *inlineRule[T]) Validate(value any) error {
 
 // ValidateWithContext implements [validation.RuleWithContext].
 func (i *inlineRule[T]) ValidateWithContext(ctx context.Context, value any) error {
-	val, ok := value.(T)
-	if !ok {
+	switch v := value.(type) {
+	case *T:
+		// Pointer struct fields arrive already as a *T (the validation library
+		// hands us the field value verbatim). Pass it through; it may be nil.
+		return i.f(ctx, v)
+	case T:
+		// Value fields arrive as a T; wrap it so the callback always sees a *T.
+		return i.f(ctx, &v)
+	default:
 		return i.f(ctx, nil)
 	}
-
-	return i.f(ctx, &val)
 }
 
 func By[T any](callback func(ctx context.Context, value *T) error) validation.Rule {

--- a/server/validators/in.go
+++ b/server/validators/in.go
@@ -29,7 +29,7 @@ func (i *inRule[T]) Validate(value any) error {
 // "cannot be blank"; this rule speaks up only when the caller supplied a value
 // that wasn't in the allowed set.
 func (i *inRule[T]) ValidateWithContext(ctx context.Context, value any) error {
-	value, isNil := validation.Indirect(value)
+	value, isNil, _ := validation.Indirect(value)
 	if isNil || validation.IsEmpty(value) {
 		return nil
 	}


### PR DESCRIPTION
This is a proof of concept PR for doing schema validation using just
monetr/validation instead of zog or json schemas.

It also surfaces errors returned from the API for schema validation back
into the form that submitted them, allowing for improved error feedback
to users in some situations.
