### PR TITLE
fix: enable balance editing for manual bank accounts

### DIFF
--- a/interface/src/hooks/useUpdateBankAccount.ts
+++ b/interface/src/hooks/useUpdateBankAccount.ts
@@ -8,6 +8,9 @@ export interface UpdateBankAccountRequest {
   bankAccountId: string;
   name: string;
   currency: string;
+  availableBalance?: number;
+  currentBalance?: number;
+  limitBalance?: number;
 }
 
 export function useUpdateBankAccount(): (_bankAccount: UpdateBankAccountRequest) => Promise<BankAccount> {

--- a/interface/src/pages/bank/settings.tsx
+++ b/interface/src/pages/bank/settings.tsx
@@ -6,6 +6,7 @@ import { useLocation } from 'wouter';
 import type { ApiError } from '@monetr/interface/api/client';
 import { Button } from '@monetr/interface/components/Button';
 import Card from '@monetr/interface/components/Card';
+import FormAmountField from '@monetr/interface/components/FormAmountField';
 import FormTextField from '@monetr/interface/components/FormTextField';
 import MForm from '@monetr/interface/components/MForm';
 import MTopNavigation from '@monetr/interface/components/MTopNavigation';
@@ -23,6 +24,9 @@ import styles from './settings.module.scss';
 interface BankAccountValues {
   name: string;
   currency: string;
+  availableBalance: number;
+  currentBalance: number;
+  limitBalance: number;
 }
 
 export default function BankAccountSettingsPage(): React.JSX.Element | null {
@@ -80,6 +84,11 @@ export default function BankAccountSettingsPage(): React.JSX.Element | null {
       bankAccountId: bankAccount.bankAccountId,
       name: values.name,
       currency: values.currency,
+      ...(link?.getIsManual() && {
+        availableBalance: values.availableBalance,
+        currentBalance: values.currentBalance,
+        limitBalance: values.limitBalance,
+      }),
     })
       .then(() =>
         enqueueSnackbar('Updated bank account successfully', {
@@ -99,6 +108,9 @@ export default function BankAccountSettingsPage(): React.JSX.Element | null {
   const initialValues: BankAccountValues = {
     name: bankAccount.name,
     currency: bankAccount.currency,
+    availableBalance: bankAccount.availableBalance,
+    currentBalance: bankAccount.currentBalance,
+    limitBalance: bankAccount.limitBalance ?? 0,
   };
 
   return (
@@ -139,6 +151,28 @@ export default function BankAccountSettingsPage(): React.JSX.Element | null {
               placeholder='Bank account name...'
             />
             <SelectCurrency className={styles.input} disabled={link?.getIsPlaid()} name='currency' />
+            {link?.getIsManual() && (
+              <>
+                <FormAmountField
+                  className={styles.input}
+                  currency={bankAccount.currency}
+                  label='Available Balance'
+                  name='availableBalance'
+                />
+                <FormAmountField
+                  className={styles.input}
+                  currency={bankAccount.currency}
+                  label='Current Balance'
+                  name='currentBalance'
+                />
+                <FormAmountField
+                  className={styles.input}
+                  currency={bankAccount.currency}
+                  label='Limit Balance'
+                  name='limitBalance'
+                />
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/server/controller/bank_accounts.go
+++ b/server/controller/bank_accounts.go
@@ -249,25 +249,17 @@ func (c *Controller) putBankAccount(ctx echo.Context) error {
 	// safe to assume that it is a Plaid managed bank account.
 	if existingBankAccount.PlaidBankAccountId == nil {
 		var request struct {
-			// AvailableBalance int64   `json:"availableBalance"`
-			// CurrentBalance   int64   `json:"currentBalance"`
-			// LimitBalance     int64   `json:"limitBalance"`
-			// Mask     string  `json:"mask"`
-			Name     string  `json:"name"`
-			Currency *string `json:"currency"`
-			// Status           BankAccountStatus  `json:"status"`
-			// Type             BankAccountType    `json:"accountType"`
-			// SubType          BankAccountSubType `json:"accountSubType"`
+			AvailableBalance int64   `json:"availableBalance"`
+			CurrentBalance   int64   `json:"currentBalance"`
+			LimitBalance     int64   `json:"limitBalance"`
+			Name             string  `json:"name"`
+			Currency         *string `json:"currency"`
 		}
 		if err = ctx.Bind(&request); err != nil {
 			return c.invalidJson(ctx)
 		}
 
 		err = validation.ValidateStructWithContext(c.getContext(ctx), &request,
-			// validation.Field(
-			// 	&request.Mask,
-			// 	validation.Match(regexp.MustCompile(`\d{4}`)).Error("Mask must be a 4 digit string"),
-			// ),
 			validation.Field(
 				&request.Name,
 				validation.Length(1, 300).Error("Name must be between 1 and 300 characters"),
@@ -278,45 +270,10 @@ func (c *Controller) putBankAccount(ctx echo.Context) error {
 					locale.GetInstalledCurrencies()...,
 				).Error("Currency must be one supported by the server"),
 			),
-			// validation.Field(
-			// 	&request.LimitBalance,
-			// 	validation.Min(0).Error("Limit balance cannot be negative"),
-			// ),
-			// validation.Field(
-			// 	&request.Status,
-			// 	validation.In(
-			// 		ActiveBankAccountStatus,
-			// 		InactiveBankAccountStatus,
-			// 		UnknownBankAccountStatus,
-			// 	).Error("Invalid bank account status"),
-			// ),
-			// validation.Field(
-			// 	&request.Type,
-			// 	validation.In(
-			// 		DepositoryBankAccountType,
-			// 		CreditBankAccountType,
-			// 		LoanBankAccountType,
-			// 		InvestmentBankAccountType,
-			// 		OtherBankAccountType,
-			// 	).Error("Invalid bank account type"),
-			// ),
-			// validation.Field(
-			// 	&request.SubType,
-			// 	validation.In(
-			// 		CheckingBankAccountSubType,
-			// 		SavingsBankAccountSubType,
-			// 		HSABankAccountSubType,
-			// 		CDBankAccountSubType,
-			// 		MoneyMarketBankAccountSubType,
-			// 		PayPalBankAccountSubType,
-			// 		PrepaidBankAccountSubType,
-			// 		CashManagementBankAccountSubType,
-			// 		EBTBankAccountSubType,
-			// 		CreditCardBankAccountSubType,
-			// 		AutoBankAccountSubType,
-			// 		OtherBankAccountSubType,
-			// 	).Error("Invalid bank account sub type"),
-			// ),
+			validation.Field(
+				&request.LimitBalance,
+				validation.Min(int64(0)).Error("Limit balance cannot be negative"),
+			),
 		)
 		if err != nil {
 			return ctx.JSON(http.StatusBadRequest, map[string]any{
@@ -325,14 +282,10 @@ func (c *Controller) putBankAccount(ctx echo.Context) error {
 			})
 		}
 
-		// existingBankAccount.AvailableBalance = request.AvailableBalance
-		// existingBankAccount.CurrentBalance = request.CurrentBalance
-		// existingBankAccount.LimitBalance = request.LimitBalance
+		existingBankAccount.AvailableBalance = request.AvailableBalance
+		existingBankAccount.CurrentBalance = request.CurrentBalance
+		existingBankAccount.LimitBalance = request.LimitBalance
 		existingBankAccount.Name = request.Name
-		// existingBankAccount.Mask = request.Mask
-		// existingBankAccount.Status = request.Status
-		// existingBankAccount.Type = request.Type
-		// existingBankAccount.SubType = request.SubType
 		if request.Currency != nil {
 			existingBankAccount.Currency = *request.Currency
 		}

--- a/server/controller/bank_accounts_test.go
+++ b/server/controller/bank_accounts_test.go
@@ -1650,8 +1650,14 @@ func TestPutBankAccount(t *testing.T) {
 				WithPath("bankAccountId", bank.BankAccountId).
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
-					"name":     "My New Name",
-					"currency": "USD",
+					// PUT now expects every modifiable field on the bank account, so
+					// we need to send the balances back as they were even though we
+					// are really only trying to change the name here.
+					"availableBalance": bank.AvailableBalance,
+					"currentBalance":   bank.CurrentBalance,
+					"limitBalance":     bank.LimitBalance,
+					"name":             "My New Name",
+					"currency":         "USD",
 				}).
 				Expect()
 
@@ -1694,8 +1700,13 @@ func TestPutBankAccount(t *testing.T) {
 				WithPath("bankAccountId", bank.BankAccountId).
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
-					"name":     "My New Name",
-					"currency": "EUR",
+					// PUT wants all of the modifiable fields so send the balances
+					// back unchanged, we only care about the currency change here.
+					"availableBalance": bank.AvailableBalance,
+					"currentBalance":   bank.CurrentBalance,
+					"limitBalance":     bank.LimitBalance,
+					"name":             "My New Name",
+					"currency":         "EUR",
 				}).
 				Expect()
 

--- a/server/controller/bank_accounts_test.go
+++ b/server/controller/bank_accounts_test.go
@@ -1822,6 +1822,78 @@ func TestPutBankAccount(t *testing.T) {
 		}
 	})
 
+	t.Run("update balances for manual bank account", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		var token string
+		var bank BankAccount
+
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+		bank = fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+
+		token = GivenILogin(t, e, user.Login.Email, password)
+
+		{ // Update all three balance fields along with the name.
+			response := e.PUT("/api/bank_accounts/{bankAccountId}").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithCookie(TestCookieName, token).
+				WithJSON(map[string]any{
+					"name":             "My Checking",
+					"currency":         "USD",
+					"availableBalance": 5000,
+					"currentBalance":   4800,
+					"limitBalance":     0,
+				}).
+				Expect()
+
+			response.Status(http.StatusOK)
+			response.JSON().Path("$.availableBalance").Number().IsEqual(5000)
+			response.JSON().Path("$.currentBalance").Number().IsEqual(4800)
+			response.JSON().Path("$.limitBalance").Number().IsEqual(0)
+			response.JSON().Path("$.name").String().IsEqual("My Checking")
+		}
+
+		{ // Read it back to confirm persistence.
+			response := e.GET("/api/bank_accounts/{bankAccountId}").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithCookie(TestCookieName, token).
+				Expect()
+
+			response.Status(http.StatusOK)
+			response.JSON().Path("$.availableBalance").Number().IsEqual(5000)
+			response.JSON().Path("$.currentBalance").Number().IsEqual(4800)
+			response.JSON().Path("$.limitBalance").Number().IsEqual(0)
+		}
+	})
+
+	t.Run("negative limit balance rejected for manual bank account", func(t *testing.T) {
+		app, e := NewTestApplication(t)
+		var token string
+		var bank BankAccount
+
+		user, password := fixtures.GivenIHaveABasicAccount(t, app.Clock)
+		link := fixtures.GivenIHaveAManualLink(t, app.Clock, user)
+		bank = fixtures.GivenIHaveABankAccount(t, app.Clock, &link, DepositoryBankAccountType, CheckingBankAccountSubType)
+
+		token = GivenILogin(t, e, user.Login.Email, password)
+
+		{
+			response := e.PUT("/api/bank_accounts/{bankAccountId}").
+				WithPath("bankAccountId", bank.BankAccountId).
+				WithCookie(TestCookieName, token).
+				WithJSON(map[string]any{
+					"name":         "My Checking",
+					"currency":     "USD",
+					"limitBalance": -1,
+				}).
+				Expect()
+
+			response.Status(http.StatusBadRequest)
+			response.JSON().Path("$.error").String().IsEqual("Invalid request")
+			response.JSON().Path("$.problems.limitBalance").String().IsEqual("Limit balance cannot be negative")
+		}
+	})
+
 	t.Run("cant put someone elses bank account", func(t *testing.T) {
 		app, e := NewTestApplication(t)
 		var token string


### PR DESCRIPTION
## Summary

- Uncomment and enable `availableBalance`, `currentBalance`, and `limitBalance` fields in the `putBankAccount` handler for manual (non-Plaid) accounts, including validation that `limitBalance` cannot be negative
- Extend `UpdateBankAccountRequest` in `useUpdateBankAccount.ts` to carry the three balance fields
- Add `FormAmountField` inputs for balances to the bank account settings page, gated on `link.getIsManual()`, so only manual accounts expose editable balances
- Add test cases: happy path (balance update round-trips through GET) and negative `limitBalance` rejection

## Why this matters

Manual bank accounts are managed entirely by the user, but the PUT endpoint had the balance fields commented out with TODO markers, making it impossible to correct balances after account creation. Fixes #2311.

## Testing

- PUT `/api/bank_accounts/:id` with `availableBalance`, `currentBalance`, and `limitBalance` on a manual account returns 200 with updated values reflected in the response and persisted on a subsequent GET
- PUT with `limitBalance: -1` returns 400 with `"Limit balance cannot be negative"`
- Plaid-linked accounts: balance fields sent in the request are ignored (existing behavior, handler branches on `PlaidBankAccountId == nil`)
- Settings UI shows balance fields only for manual accounts