### PR TITLE
feat(api): Allow email domains to be blocked by config

### DIFF
--- a/.github/dictionary.txt
+++ b/.github/dictionary.txt
@@ -18,11 +18,11 @@ CORS
 CSI
 CSP
 CSV
-Crypto
 Chatwoot
 Chisago
 CloudNativePG
 ConfigMap
+Crypto
 DBSCAN
 DNS
 DNT
@@ -107,6 +107,7 @@ YAML
 anonymized?
 automations
 backend
+blocklist
 build-time
 captcha
 centroid

--- a/docs/src/v1/en/documentation/configure.mdx
+++ b/docs/src/v1/en/documentation/configure.mdx
@@ -61,6 +61,10 @@ allowSignUp: true
 email:
   enabled: false
   domain: "" # Does not need to match your `externalUrl` domain.
+  # # Email domains that are not allowed to sign up for a new account. Only affects
+  # # sign up, not sign in. See the Email configuration guide for more detail.
+  # blockedDomains:
+  #   - mailinator.com
   verification:
     enabled: false
     tokenLifetime: 10m

--- a/docs/src/v1/en/documentation/configure/email.mdx
+++ b/docs/src/v1/en/documentation/configure/email.mdx
@@ -18,22 +18,49 @@ Below is an example of the email/SMTP configuration block:
 email:
   enabled: true
   domain: "example.com"
+  blockedDomains: [ ... ] # Email domains not allowed to sign up (sign up only)
   verification: { ... }   # Email verification configuration
   forgotPassword: { ... } # Password reset via email link
   smtp: { ... }           # SMTP configuration
 ```
 
-| **Name**  | **Type** | **Default** | **Description**                                                                                                                   |
-| ---       | ---      | ---         | ---                                                                                                                               |
-| `enabled` | Boolean  | `false`     | Are email notifications enabled on this server?                                                                                   |
-| `domain`  | String   |             | Email domain used to send emails, emails will always be sent from `no-reply@{DOMAIN}`. Do not provide a full URL with a protocol. |
+| **Name**         | **Type** | **Default** | **Description**                                                                                                                                              |
+| ---              | ---      | ---         | ---                                                                                                                                                          |
+| `enabled`        | Boolean  | `false`     | Are email notifications enabled on this server?                                                                                                              |
+| `domain`         | String   |             | Email domain used to send emails, emails will always be sent from `no-reply@{DOMAIN}`. Do not provide a full URL with a protocol.                            |
+| `blockedDomains` | List     |             | Email domains that are not allowed to sign up for a new account. Only affects sign up, not sign in. See [Blocked Sign Up Domains](#blocked-sign-up-domains). |
 
 The following environment variables map to the following configuration file fields. Each field is documented below.
 
-| Variable               | Config File Field |
-| ---                    | ---               |
-| `MONETR_EMAIL_ENABLED` | `email.enabled`   |
-| `MONETR_EMAIL_DOMAIN`  | `email.domain`    |
+| Variable                       | Config File Field      |
+| ---                            | ---                    |
+| `MONETR_EMAIL_ENABLED`         | `email.enabled`        |
+| `MONETR_EMAIL_DOMAIN`          | `email.domain`         |
+| `MONETR_EMAIL_BLOCKED_DOMAINS` | `email.blockedDomains` |
+
+## Blocked Sign Up Domains
+
+If you want to keep certain email domains (such as disposable or throwaway email providers) from being used to create
+new accounts, add them to `blockedDomains`. This only restricts **sign up**, an account that already exists on one of
+these domains can still sign in, reset its password, and verify its email. It works regardless of whether email sending
+is `enabled`, it does not require SMTP to be configured.
+
+The match is case insensitive and matches the domain exactly, so blocking `example.com` does not block
+`mail.example.com`. An empty list (the default) disables the feature.
+
+When someone tries to sign up with a blocked domain monetr intentionally returns the same "email already in use" error
+that it returns for an address that is already registered. This is so the blocklist is not disclosed to people signing
+up. The actual reason, including which domain was blocked, is recorded in the server logs.
+
+```yaml title="config.yaml"
+email:
+  blockedDomains:
+    - mailinator.com
+    - guerrillamail.com
+```
+
+When set via the environment variable the domains are comma separated, for example
+`MONETR_EMAIL_BLOCKED_DOMAINS=mailinator.com,guerrillamail.com`.
 
 ## Email Verification Configuration
 

--- a/server/config/configuration.go
+++ b/server/config/configuration.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/monetr/monetr/server/util"
@@ -136,6 +137,13 @@ type Email struct {
 	// Email is sent via SMTP. If you want to send emails it is required to
 	// include an SMTP configuration.
 	SMTP SMTPClient `yaml:"smtp"`
+	// BlockedDomains is the set of email domains that are NOT allowed to sign up
+	// for a new account on this server. This only restricts sign up. Existing
+	// users on one of these domains can still sign in, reset their password and
+	// verify their email. An empty list turns the feature off. This applies even
+	// when email sending (`enabled`) is turned off, it has nothing to do with
+	// SMTP being configured.
+	BlockedDomains []string `yaml:"blockedDomains"`
 }
 
 type EmailVerification struct {
@@ -169,6 +177,51 @@ func (s Email) ShouldVerifyEmails() bool {
 
 func (s Email) AllowPasswordReset() bool {
 	return s.Enabled && s.ForgotPassword.Enabled
+}
+
+// BlockedEmailDomain returns the normalized domain portion of the email address
+// along with true when that domain is on the sign up blocklist. When it is not
+// blocked (no blocklist, no domain, or just not a match) it returns "", false.
+// We hand the domain back so the caller can log which domain got blocked
+// without having to parse the address a second time. We only call this during
+// sign up so an operator can keep throwaway/disposable email providers from
+// creating accounts. The comparison is case insensitive and matches the domain
+// exactly, blocking `example.com` does NOT block `mail.example.com`.
+// TODO Should we match subdomains too? For a disposable email blocklist an
+// exact match is usually what you want, revisit this if someone needs the
+// allow-list style behavior instead.
+func (s Email) BlockedEmailDomain(emailAddress string) (string, bool) {
+	if len(s.BlockedDomains) == 0 {
+		return "", false
+	}
+
+	// The register controller only trims the email, it does not lowercase it
+	// until the login is actually created, so normalize it ourselves here.
+	emailAddress = strings.ToLower(strings.TrimSpace(emailAddress))
+	at := strings.LastIndex(emailAddress, "@")
+	if at < 0 {
+		return "", false
+	}
+	domain := emailAddress[at+1:]
+	if domain == "" {
+		return "", false
+	}
+
+	for i := range s.BlockedDomains {
+		// Be forgiving about how the operator wrote the entry, they might have
+		// included an @ or some stray whitespace or casing.
+		blocked := strings.TrimPrefix(
+			strings.ToLower(
+				strings.TrimSpace(s.BlockedDomains[i]),
+			),
+			"@",
+		)
+		if blocked != "" && domain == blocked {
+			return domain, true
+		}
+	}
+
+	return "", false
 }
 
 // ProofOfWork gates the unauthenticated auth endpoints (register, login, forgot
@@ -436,6 +489,7 @@ func setupEnv(v *viper.Viper) {
 	v.MustBindEnv("Email.SMTP.Password", "MONETR_EMAIL_SMTP_PASSWORD")
 	v.MustBindEnv("Email.SMTP.Host", "MONETR_EMAIL_SMTP_HOST")
 	v.MustBindEnv("Email.SMTP.Port", "MONETR_EMAIL_SMTP_PORT")
+	v.MustBindEnv("Email.BlockedDomains", "MONETR_EMAIL_BLOCKED_DOMAINS")
 	v.MustBindEnv("Logging.Level", "MONETR_LOG_LEVEL")
 	v.MustBindEnv("Logging.Format", "MONETR_LOG_FORMAT")
 	v.MustBindEnv("KeyManagement.Provider", "MONETR_KMS_PROVIDER")

--- a/server/config/email_test.go
+++ b/server/config/email_test.go
@@ -1,0 +1,85 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/monetr/monetr/server/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmail_BlockedEmailDomain(t *testing.T) {
+	t.Run("empty list never blocks", func(t *testing.T) {
+		email := config.Email{}
+		domain, blocked := email.BlockedEmailDomain("person@example.com")
+		assert.False(t, blocked, "an empty blocklist should never block anything")
+		assert.Empty(t, domain, "no domain should be returned when nothing is blocked")
+	})
+
+	t.Run("blocks an exact domain match", func(t *testing.T) {
+		email := config.Email{
+			BlockedDomains: []string{"example.com"},
+		}
+		domain, blocked := email.BlockedEmailDomain("person@example.com")
+		assert.True(t, blocked, "example.com is on the blocklist so it should be blocked")
+		assert.Equal(t, "example.com", domain, "should return the domain it matched on")
+	})
+
+	t.Run("is case insensitive", func(t *testing.T) {
+		email := config.Email{
+			BlockedDomains: []string{"Example.COM"},
+		}
+		domain, blocked := email.BlockedEmailDomain("Person@EXAMPLE.com")
+		assert.True(t, blocked, "the match should not care about casing on either side")
+		assert.Equal(t, "example.com", domain, "the returned domain should be normalized to lowercase")
+	})
+
+	t.Run("does not block a subdomain", func(t *testing.T) {
+		// We intentionally only match the domain exactly, blocking example.com
+		// should NOT also block mail.example.com.
+		email := config.Email{
+			BlockedDomains: []string{"example.com"},
+		}
+		domain, blocked := email.BlockedEmailDomain("person@mail.example.com")
+		assert.False(t, blocked, "a subdomain of a blocked domain should not be blocked")
+		assert.Empty(t, domain)
+	})
+
+	t.Run("tolerates a leading @ in the config entry", func(t *testing.T) {
+		// Someone might write the blocklist entry as @example.com, we should treat
+		// that the same as example.com.
+		email := config.Email{
+			BlockedDomains: []string{"@example.com"},
+		}
+		_, blocked := email.BlockedEmailDomain("person@example.com")
+		assert.True(t, blocked, "a leading @ in the config entry should be ignored")
+	})
+
+	t.Run("an address with no domain is not blocked", func(t *testing.T) {
+		email := config.Email{
+			BlockedDomains: []string{"example.com"},
+		}
+		domain, blocked := email.BlockedEmailDomain("not-an-email")
+		assert.False(t, blocked, "if there is no domain to compare we should not block it")
+		assert.Empty(t, domain)
+	})
+
+	t.Run("an unrelated domain is not blocked", func(t *testing.T) {
+		email := config.Email{
+			BlockedDomains: []string{"example.com"},
+		}
+		_, blocked := email.BlockedEmailDomain("person@monetr.app")
+		assert.False(t, blocked, "a domain that is not on the list should be allowed through")
+	})
+
+	t.Run("blocks when one of several domains matches", func(t *testing.T) {
+		email := config.Email{
+			BlockedDomains: []string{
+				"mailinator.com",
+				"guerrillamail.com",
+				"example.com",
+			},
+		}
+		_, blocked := email.BlockedEmailDomain("person@guerrillamail.com")
+		assert.True(t, blocked, "a match against any entry in the list should block")
+	})
+}

--- a/server/controller/authentication.go
+++ b/server/controller/authentication.go
@@ -379,14 +379,22 @@ func (c *Controller) postRegister(ctx echo.Context) error {
 	}
 
 	// Before the captcha, it is the cheap fail-fast. No-op when disabled.
-	if err := c.validateProofOfWork(ctx, powchallenge.PurposeRegister, registerRequest.Challenge, registerRequest.Nonce); err != nil {
+	if err := c.validateProofOfWork(
+		ctx,
+		powchallenge.PurposeRegister,
+		registerRequest.Challenge,
+		registerRequest.Nonce,
+	); err != nil {
 		return err // validateProofOfWork returns a valid http error.
 	}
 
 	// This will take the captcha from the request and validate it if the API is
 	// configured to do so. If it is enabled and the captcha fails then an error
 	// is returned to the client.
-	if err := c.validateRegistrationCaptcha(c.getContext(ctx), registerRequest.Captcha); err != nil {
+	if err := c.validateRegistrationCaptcha(
+		c.getContext(ctx),
+		registerRequest.Captcha,
+	); err != nil {
 		return c.wrapAndReturnError(ctx, err, http.StatusBadRequest, "valid ReCAPTCHA is required")
 	}
 
@@ -408,7 +416,12 @@ func (c *Controller) postRegister(ctx echo.Context) error {
 	}
 
 	if _, err := locale.GetLConv(registerRequest.Locale); err != nil {
-		log.WarnContext(c.getContext(ctx), "invalid locale in register request, falling back to global default", "locale", registerRequest.Locale, "err", err)
+		log.WarnContext(
+			c.getContext(ctx),
+			"invalid locale in register request, falling back to global default",
+			"locale", registerRequest.Locale,
+			"err", err,
+		)
 		registerRequest.Locale = consts.DefaultLocale
 	}
 
@@ -419,6 +432,23 @@ func (c *Controller) postRegister(ctx echo.Context) error {
 		registerRequest.FirstName,
 	); err != nil {
 		return err // validateRegistration also returns a valid http error that can just be passed through.
+	}
+
+	// If the email's domain is on the sign up blocklist we reject it, but we
+	// deliberately return the SAME error a client gets for an email that is
+	// already taken so we do not advertise to a would be abuser that their domain
+	// is specifically blocked. From the outside a blocked domain is
+	// indistinguishable from an address that already exists. The real reason, and
+	// which domain it was, is only ever visible to us here in the logs.
+	if domain, blocked := c.Configuration.Email.BlockedEmailDomain(
+		registerRequest.Email,
+	); blocked {
+		log.WarnContext(
+			c.getContext(ctx),
+			"registration blocked, email domain is not allowed",
+			"emailDomain", domain,
+		)
+		return c.failure(ctx, http.StatusBadRequest, EmailAlreadyExists{})
 	}
 
 	timezone, err := zoneinfo.Timezone(registerRequest.Timezone)

--- a/server/controller/authentication_test.go
+++ b/server/controller/authentication_test.go
@@ -1258,6 +1258,64 @@ func TestRegister(t *testing.T) {
 			response.JSON().Path("$.user.account.locale").String().IsEqual("en_US")
 		}
 	})
+
+	t.Run("a blocked domain is rejected as if the email already exists", func(t *testing.T) {
+		conf := NewTestApplicationConfig(t)
+		// Every generated email in the tests uses the monetr.mini domain, so by
+		// blocking it we can prove that sign up gets rejected.
+		conf.Email.BlockedDomains = []string{"monetr.mini"}
+		_, e := NewTestApplicationWithConfig(t, conf)
+
+		// The email from validRegisterBody is unique, so it definitely does not
+		// already exist. The ONLY reason this can come back as EMAIL_IN_USE is
+		// because the domain is blocked, which is exactly the indistinguishable
+		// response we want a would be abuser to see.
+		response := e.POST(`/api/authentication/register`).
+			WithJSON(validRegisterBody(t)).
+			Expect()
+
+		response.Status(http.StatusBadRequest)
+		response.JSON().Path("$.code").IsEqual("EMAIL_IN_USE")
+		response.JSON().Path("$.error").IsEqual("email already in use")
+	})
+
+	t.Run("can still sign up with a domain that is not blocked", func(t *testing.T) {
+		conf := NewTestApplicationConfig(t)
+		conf.Email.BlockedDomains = []string{"mailinator.com"}
+		_, e := NewTestApplicationWithConfig(t, conf)
+
+		// validRegisterBody uses a monetr.mini email which is not on the blocklist,
+		// so registration should succeed like normal.
+		response := e.POST(`/api/authentication/register`).
+			WithJSON(validRegisterBody(t)).
+			Expect()
+
+		response.Status(http.StatusOK)
+		AssertSetTokenCookie(t, response)
+	})
+
+	t.Run("blocking a domain does not stop an existing user from signing in", func(t *testing.T) {
+		// This is the whole point of the feature, the blocklist must only gate sign
+		// up. Seed a full account through the repository (NOT the register
+		// endpoint) so it behaves like an account that already existed before the
+		// domain was blocked. GivenIHaveABasicAccount creates the login on the
+		// monetr.mini domain.
+		conf := NewTestApplicationConfig(t)
+		conf.Email.BlockedDomains = []string{"monetr.mini"}
+		app, e := NewTestApplicationWithConfig(t, conf)
+
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+
+		response := e.POST(`/api/authentication/login`).
+			WithJSON(map[string]any{
+				"email":    user.Login.Email,
+				"password": password,
+			}).
+			Expect()
+
+		response.Status(http.StatusOK)
+		AssertSetTokenCookie(t, response)
+	})
 }
 
 func TestVerifyEmail(t *testing.T) {


### PR DESCRIPTION
Email domains can now be blocked in the configuration file, this will
prevent users of that domain from signing up going forward but will not
prevent users of that domain from logging in. This is so that throwaway
email domains can be blocked from being used to spam verification emails
in monetrs sign up flow.
