### PR TITLE
refactor(api): Spending schema validation

### DIFF
--- a/interface/src/models/Spending.ts
+++ b/interface/src/models/Spending.ts
@@ -10,9 +10,9 @@ import parseDate from '@monetr/interface/util/parseDate';
 export const FREE_TO_USE = ID.from<Spending>('spnd_freeToUse');
 
 export enum SpendingType {
-  FreeToUse = -1, // Cannot be present on actual responses!
-  Expense = 0,
-  Goal = 1,
+  FreeToUse = 'free', // Cannot be present on actual responses!
+  Expense = 'expense',
+  Goal = 'goal',
 }
 
 export default class Spending {

--- a/server/controller/funding_schedules_test.go
+++ b/server/controller/funding_schedules_test.go
@@ -103,7 +103,7 @@ func TestPostFundingSchedules(t *testing.T) {
 
 		response.Status(http.StatusBadRequest)
 		response.JSON().Path("$.error").String().IsEqual("Invalid request")
-		response.JSON().Path("$.problems.description").String().IsEqual("Description must be between 1 and 300 characters")
+		response.JSON().Path("$.problems.description").String().IsEqual("Must be between 1 and 300 characters")
 	})
 
 	t.Run("create a funding schedule with excluded weekends", func(t *testing.T) {

--- a/server/controller/spending.go
+++ b/server/controller/spending.go
@@ -3,10 +3,12 @@ package controller
 import (
 	"net/http"
 
+	"log/slog"
+
 	"github.com/labstack/echo/v4"
 	"github.com/monetr/monetr/server/internal/myownsanity"
 	. "github.com/monetr/monetr/server/models"
-	"log/slog"
+	"github.com/monetr/monetr/server/schemas"
 )
 
 func (c *Controller) getSpending(ctx echo.Context) error {
@@ -57,31 +59,19 @@ func (c *Controller) postSpending(ctx echo.Context) error {
 		return c.badRequest(ctx, "must specify a valid bank account Id")
 	}
 
-	spending := &Spending{}
-	if err := ctx.Bind(spending); err != nil {
-		return c.invalidJson(ctx)
+	spending, err := parse(
+		c,
+		ctx,
+		&Spending{
+			BankAccountId: bankAccountId,
+		},
+		schemas.CreateSpending,
+	)
+	if err != nil {
+		return err
 	}
 
 	log := c.getLog(ctx)
-
-	spending.SpendingId = "" // Make sure we create a new spending.
-	spending.BankAccountId = bankAccountId
-	spending.Name, err = c.cleanString(ctx, "Name", spending.Name)
-	if err != nil {
-		return err
-	}
-	spending.Description, err = c.cleanString(ctx, "Description", spending.Description)
-	if err != nil {
-		return err
-	}
-	if spending.Name == "" {
-		return c.badRequest(ctx, "spending must have a name")
-	}
-
-	if spending.TargetAmount <= 0 {
-		return c.badRequest(ctx, "target amount must be greater than 0")
-	}
-
 	repo := c.mustGetAuthenticatedRepository(ctx)
 
 	// We need to calculate what the next contribution will be for this new
@@ -105,6 +95,7 @@ func (c *Controller) postSpending(ctx echo.Context) error {
 		return c.badRequest(ctx, "next due date cannot be in the past")
 	}
 
+	// TODO This might not be needed with the schema validation
 	switch spending.SpendingType {
 	case SpendingTypeExpense:
 		if spending.RuleSet == nil {
@@ -120,7 +111,10 @@ func (c *Controller) postSpending(ctx echo.Context) error {
 		if spending.SpendingType != SpendingTypeExpense {
 			return c.badRequest(ctx, "auto create transaction is only supported for expenses")
 		}
-		isManual, err := repo.GetLinkIsManualByBankAccountId(c.getContext(ctx), bankAccountId)
+		isManual, err := repo.GetLinkIsManualByBankAccountId(
+			c.getContext(ctx),
+			bankAccountId,
+		)
 		if err != nil {
 			return c.wrapPgError(ctx, err, "failed to validate if link is manual")
 		}
@@ -132,12 +126,18 @@ func (c *Controller) postSpending(ctx echo.Context) error {
 	// Make sure that the next recurrence date is properly in the user's timezone.
 	nextRecurrence, err := c.midnightInLocal(ctx, next)
 	if err != nil {
-		return c.wrapAndReturnError(ctx, err, http.StatusInternalServerError, "could not determine next recurrence")
+		return c.wrapAndReturnError(
+			ctx,
+			err,
+			http.StatusInternalServerError,
+			"could not determine next recurrence",
+		)
 	}
 
 	spending.NextRecurrence = nextRecurrence
 
-	// Once we have all that data we can calculate the new expenses next contribution amount.
+	// Once we have all that data we can calculate the new expenses next
+	// contribution amount.
 	spending.CalculateNextContribution(
 		c.getContext(ctx),
 		c.mustGetTimezone(ctx),

--- a/server/controller/spending.go
+++ b/server/controller/spending.go
@@ -9,6 +9,7 @@ import (
 	"github.com/monetr/monetr/server/internal/myownsanity"
 	. "github.com/monetr/monetr/server/models"
 	"github.com/monetr/monetr/server/schemas"
+	"github.com/monetr/monetr/server/util"
 )
 
 func (c *Controller) getSpending(ctx echo.Context) error {
@@ -73,6 +74,7 @@ func (c *Controller) postSpending(ctx echo.Context) error {
 
 	log := c.getLog(ctx)
 	repo := c.mustGetAuthenticatedRepository(ctx)
+	timezone := c.mustGetTimezone(ctx)
 
 	// We need to calculate what the next contribution will be for this new
 	// spending. So we need to retrieve it's funding schedule. This also helps us
@@ -93,6 +95,8 @@ func (c *Controller) postSpending(ctx echo.Context) error {
 	next := spending.NextRecurrence
 	if next.Before(c.Clock.Now()) {
 		return c.badRequest(ctx, "next due date cannot be in the past")
+	} else if !util.IsMidnight(next, timezone) {
+		return c.badRequest(ctx, "next due date must be midnight in your timezone")
 	}
 
 	// TODO This might not be needed with the schema validation

--- a/server/controller/spending_test.go
+++ b/server/controller/spending_test.go
@@ -757,7 +757,7 @@ func TestPostSpending(t *testing.T) {
 		}
 
 		now := app.Clock.Now()
-		ruleset := testutils.Must(t, NewRuleSet, FirstDayOfEveryMonth)
+		ruleset := testutils.RuleSetInTimezone(t, testutils.MustEz(t, user.Account.GetTimezone), FirstDayOfEveryMonth)
 		nextRecurrence := ruleset.After(now, false)
 
 		response := e.POST("/api/bank_accounts/{bankAccountId}/spending").
@@ -806,7 +806,7 @@ func TestPostSpending(t *testing.T) {
 		}
 
 		now := app.Clock.Now()
-		ruleset := testutils.Must(t, NewRuleSet, FirstDayOfEveryMonth)
+		ruleset := testutils.RuleSetInTimezone(t, testutils.MustEz(t, user.Account.GetTimezone), FirstDayOfEveryMonth)
 		nextRecurrence := ruleset.After(now, false)
 
 		response := e.POST("/api/bank_accounts/{bankAccountId}/spending").
@@ -1103,7 +1103,12 @@ func TestGetSpendingByID(t *testing.T) {
 					"fundingScheduleId": fundingScheduleId,
 					"targetAmount":      5000,
 					"spendingType":      SpendingTypeExpense,
-					"nextRecurrence":    app.Clock.Now().AddDate(0, 1, 0),
+					"nextRecurrence": testutils.RuleSetInTimezone(
+						t,
+						testutils.MustEz(t, user.Account.GetTimezone),
+						FirstDayOfEveryMonth,
+					).
+						After(app.Clock.Now(), false),
 				}).
 				Expect().
 				Status(http.StatusOK).
@@ -1278,7 +1283,11 @@ func TestGetSpendingTransactions(t *testing.T) {
 					"fundingScheduleId": fundingScheduleId,
 					"targetAmount":      8000,
 					"spendingType":      SpendingTypeExpense,
-					"nextRecurrence":    app.Clock.Now().AddDate(0, 1, 0),
+					"nextRecurrence": testutils.RuleSetInTimezone(
+						t,
+						testutils.MustEz(t, user.Account.GetTimezone),
+						FirstDayOfEveryMonth,
+					).After(app.Clock.Now(), false),
 				}).
 				Expect().
 				Status(http.StatusOK).
@@ -2097,7 +2106,11 @@ func TestPutSpending(t *testing.T) {
 					"fundingScheduleId": fundingScheduleId,
 					"targetAmount":      100000,
 					"spendingType":      SpendingTypeExpense,
-					"nextRecurrence":    app.Clock.Now().AddDate(0, 1, 0),
+					"nextRecurrence": testutils.RuleSetInTimezone(
+						t,
+						testutils.MustEz(t, user.Account.GetTimezone),
+						FirstDayOfEveryMonth,
+					).After(app.Clock.Now(), false),
 				}).
 				Expect().
 				Status(http.StatusOK).
@@ -2149,7 +2162,11 @@ func TestPutSpending(t *testing.T) {
 			assert.False(t, fundingScheduleId.IsZero(), "must be able to extract the funding schedule ID")
 		}
 
-		nextRecurrence := app.Clock.Now().Add(30 * 24 * time.Hour)
+		nextRecurrence := testutils.RuleSetInTimezone(
+			t,
+			testutils.MustEz(t, user.Account.GetTimezone),
+			FirstDayOfEveryMonth,
+		).After(app.Clock.Now(), false)
 
 		var spendingId ID[Spending]
 		{ // Create a goal
@@ -2216,7 +2233,7 @@ func TestPutSpending(t *testing.T) {
 		}
 
 		now := app.Clock.Now()
-		ruleset := testutils.Must(t, NewRuleSet, FirstDayOfEveryMonth)
+		ruleset := testutils.RuleSetInTimezone(t, testutils.MustEz(t, user.Account.GetTimezone), FirstDayOfEveryMonth)
 		nextRecurrence := ruleset.After(now, false)
 
 		var spendingId ID[Spending]
@@ -2286,7 +2303,7 @@ func TestPutSpending(t *testing.T) {
 		}
 
 		now := app.Clock.Now()
-		ruleset := testutils.Must(t, NewRuleSet, FirstDayOfEveryMonth)
+		ruleset := testutils.RuleSetInTimezone(t, testutils.MustEz(t, user.Account.GetTimezone), FirstDayOfEveryMonth)
 		nextRecurrence := ruleset.After(now, false)
 
 		var spendingId ID[Spending]
@@ -2730,7 +2747,11 @@ func TestDeleteSpending(t *testing.T) {
 					"fundingScheduleId": fundingScheduleId,
 					"targetAmount":      5000,
 					"spendingType":      SpendingTypeExpense,
-					"nextRecurrence":    app.Clock.Now().AddDate(0, 1, 0),
+					"nextRecurrence": testutils.RuleSetInTimezone(
+						t,
+						testutils.MustEz(t, user.Account.GetTimezone),
+						FirstDayOfEveryMonth,
+					).After(app.Clock.Now(), false),
 				}).
 				Expect().
 				Status(http.StatusOK).

--- a/server/controller/spending_test.go
+++ b/server/controller/spending_test.go
@@ -118,7 +118,10 @@ func TestPostSpending(t *testing.T) {
 				Expect()
 
 			response.Status(http.StatusBadRequest)
-			response.JSON().Path("$.error").IsEqual("Name must not be longer than 250 characters")
+			response.JSON().Path("$.error").String().IsEqual("Invalid request")
+			// The schema validates against both the expense and goal variants, so the
+			// failure comes back as a oneOf envelope. The expense variant is first.
+			response.JSON().Path("$.problems.oneOf[0].name").String().IsEqual("Name must be between 1 and 300 characters")
 		}
 
 		{ // Create an expense with a description thats too long
@@ -143,7 +146,14 @@ func TestPostSpending(t *testing.T) {
 				Expect()
 
 			response.Status(http.StatusBadRequest)
-			response.JSON().Path("$.error").IsEqual("Description must not be longer than 250 characters")
+			response.JSON().Path("$.error").String().IsEqual("Invalid request")
+			// Description is validated as one of a nil value or a valid text field,
+			// so a too long description fails both branches inside the expense
+			// variant.
+			response.JSON().Path("$.problems.oneOf[0].description.oneOf").Array().ConsistsOf(
+				"must be nil",
+				"Must be between 1 and 300 characters",
+			)
 		}
 	})
 
@@ -185,7 +195,7 @@ func TestPostSpending(t *testing.T) {
 				Expect()
 
 			response.Status(http.StatusBadRequest)
-			response.JSON().Path("$.error").String().IsEqual("invalid JSON body")
+			response.JSON().Path("$.error").String().IsEqual("failed to parse request")
 		}
 	})
 
@@ -236,7 +246,8 @@ func TestPostSpending(t *testing.T) {
 				Expect()
 
 			response.Status(http.StatusBadRequest)
-			response.JSON().Path("$.error").String().IsEqual("spending must have a name")
+			response.JSON().Path("$.error").String().IsEqual("Invalid request")
+			response.JSON().Path("$.problems.oneOf[0].name").String().IsEqual("required key is missing")
 		}
 	})
 
@@ -287,7 +298,8 @@ func TestPostSpending(t *testing.T) {
 				Expect()
 
 			response.Status(http.StatusBadRequest)
-			response.JSON().Path("$.error").String().IsEqual("target amount must be greater than 0")
+			response.JSON().Path("$.error").String().IsEqual("Invalid request")
+			response.JSON().Path("$.problems.oneOf[0].targetAmount").String().IsEqual("required key is missing")
 		}
 	})
 
@@ -339,7 +351,8 @@ func TestPostSpending(t *testing.T) {
 				Expect()
 
 			response.Status(http.StatusBadRequest)
-			response.JSON().Path("$.error").String().IsEqual("target amount must be greater than 0")
+			response.JSON().Path("$.error").String().IsEqual("Invalid request")
+			response.JSON().Path("$.problems.oneOf[0].targetAmount").String().IsEqual("Target amount must be greater than zero")
 		}
 	})
 
@@ -361,9 +374,12 @@ func TestPostSpending(t *testing.T) {
 				WithPath("bankAccountId", bank.BankAccountId).
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
-					"name":              "Some Monthly Expense",
-					"ruleset":           ruleset,
-					"fundingScheduleId": "fund_bogus",
+					"name":    "Some Monthly Expense",
+					"ruleset": ruleset,
+					// A malformed funding schedule Id is now rejected by the schema
+					// before we ever look it up, so use a well formed but nonexistent Id
+					// to make sure we still exercise the not found path here.
+					"fundingScheduleId": NewID[FundingSchedule](),
 					"targetAmount":      1000,
 					"spendingType":      SpendingTypeExpense,
 					"nextRecurrence":    nextRecurrence,
@@ -408,7 +424,11 @@ func TestPostSpending(t *testing.T) {
 				WithPath("bankAccountId", bank.BankAccountId).
 				WithCookie(TestCookieName, token).
 				WithJSON(map[string]any{
-					"name":              "Some Monthly Expense",
+					"name": "Some Monthly Expense",
+					// A ruleset is required by the schema for expenses, so include one to
+					// make sure we actually get to the past due date check in the
+					// controller and not the schema validation.
+					"ruleset":           FirstDayOfEveryMonth,
 					"fundingScheduleId": fundingScheduleId,
 					"targetAmount":      1000,
 					"spendingType":      SpendingTypeExpense,
@@ -468,16 +488,18 @@ func TestPostSpending(t *testing.T) {
 				Expect()
 
 			response.Status(http.StatusBadRequest)
-			response.JSON().Path("$.error").String().IsEqual("recurrence rule must be specified for expenses")
+			response.JSON().Path("$.error").String().IsEqual("Invalid request")
+			response.JSON().Path("$.problems.oneOf[0].ruleset").String().IsEqual("required key is missing")
 		}
 	})
 
 	t.Run("missing rule for expense regression 1599", func(t *testing.T) {
-		// Pin the timestamp and timezone to a known-bad combo from issue 1599. With
-		// these locked, the buggy pattern from "missing rule for expense" can be
-		// observed deterministically: util.Midnight rewinds the next recurrence to
-		// before now, so the API returns the past-date error instead of the
-		// missing-rule error this test is actually checking.
+		// Pin the timestamp and timezone to a known-bad combo from issue 1599. The
+		// old buggy pattern was that util.Midnight would rewind the next recurrence
+		// to before now, so the API returned the past-date error instead of the
+		// missing-rule error this test is actually checking. The schema validation
+		// now runs before any of that date math, so the missing ruleset is caught
+		// first regardless of timezone, which is what keeps 1599 fixed.
 		t.Setenv("MONETR_TIMESTAMP", "2023-10-31 18:46:01.423737301 +0000 UTC")
 		t.Setenv("MONETR_TIMEZONE", "Pacific/Auckland")
 
@@ -527,7 +549,8 @@ func TestPostSpending(t *testing.T) {
 				Expect()
 
 			response.Status(http.StatusBadRequest)
-			response.JSON().Path("$.error").String().IsEqual("recurrence rule must be specified for expenses")
+			response.JSON().Path("$.error").String().IsEqual("Invalid request")
+			response.JSON().Path("$.problems.oneOf[0].ruleset").String().IsEqual("required key is missing")
 		}
 	})
 
@@ -579,7 +602,10 @@ func TestPostSpending(t *testing.T) {
 				Expect()
 
 			response.Status(http.StatusBadRequest)
-			response.JSON().Path("$.error").String().IsEqual("recurrence rule cannot be specified for goals")
+			response.JSON().Path("$.error").String().IsEqual("Invalid request")
+			// This is a goal with a ruleset, so it fails the goal variant (index 1)
+			// of the schema where a ruleset must not be provided.
+			response.JSON().Path("$.problems.oneOf[1].ruleset").String().IsEqual("must not be provided")
 		}
 	})
 
@@ -697,7 +723,10 @@ func TestPostSpending(t *testing.T) {
 			Expect()
 
 		response.Status(http.StatusBadRequest)
-		response.JSON().Path("$.error").String().IsEqual("auto create transaction is only supported for expenses")
+		response.JSON().Path("$.error").String().IsEqual("Invalid request")
+		// A goal cannot specify autoCreateTransaction at all, so the goal variant
+		// (index 1) of the schema rejects the key outright.
+		response.JSON().Path("$.problems.oneOf[1].autoCreateTransaction").String().IsEqual("key not expected")
 	})
 
 	t.Run("rejects auto create transaction on plaid link", func(t *testing.T) {

--- a/server/forecast/fixtures/elliots-spending-20230705.json
+++ b/server/forecast/fixtures/elliots-spending-20230705.json
@@ -12,7 +12,7 @@
     "nextRecurrence": "2023-10-01T05:00:00Z",
     "ruleset": "DTSTART:20230401T050000Z\nRRULE:FREQ=MONTHLY;INTERVAL=3;BYMONTHDAY=1",
     "spendingId": "spnd_01hy4f3jcf2znmm3r22ay0ketz",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 20000,
     "usedAmount": 0
   },
@@ -29,7 +29,7 @@
     "nextRecurrence": "2023-08-14T05:00:00Z",
     "ruleset": "DTSTART:20230414T050000Z\nRRULE:FREQ=MONTHLY;INTERVAL=2;BYMONTHDAY=14",
     "spendingId": "spnd_01hy4f3jcf2znmm3r22b1adyfv",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 6300,
     "usedAmount": 0
   },
@@ -46,7 +46,7 @@
     "nextRecurrence": "2023-07-28T05:00:00Z",
     "ruleset": "DTSTART:20230228T060000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=28",
     "spendingId": "spnd_01hy4f3jcf2znmm3r22cp7kk80",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 4000,
     "usedAmount": 0
   },
@@ -63,7 +63,7 @@
     "nextRecurrence": "2023-07-26T05:00:00Z",
     "ruleset": "DTSTART:20230326T050000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=26",
     "spendingId": "spnd_01hy4f3jcf2znmm3r22ebj2nm5",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 1609,
     "usedAmount": 0
   },
@@ -80,7 +80,7 @@
     "nextRecurrence": "2023-07-25T05:00:00Z",
     "ruleset": "DTSTART:20230325T050000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=25",
     "spendingId": "spnd_01hy4f3jcf2znmm3r22g14axzb",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 214,
     "usedAmount": 0
   },
@@ -97,7 +97,7 @@
     "nextRecurrence": "2023-07-26T05:00:00Z",
     "ruleset": "DTSTART:20230426T050000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=26",
     "spendingId": "spnd_01hy4f3jcf2znmm3r22h3hz2x3",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 378,
     "usedAmount": 0
   },
@@ -114,7 +114,7 @@
     "nextRecurrence": "2023-07-25T05:00:00Z",
     "ruleset": "DTSTART:20230725T050000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=25",
     "spendingId": "spnd_01hy4f3jcf2znmm3r22j3v28b4",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 1000,
     "usedAmount": 0
   },
@@ -131,7 +131,7 @@
     "nextRecurrence": "2023-07-18T05:00:00Z",
     "ruleset": "DTSTART:20230318T050000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=18",
     "spendingId": "spnd_01hy4f3jcf2znmm3r22p33yxj2",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 1000,
     "usedAmount": 0
   },
@@ -148,7 +148,7 @@
     "nextRecurrence": "2024-06-01T05:00:00Z",
     "ruleset": "DTSTART:20230601T050000Z\nRRULE:FREQ=YEARLY;INTERVAL=1;BYMONTH=6;BYMONTHDAY=1",
     "spendingId": "spnd_01hy4f3jcf2znmm3r22rz29nth",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 9000,
     "usedAmount": 0
   },
@@ -165,7 +165,7 @@
     "nextRecurrence": "2023-07-31T05:00:00Z",
     "ruleset": "DTSTART:20230731T050000Z\nRRULE:FREQ=YEARLY;INTERVAL=1;BYMONTH=8;BYMONTHDAY=1",
     "spendingId": "spnd_01hy4f3jcf2znmm3r22t0qj3b5",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 10000,
     "usedAmount": 0
   },
@@ -182,7 +182,7 @@
     "nextRecurrence": "2023-07-30T05:00:00Z",
     "ruleset": "DTSTART:20230330T050000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=30",
     "spendingId": "spnd_01hy4f3jcf2znmm3r22vqnnbcy",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 2000,
     "usedAmount": 0
   },
@@ -199,7 +199,7 @@
     "nextRecurrence": "2023-07-29T05:00:00Z",
     "ruleset": "DTSTART:20230329T050000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=29",
     "spendingId": "spnd_01hy4f3jcf2znmm3r22vya2y01",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 999,
     "usedAmount": 0
   },
@@ -216,7 +216,7 @@
     "nextRecurrence": "2023-07-06T05:00:00Z",
     "ruleset": "DTSTART:20230306T060000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=6",
     "spendingId": "spnd_01hy4f3jcf2znmm3r22wmt4wca",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 1600,
     "usedAmount": 0
   },
@@ -233,7 +233,7 @@
     "nextRecurrence": "2023-08-01T05:00:00Z",
     "ruleset": "DTSTART:20230401T050000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=1",
     "spendingId": "spnd_01hy4f3jcf2znmm3r22yphmpra",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 1000,
     "usedAmount": 0
   },
@@ -250,7 +250,7 @@
     "nextRecurrence": "2035-01-01T06:00:00Z",
     "ruleset": null,
     "spendingId": "spnd_01hy4f3jcf2znmm3r230ans5m0",
-    "spendingType": 1,
+    "spendingType": "goal",
     "targetAmount": 17500000,
     "usedAmount": 0
   },
@@ -267,7 +267,7 @@
     "nextRecurrence": "2023-07-20T05:00:00Z",
     "ruleset": "DTSTART:20230320T050000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=20",
     "spendingId": "spnd_01hy4f3jcf2znmm3r233ezrrk7",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 36300,
     "usedAmount": 0
   },
@@ -284,7 +284,7 @@
     "nextRecurrence": "2023-07-08T05:00:00Z",
     "ruleset": "DTSTART:20230308T060000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=8",
     "spendingId": "spnd_01hy4f3jcf2znmm3r235nyg90r",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 1200,
     "usedAmount": 0
   },
@@ -301,7 +301,7 @@
     "nextRecurrence": "2023-12-01T06:00:00Z",
     "ruleset": "DTSTART:20231201T060000Z\nRRULE:FREQ=YEARLY;INTERVAL=1;BYMONTH=12;BYMONTHDAY=1",
     "spendingId": "spnd_01hy4f3jcf2znmm3r237651adz",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 10000,
     "usedAmount": 0
   },
@@ -318,7 +318,7 @@
     "nextRecurrence": "2024-02-03T06:00:00Z",
     "ruleset": "DTSTART:20240203T060000Z\nRRULE:FREQ=YEARLY;INTERVAL=1;BYMONTH=2;BYMONTHDAY=3",
     "spendingId": "spnd_01hy4f3jcf2znmm3r237qd6hd0",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 4000,
     "usedAmount": 0
   },
@@ -335,7 +335,7 @@
     "nextRecurrence": "2024-03-15T05:00:00Z",
     "ruleset": "DTSTART:20240315T050000Z\nRRULE:FREQ=YEARLY;INTERVAL=1;BYMONTH=3;BYMONTHDAY=15",
     "spendingId": "spnd_01hy4f3jcf2znmm3r23agk9jbf",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 100000,
     "usedAmount": 0
   },
@@ -352,7 +352,7 @@
     "nextRecurrence": "2024-04-01T05:00:00Z",
     "ruleset": "DTSTART:20230401T050000Z\nRRULE:FREQ=YEARLY;INTERVAL=1;BYMONTH=4;BYMONTHDAY=1",
     "spendingId": "spnd_01hy4f3jcf2znmm3r23bmcvmq1",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 5985,
     "usedAmount": 0
   },
@@ -369,7 +369,7 @@
     "nextRecurrence": "2023-11-01T05:00:00Z",
     "ruleset": null,
     "spendingId": "spnd_01hy4f3jcf2znmm3r23enqcs0g",
-    "spendingType": 1,
+    "spendingType": "goal",
     "targetAmount": 283470,
     "usedAmount": 139371
   },
@@ -386,7 +386,7 @@
     "nextRecurrence": "2024-03-14T05:00:00Z",
     "ruleset": "DTSTART:20240314T050000Z\nRRULE:FREQ=YEARLY;INTERVAL=1;BYMONTH=3;BYMONTHDAY=14",
     "spendingId": "spnd_01hy4f3jcf2znmm3r23gwx85cc",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 6999,
     "usedAmount": 0
   },
@@ -403,7 +403,7 @@
     "nextRecurrence": "2024-03-15T05:00:00Z",
     "ruleset": "DTSTART:20230315T050000Z\nRRULE:FREQ=YEARLY;INTERVAL=1;BYMONTH=3;BYMONTHDAY=15",
     "spendingId": "spnd_01hy4f3jcf2znmm3r23j3ws61r",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 10000,
     "usedAmount": 0
   },
@@ -420,7 +420,7 @@
     "nextRecurrence": "2023-08-03T05:00:00Z",
     "ruleset": "DTSTART:20230303T060000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=3",
     "spendingId": "spnd_01hy4f3jcf2znmm3r23kth4x0k",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 999,
     "usedAmount": 0
   },
@@ -437,7 +437,7 @@
     "nextRecurrence": "2023-07-10T05:00:00Z",
     "ruleset": "DTSTART:20230310T060000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=10",
     "spendingId": "spnd_01hy4f3jcf2znmm3r23qhb61sw",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 47500,
     "usedAmount": 0
   },
@@ -454,7 +454,7 @@
     "nextRecurrence": "2026-01-01T06:00:00Z",
     "ruleset": null,
     "spendingId": "spnd_01hy4f3jcf2znmm3r23rxxpjnb",
-    "spendingType": 1,
+    "spendingType": "goal",
     "targetAmount": 1001000,
     "usedAmount": 125135
   },
@@ -471,7 +471,7 @@
     "nextRecurrence": "2023-07-15T05:00:00Z",
     "ruleset": "DTSTART:20230228T060000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15,-1",
     "spendingId": "spnd_01hy4f3jcf2znmm3r23srdqyez",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 100000,
     "usedAmount": 0
   },
@@ -488,7 +488,7 @@
     "nextRecurrence": "2023-08-01T05:00:00Z",
     "ruleset": "DTSTART:20230301T060000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=1",
     "spendingId": "spnd_01hy4f3jcf2znmm3r23tq36hm4",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 180000,
     "usedAmount": 0
   },
@@ -505,7 +505,7 @@
     "nextRecurrence": "2023-08-04T05:00:00Z",
     "ruleset": "DTSTART:20230304T060000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=4",
     "spendingId": "spnd_01hy4f3jcf2znmm3r23xq3eb0f",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 6962,
     "usedAmount": 0
   },
@@ -522,7 +522,7 @@
     "nextRecurrence": "2023-10-01T05:00:00Z",
     "ruleset": "DTSTART:20230401T050000Z\nRRULE:FREQ=MONTHLY;INTERVAL=3;BYMONTHDAY=1",
     "spendingId": "spnd_01hy4f3jcf2znmm3r240c07664",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 14925,
     "usedAmount": 0
   },
@@ -539,7 +539,7 @@
     "nextRecurrence": "2023-07-16T05:00:00Z",
     "ruleset": "DTSTART:20230316T050000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=16",
     "spendingId": "spnd_01hy4f3jcf2znmm3r242r5y975",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 2468,
     "usedAmount": 0
   },
@@ -556,7 +556,7 @@
     "nextRecurrence": "2023-07-09T05:00:00Z",
     "ruleset": "DTSTART:20230309T060000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=9",
     "spendingId": "spnd_01hy4f3jcf2znmm3r244qnm740",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 2400,
     "usedAmount": 0
   },
@@ -573,7 +573,7 @@
     "nextRecurrence": "2023-10-04T05:00:00Z",
     "ruleset": null,
     "spendingId": "spnd_01hy4f3jcf2znmm3r2459cgxhc",
-    "spendingType": 1,
+    "spendingType": "goal",
     "targetAmount": 150427,
     "usedAmount": 69658
   },
@@ -590,7 +590,7 @@
     "nextRecurrence": "2023-08-01T05:00:00Z",
     "ruleset": "DTSTART:20230301T060000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=1",
     "spendingId": "spnd_01hy4f3jcf2znmm3r2497zbdd8",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 1611,
     "usedAmount": 0
   },
@@ -607,7 +607,7 @@
     "nextRecurrence": "2023-08-05T05:00:00Z",
     "ruleset": "DTSTART:20230305T060000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=5",
     "spendingId": "spnd_01hy4f3jcf2znmm3r24d1jw35s",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 999,
     "usedAmount": 0
   },
@@ -624,7 +624,7 @@
     "nextRecurrence": "2023-08-05T05:00:00Z",
     "ruleset": "DTSTART:20230305T060000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=5",
     "spendingId": "spnd_01hy4f3jcf2znmm3r24fsybe2v",
-    "spendingType": 0,
+    "spendingType": "expense",
     "targetAmount": 1073,
     "usedAmount": 0
   }

--- a/server/forecast/spending.go
+++ b/server/forecast/spending.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"time"
 
+	"log/slog"
+
 	"github.com/monetr/monetr/server/crumbs"
 	"github.com/monetr/monetr/server/internal/myownsanity"
 	"github.com/monetr/monetr/server/logging"
 	. "github.com/monetr/monetr/server/models"
 	"github.com/monetr/monetr/server/util"
 	"github.com/pkg/errors"
-	"log/slog"
 )
 
 type SpendingEvent struct {
@@ -242,8 +243,6 @@ func (s *spendingInstructionBase) getNextSpendingEventAfter(
 
 	nextRecurrence := util.Midnight(s.spending.NextRecurrence, timezone)
 	switch s.spending.SpendingType {
-	case SpendingTypeOverflow:
-		return nil, nil
 	case SpendingTypeGoal:
 		// If we are working with a goal and it has already "completed" then there
 		// is nothing more to do, no more events will come up for this spending

--- a/server/migrations/schema/2026062000_SpendingType.tx.up.sql
+++ b/server/migrations/schema/2026062000_SpendingType.tx.up.sql
@@ -1,3 +1,4 @@
+ALTER TABLE "spending" DROP CONSTRAINT "uq_spending_type_name";
 ALTER TABLE "spending" ADD COLUMN "spending_type_new" TEXT;
 UPDATE "spending" SET "spending_type_new" = 'expense' WHERE "spending_type" = 0;
 UPDATE "spending" SET "spending_type_new" = 'goal' WHERE "spending_type" = 1;
@@ -5,5 +6,5 @@ UPDATE "spending" SET "spending_type_new" = 'goal' WHERE "spending_type" = 1;
 UPDATE "spending" SET "spending_type_new" = 'goal' WHERE "spending_type_new" IS NULL;
 ALTER TABLE "spending" ALTER COLUMN "spending_type_new" SET NOT NULL;
 ALTER TABLE "spending" DROP COLUMN "spending_type";
--- TODO Is there a unique constraint on spending type + name?
 ALTER TABLE "spending" RENAME COLUMN "spending_type_new" TO "spending_type";
+ALTER TABLE "spending" ADD CONSTRAINT "uq_spending_type_name" UNIQUE ("bank_account_id", "spending_type", "name");

--- a/server/migrations/schema/2026062000_SpendingType.tx.up.sql
+++ b/server/migrations/schema/2026062000_SpendingType.tx.up.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "spending" ADD COLUMN "spending_type_new" TEXT;
+UPDATE "spending" SET "spending_type_new" = 'expense' WHERE "spending_type" = 0;
+UPDATE "spending" SET "spending_type_new" = 'goal' WHERE "spending_type" = 1;
+-- Everything else?
+UPDATE "spending" SET "spending_type_new" = 'goal' WHERE "spending_type_new" IS NULL;
+ALTER TABLE "spending" ALTER COLUMN "spending_type_new" SET NOT NULL;
+ALTER TABLE "spending" DROP COLUMN "spending_type";
+-- TODO Is there a unique constraint on spending type + name?
+ALTER TABLE "spending" RENAME COLUMN "spending_type_new" TO "spending_type";

--- a/server/migrations/schema_test.go
+++ b/server/migrations/schema_test.go
@@ -304,7 +304,7 @@ func TestUp_FreshFullEmbed(t *testing.T) {
 	oldV, newV, err := m.Up(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), oldV)
-	assert.Equal(t, int64(2026050600), newV)
+	assert.Equal(t, int64(2026062000), newV)
 
 	versions := readSchemaVersions(t, db)
 	ups, err := discoverMigrations(embeddedMigrations)
@@ -321,5 +321,5 @@ func TestUp_FreshFullEmbed(t *testing.T) {
 	current, err := m.CurrentVersion(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, latest, current)
-	assert.Equal(t, int64(2026050600), latest)
+	assert.Equal(t, int64(2026062000), latest)
 }

--- a/server/models/spending.go
+++ b/server/models/spending.go
@@ -11,12 +11,11 @@ import (
 	"github.com/monetr/monetr/server/util"
 )
 
-type SpendingType uint8
+type SpendingType string
 
 const (
-	SpendingTypeExpense SpendingType = iota
-	SpendingTypeGoal
-	SpendingTypeOverflow
+	SpendingTypeExpense SpendingType = "expense" // 0
+	SpendingTypeGoal    SpendingType = "goal"    // 1
 )
 
 type Spending struct {
@@ -177,11 +176,6 @@ func calculateNextContribution(
 	defer span.Finish()
 
 	span.SetTag("spendingId", spending.SpendingId.String())
-
-	if spending.SpendingType == SpendingTypeOverflow {
-		crumbs.Debug(ctx, "No need to calculate contribution for overflow spending", nil)
-		return spending
-	}
 
 	// Don't change the time by convert it to the account timezone. This will make
 	// debugging easier if there is a problem.

--- a/server/schemas/amount.go
+++ b/server/schemas/amount.go
@@ -6,50 +6,57 @@ import (
 
 	"github.com/monetr/monetr/server/validators"
 	"github.com/monetr/validation"
+	"github.com/monetr/validation/is"
 	"github.com/pkg/errors"
 )
 
 func Amount() validation.Rule {
-	return validators.By[any](func(_ context.Context, value *any) error {
-		if value == nil {
-			return errors.New("Amount is not a valid integer")
-		}
-		switch value := (*value).(type) {
-		case json.Number:
-			if jint, err := value.Int64(); err != nil {
+	return validation.AllOf(
+		is.Integer,
+		validators.By[any](func(_ context.Context, value *any) error {
+			if value == nil {
 				return errors.New("Amount is not a valid integer")
-			} else if jint == 0 {
-				return errors.New("Amount cannot be zero")
 			}
+			switch value := (*value).(type) {
+			case json.Number:
+				if jint, err := value.Int64(); err != nil {
+					return errors.New("Amount is not a valid integer")
+				} else if jint == 0 {
+					return errors.New("Amount cannot be zero")
+				}
 
-			return nil
-		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-			if value == 0 {
-				return errors.New("Amount cannot be zero")
+				return nil
+			case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+				if value == 0 {
+					return errors.New("Amount cannot be zero")
+				}
+				return nil
+			default:
+				return errors.New("Amount is not a valid integer")
 			}
-			return nil
-		default:
-			return errors.New("Amount is not a valid integer")
-		}
-	})
+		}),
+	)
 }
 
 func PositiveAmount(prefix string) validation.Rule {
-	return validators.By[any](func(_ context.Context, value *any) error {
-		if value == nil {
-			return errors.Errorf("%s is not a valid integer", prefix)
-		}
-		switch value := (*value).(type) {
-		case json.Number:
-			if jint, err := value.Int64(); err != nil {
+	return validation.AllOf(
+		is.Integer,
+		validators.By[any](func(_ context.Context, value *any) error {
+			if value == nil {
 				return errors.Errorf("%s is not a valid integer", prefix)
-			} else if jint <= 0 {
-				return errors.Errorf("%s must be greater than zero", prefix)
 			}
+			switch value := (*value).(type) {
+			case json.Number:
+				if jint, err := value.Int64(); err != nil {
+					return errors.Errorf("%s is not a valid integer", prefix)
+				} else if jint <= 0 {
+					return errors.Errorf("%s must be greater than zero", prefix)
+				}
 
-			return nil
-		default:
-			return errors.Errorf("%s is not a valid integer", prefix)
-		}
-	})
+				return nil
+			default:
+				return errors.Errorf("%s is not a valid integer", prefix)
+			}
+		}),
+	)
 }

--- a/server/schemas/funding_schedule.go
+++ b/server/schemas/funding_schedule.go
@@ -1,8 +1,6 @@
 package schemas
 
 import (
-	"time"
-
 	"github.com/monetr/monetr/server/validators"
 	"github.com/monetr/validation"
 	"github.com/monetr/validation/is"
@@ -10,89 +8,66 @@ import (
 
 var (
 	CreateFundingSchedule = validation.Map(
-		validation.Key(
-			"name",
+		validation.Key("name",
 			validation.Required.Error("Name is required"),
 			Name(),
 		).Required(Require),
-		validation.Key(
-			"description",
-			validation.IsString,
-			is.PrintableUnicode,
-			validation.Length(1, 300).Error("Description must be between 1 and 300 characters"),
+		validation.Key("description",
+			TextField(),
 		).Required(validators.Optional),
-		validation.Key(
-			"ruleset",
+		validation.Key("ruleset",
 			validation.Required.Error("Ruleset must be specified for funding schedules"),
-			validation.IsString,
 			Ruleset(),
 		).Required(validators.Require),
-		validation.Key(
-			"excludeWeekends",
-			validation.IsBoolean,
-			validation.In(true, false).Error("Exclude weekends must be a valid boolean"),
+		validation.Key("excludeWeekends",
+			Boolean().Error("Exclude weekends must be a valid boolean"),
 		).Required(validators.Optional),
-		validation.Key(
-			"autoCreateTransaction",
-			validation.IsBoolean,
-			validation.In(true, false).Error("Auto create transaction must be a valid boolean"),
+		validation.Key("autoCreateTransaction",
+			Boolean().Error("Auto create transaction must be a valid boolean"),
 		).Required(validators.Optional),
-		validation.Key(
-			"estimatedDeposit",
+		validation.Key("estimatedDeposit",
 			validation.OneOf(
 				validation.Nil,
 				validation.AllOf(
-					validation.IsInteger,
 					PositiveAmount("Estimated deposit"),
+					// TODO This might be redundant?
 					validation.Min(float64(0)).Error("Estimated deposit cannot be less than 0"),
 				),
 			),
 		).Required(validators.Optional),
-		validation.Key(
-			"nextRecurrence",
-			validation.IsString,
-			validation.Date(time.RFC3339).Error("Next recurrence must be in the future"),
+		validation.Key("nextRecurrence",
+			Timestamp().Error("Next recurrence must be a valid date"),
 		).Required(validators.Optional),
 	)
 
 	PatchFundingSchedule = validation.Map(
-		validation.Key(
-			"name",
+		validation.Key("name",
 			validation.Required.Error("Name is required"),
 			Name(),
 		).Required(Optional),
-		validation.Key(
-			"description",
-			is.PrintableUnicode,
-			validation.IsString,
-			validation.Length(1, 300).Error("Description must be between 1 and 300 characters"),
+		validation.Key("description",
+			TextField(),
 		).Required(validators.Optional),
-		validation.Key(
-			"ruleset",
+		validation.Key("ruleset",
 			validation.Required.Error("Ruleset cannot be blank when specified"),
-			validation.IsString,
+			is.String,
 			Ruleset(),
 		).Required(validators.Optional),
-		validation.Key(
-			"excludeWeekends",
-			validation.IsBoolean,
+		validation.Key("excludeWeekends",
+			is.Boolean,
 			validation.In(true, false).Error("Exclude weekends must be a valid boolean"),
 		).Required(validators.Optional),
-		validation.Key(
-			"autoCreateTransaction",
-			validation.IsBoolean,
+		validation.Key("autoCreateTransaction",
+			is.Boolean,
 			validation.In(true, false).Error("Auto create transaction must be a valid boolean"),
 		).Required(validators.Optional),
-		validation.Key(
-			"estimatedDeposit",
-			validation.IsInteger,
+		validation.Key("estimatedDeposit",
+			is.Integer,
+			// TODO [PositiveAmount] here instead?
 			validation.Min(float64(0)).Error("Estimated deposit cannot be less than 0"),
 		).Required(validators.Optional),
-		validation.Key(
-			"nextRecurrence",
-			validation.Required.Error("Next recurrence cannot be blank when specified"),
-			validation.IsString,
-			validation.Date(time.RFC3339).Error("Next recurrence must be a valid date"),
+		validation.Key("nextRecurrence",
+			Timestamp().Error("Next recurrence must be a valid date"),
 		).Required(validators.Optional),
 	)
 )

--- a/server/schemas/funding_schedule.go
+++ b/server/schemas/funding_schedule.go
@@ -68,6 +68,7 @@ var (
 		).Required(validators.Optional),
 		validation.Key("nextRecurrence",
 			Timestamp().Error("Next recurrence must be a valid date"),
+			validation.Required.Error("Next recurrence cannot be blank when specified"),
 		).Required(validators.Optional),
 	)
 )

--- a/server/schemas/ruleset.go
+++ b/server/schemas/ruleset.go
@@ -3,38 +3,42 @@ package schemas
 import (
 	"github.com/monetr/monetr/server/models"
 	"github.com/monetr/validation"
+	"github.com/monetr/validation/is"
 )
 
 func Ruleset() validation.Rule {
-	return validation.NewStringRule(func(input string) bool {
-		ruleset, err := models.NewRuleSet(input)
-		if err != nil {
-			return false
-		}
+	return validation.AllOf(
+		is.String,
+		validation.NewStringRule(func(input string) bool {
+			ruleset, err := models.NewRuleSet(input)
+			if err != nil {
+				return false
+			}
 
-		// We require that the caller always specify a DTSTART for these rulesets.
-		// The rrule library will happily parse a rule that has no DTSTART but then
-		// it falls back to a zero value start time, and all of our relative date
-		// math downstream goes sideways when that happens. So if there is not an
-		// explicit start we reject the whole thing and make them be specific about
-		// when the schedule actually begins.
-		if ruleset.GetDTStart().IsZero() {
-			return false
-		}
+			// We require that the caller always specify a DTSTART for these rulesets.
+			// The rrule library will happily parse a rule that has no DTSTART but then
+			// it falls back to a zero value start time, and all of our relative date
+			// math downstream goes sideways when that happens. So if there is not an
+			// explicit start we reject the whole thing and make them be specific about
+			// when the schedule actually begins.
+			if ruleset.GetDTStart().IsZero() {
+				return false
+			}
 
-		// All of these are just a denial of service waiting to happen
-		if len(ruleset.GetRRule().Options.Byhour) > 0 {
-			return false
-		}
+			// All of these are just a denial of service waiting to happen
+			if len(ruleset.GetRRule().Options.Byhour) > 0 {
+				return false
+			}
 
-		if len(ruleset.GetRRule().Options.Byminute) > 0 {
-			return false
-		}
+			if len(ruleset.GetRRule().Options.Byminute) > 0 {
+				return false
+			}
 
-		if len(ruleset.GetRRule().Options.Bysecond) > 0 {
-			return false
-		}
+			if len(ruleset.GetRRule().Options.Bysecond) > 0 {
+				return false
+			}
 
-		return true
-	}, "Ruleset must be valid")
+			return true
+		}, "Ruleset must be valid"),
+	)
 }

--- a/server/schemas/schemas.go
+++ b/server/schemas/schemas.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"regexp"
 	"strings"
+	"time"
 
 	locale "github.com/elliotcourant/go-lclocale"
 	"github.com/monetr/monetr/server/merge"
@@ -122,4 +123,20 @@ func CurrencyCode() validation.Rule {
 			locale.GetInstalledCurrencies()...,
 		).Error("Currency must be one supported by the server"),
 	)
+}
+
+// Boolean is a shorthand for any non-nilable boolean field.
+func Boolean() validation.AllOfRule {
+	return validation.AllOf(
+		is.Boolean,
+		validation.In(true, false),
+		validation.NotNil,
+	)
+}
+
+func Timestamp() validation.AllOfRule {
+	return validation.AllOf(
+		is.String,
+		validation.Date(time.RFC3339),
+	).Error("Must be a valid timestamp")
 }

--- a/server/schemas/spending.go
+++ b/server/schemas/spending.go
@@ -1,0 +1,91 @@
+package schemas
+
+import (
+	"github.com/monetr/monetr/server/models"
+	"github.com/monetr/monetr/server/validators"
+	"github.com/monetr/validation"
+)
+
+var (
+	CreateSpending = validation.OneOf(
+		// Expense schema
+		validation.Map(
+			validation.Key("fundingScheduleId",
+				ValidID[models.FundingSchedule](),
+				validation.Required,
+			).Required(Require),
+			validation.Key("spendingType",
+				validation.Eq("expense"),
+				validation.Required,
+			).Required(Require),
+			validation.Key("name",
+				Name(),
+			).Required(Require),
+			validation.Key("description",
+				validation.OneOf(
+					validation.Nil,
+					TextField(),
+				),
+			).Required(Optional),
+			validation.Key("targetAmount",
+				PositiveAmount("Target amount"),
+				validation.Required,
+			).Required(Require),
+			validation.Key("currentAmount",
+				PositiveAmount("Current amount"),
+				// Different from [validation.Required] since it rejects 0.
+				validation.NotNil,
+			).Required(Optional),
+			validation.Key("ruleset",
+				Ruleset(),
+				validation.Required,
+			).Required(Require),
+			validation.Key("nextRecurrence",
+				Timestamp().Error("Next recurrence must be a valid date"),
+				validation.Required,
+			).Required(Require),
+			validation.Key("autoCreateTransaction",
+				Boolean(),
+			).Required(validators.Optional),
+		),
+		// Goal schema
+		validation.Map(
+			validation.Key("fundingScheduleId",
+				ValidID[models.FundingSchedule](),
+				validation.Required,
+			).Required(Require),
+			validation.Key("spendingType",
+				validation.Eq("goal"),
+				validation.Required,
+			).Required(Require),
+			validation.Key("name",
+				Name(),
+			).Required(Require),
+			validation.Key("description",
+				validation.OneOf(
+					validation.Nil,
+					TextField(),
+				),
+			).Required(Optional),
+			validation.Key("targetAmount",
+				PositiveAmount("Target amount"),
+				validation.Required,
+			).Required(Require),
+			validation.Key("currentAmount",
+				PositiveAmount("Current amount"),
+				// Different from [validation.Required] since it rejects 0.
+				validation.NotNil,
+			).Required(Optional),
+			validation.Key("ruleset",
+				validation.Never,
+			).Required(Optional),
+			validation.Key("nextRecurrence",
+				Timestamp().Error("Next recurrence must be a valid date"),
+				validation.Required,
+			).Required(Require),
+			validation.Key("isPaused",
+				Boolean(),
+			).Required(validators.Optional),
+		),
+	)
+)

--- a/server/util/midnight.go
+++ b/server/util/midnight.go
@@ -72,3 +72,9 @@ func ParseInLocal(format, input string, location *time.Location) (time.Time, err
 
 	return InLocal(date, location), nil
 }
+
+// IsMidnight returns true if the input timestamp is midnight in the specified
+// timezone, not necessarily midnight on the timestamp itself.
+func IsMidnight(input time.Time, timezone *time.Location) bool {
+	return input.In(timezone).Hour() == 0
+}


### PR DESCRIPTION
This is like the last major object type that needs schema validation
before I can really start opening up the API to external users via API
keys.
