### PR TITLE
fix(api): Fixing duplicate automatic transaction issue

### DIFF
--- a/server/funding/funding_jobs/process_funding_schedules.go
+++ b/server/funding/funding_jobs/process_funding_schedules.go
@@ -293,13 +293,17 @@ func ProcessFundingSchedule(ctx queue.Context, args ProcessFundingScheduleArgume
 						log,
 					)
 
-					// If this expense has auto create transaction enabled, create a
-					// transaction for the just-passed due date and allocate it from the
-					// expense. Goals are excluded by design.
+					// If this expense has auto create transaction enabled and its due
+					// date has actually passed, create a transaction for that due date
+					// and allocate it from the expense. Funding often happens before
+					// the expense is due; in that case the transaction must not be
+					// created early here, ProcessSpending will create it once the due
+					// date passes. Goals are excluded by design.
 					if isManual &&
 						spending.SpendingType == models.SpendingTypeExpense &&
 						spending.AutoCreateTransaction &&
-						spending.TargetAmount > 0 {
+						spending.TargetAmount > 0 &&
+						dueDate.Before(ctx.Clock().Now()) {
 						if bankAccount == nil {
 							bankAccount, err = repo.GetBankAccount(ctx, args.BankAccountId)
 							if err != nil {

--- a/server/funding/funding_jobs/process_funding_schedules_test.go
+++ b/server/funding/funding_jobs/process_funding_schedules_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/monetr/monetr/server/internal/testutils"
 	"github.com/monetr/monetr/server/models"
 	"github.com/monetr/monetr/server/repository"
+	"github.com/monetr/monetr/server/spending/spending_jobs"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -1175,5 +1176,170 @@ func TestProcessFundingSchedule(t *testing.T) {
 		assert.NotNil(t, transactions[0].SpendingId, "transaction should be allocated to a spending")
 		assert.Equal(t, spending.SpendingId, *transactions[0].SpendingId, "transaction should be allocated to the auto-create expense")
 		assert.True(t, transactions[0].Date.Equal(expectedDueDate), "transaction date should match the expense's original due date")
+	})
+
+	t.Run("does not auto create expense transaction before its due date", func(t *testing.T) {
+		clock := clock.NewMock()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		log := testutils.GetLog(t)
+		db := testutils.GetPgDatabase(t)
+
+		user, _ := fixtures.GivenIHaveABasicAccount(t, clock)
+		link := fixtures.GivenIHaveAManualLink(t, clock, user)
+		bankAccount := fixtures.GivenIHaveABankAccount(
+			t,
+			clock,
+			&link,
+			models.DepositoryBankAccountType,
+			models.CheckingBankAccountSubType,
+		)
+
+		timezone := testutils.MustEz(t, user.Account.GetTimezone)
+		fundingRule := testutils.RuleToSet(t, timezone, "FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15,-1", clock.Now())
+		fundingSchedule := testutils.MustInsert(t, models.FundingSchedule{
+			AccountId:              bankAccount.AccountId,
+			BankAccountId:          bankAccount.BankAccountId,
+			Name:                   "Payday",
+			Description:            "Payday",
+			RuleSet:                fundingRule,
+			NextRecurrence:         fundingRule.After(clock.Now(), false),
+			NextRecurrenceOriginal: fundingRule.After(clock.Now(), false),
+		})
+
+		// The expense is due on the 25th, well after the funding schedule fires on
+		// the 15th. When the funding schedule is processed the expense should only
+		// receive its contribution; the transaction must not be created until the
+		// due date actually passes, otherwise it would show up early and then be
+		// duplicated by ProcessSpending once the expense goes stale.
+		spendingRule := testutils.RuleToSet(t, timezone, "FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=25", clock.Now())
+		expectedDueDate := spendingRule.After(clock.Now(), false)
+		spending := testutils.MustInsert(t, models.Spending{
+			AccountId:              bankAccount.AccountId,
+			BankAccountId:          bankAccount.BankAccountId,
+			FundingScheduleId:      fundingSchedule.FundingScheduleId,
+			SpendingType:           models.SpendingTypeExpense,
+			Name:                   "Auto Expense",
+			Description:            "Due after the funding schedule fires",
+			TargetAmount:           5000,
+			CurrentAmount:          0,
+			NextContributionAmount: 5000,
+			RuleSet:                spendingRule,
+			NextRecurrence:         expectedDueDate,
+			AutoCreateTransaction:  true,
+			CreatedAt:              clock.Now(),
+		})
+
+		// Move time forward past the funding schedule's next recurrence, but not
+		// past the expense's due date.
+		clock.Add(18 * 24 * time.Hour)
+
+		{
+			context := mockgen.NewMockContext(ctrl)
+			context.EXPECT().Clock().Return(clock).AnyTimes()
+			context.EXPECT().DB().Return(db).AnyTimes()
+			context.EXPECT().Log().Return(log).AnyTimes()
+			context.EXPECT().RunInTransaction(gomock.Any(), gomock.Any()).Times(1)
+
+			err := funding_jobs.ProcessFundingSchedule(
+				mockqueue.NewMockContext(context),
+				funding_jobs.ProcessFundingScheduleArguments{
+					AccountId:          bankAccount.AccountId,
+					BankAccountId:      bankAccount.BankAccountId,
+					FundingScheduleIds: []models.ID[models.FundingSchedule]{fundingSchedule.FundingScheduleId},
+				},
+			)
+			assert.NoError(t, err, "should process funding schedule successfully")
+		}
+
+		// Verify the expense received its contribution but was not spent from.
+		updatedSpending := testutils.MustRetrieve(t, spending)
+		assert.EqualValues(
+			t,
+			int64(5000),
+			updatedSpending.CurrentAmount,
+			"current amount should have received the contribution and not been allocated to a transaction",
+		)
+		assert.True(
+			t,
+			updatedSpending.NextRecurrence.Equal(expectedDueDate),
+			"next recurrence should not change, the expense is not due yet",
+		)
+
+		// Verify the bank account balance did not change.
+		updatedBankAccount := testutils.MustRetrieve(t, bankAccount)
+		assert.EqualValues(t, bankAccount.AvailableBalance, updatedBankAccount.AvailableBalance, "available balance should not change")
+		assert.EqualValues(t, bankAccount.CurrentBalance, updatedBankAccount.CurrentBalance, "current balance should not change")
+
+		// Verify no transactions were created, the expense is not due yet.
+		repo := repository.NewRepositoryFromSession(
+			clock,
+			user.UserId,
+			user.AccountId,
+			db,
+			log,
+		)
+		transactions, err := repo.GetTransactions(t.Context(), bankAccount.BankAccountId, 100, 0)
+		assert.NoError(t, err, "should retrieve transactions")
+		assert.Empty(t, transactions, "no transactions should have been created before the expense's due date")
+
+		// Now move time forward past the expense's due date, ProcessSpending should
+		// pick up the stale expense and create the transaction for it. Exactly one
+		// transaction should exist afterwards; before the fix this flow produced
+		// two, one created early by the funding job and one by ProcessSpending.
+		clock.Add(10 * 24 * time.Hour)
+
+		{
+			context := mockgen.NewMockContext(ctrl)
+			context.EXPECT().Clock().Return(clock).AnyTimes()
+			context.EXPECT().DB().Return(db).AnyTimes()
+			context.EXPECT().Log().Return(log).AnyTimes()
+			context.EXPECT().RunInTransaction(gomock.Any(), gomock.Any()).Times(1)
+
+			err := spending_jobs.ProcessSpending(
+				mockqueue.NewMockContext(context),
+				spending_jobs.ProcessSpendingArguments{
+					AccountId:     bankAccount.AccountId,
+					BankAccountId: bankAccount.BankAccountId,
+				},
+			)
+			assert.NoError(t, err, "should process spending successfully")
+		}
+
+		// Verify the contribution was allocated to the auto-created transaction.
+		updatedSpending = testutils.MustRetrieve(t, spending)
+		assert.EqualValues(
+			t,
+			int64(0),
+			updatedSpending.CurrentAmount,
+			"current amount should have been allocated to the transaction",
+		)
+
+		// Verify the bank account balance was decremented by the expense amount.
+		updatedBankAccount = testutils.MustRetrieve(t, bankAccount)
+		assert.EqualValues(
+			t,
+			bankAccount.AvailableBalance-5000,
+			updatedBankAccount.AvailableBalance,
+			"available balance should have been decremented by the expense target amount",
+		)
+		assert.EqualValues(
+			t,
+			bankAccount.CurrentBalance-5000,
+			updatedBankAccount.CurrentBalance,
+			"current balance should have been decremented by the expense target amount",
+		)
+
+		// Verify exactly one expense transaction was created at the due date.
+		transactions, err = repo.GetTransactions(t.Context(), bankAccount.BankAccountId, 100, 0)
+		assert.NoError(t, err, "should retrieve transactions")
+		assert.Len(t, transactions, 1, "exactly one expense transaction should have been created")
+		assert.EqualValues(t, int64(5000), transactions[0].Amount, "transaction amount should match the expense target")
+		assert.Equal(t, models.TransactionSourceManual, transactions[0].Source, "transaction source should be manual")
+		assert.Equal(t, spending.Name, transactions[0].Name, "transaction name should match the expense name")
+		assert.NotNil(t, transactions[0].SpendingId, "transaction should be allocated to a spending")
+		assert.Equal(t, spending.SpendingId, *transactions[0].SpendingId, "transaction should be allocated to the auto-create expense")
+		assert.True(t, transactions[0].Date.Equal(expectedDueDate), "transaction date should match the expense's due date")
 	})
 }

--- a/server/models/funding_schedule.go
+++ b/server/models/funding_schedule.go
@@ -50,12 +50,13 @@ func (o *FundingSchedule) BeforeInsert(ctx context.Context) (context.Context, er
 // instead.
 func (o *FundingSchedule) GetNumberOfContributionsBetween(
 	start, end time.Time,
-	_ *time.Location,
+	timezone *time.Location,
 ) int64 {
-	rule := o.RuleSet.Set
 	// Make sure that the rule is using the timezone of the dates provided. This
 	// is an easy way to force that. We also need to truncate the hours on the
 	// start time. To make sure that we are operating relative to midnight.
+	rule := o.RuleSet.Clone()
+	rule.DTStart(rule.GetDTStart().In(timezone))
 	items := rule.Between(start, end, true)
 	return int64(len(items))
 }

--- a/server/models/spending.go
+++ b/server/models/spending.go
@@ -88,10 +88,16 @@ func (e Spending) GetProgressAmount() int64 {
 // GetRecurrencesBefore will return an array of times that this spending item will be used (based on the recurrence
 // rule) between the provided now and before in the specified time zone. Goals will at most return a single time if the
 // goal is due within that window.
-func (e *Spending) GetRecurrencesBefore(now, before time.Time, _ *time.Location) []time.Time {
+func (e *Spending) GetRecurrencesBefore(now, before time.Time, timezone *time.Location) []time.Time {
 	switch e.SpendingType {
 	case SpendingTypeExpense:
-		return e.RuleSet.Between(now, before, false)
+		// Make sure that the rule increments relative to midnight in the user's
+		// timezone. The stored DTSTART is the same instant but is represented in
+		// UTC, which can shift occurrences onto the wrong day for timezones that
+		// are ahead of UTC.
+		rule := e.RuleSet.Clone()
+		rule.DTStart(rule.GetDTStart().In(timezone))
+		return rule.Between(now, before, false)
 	case SpendingTypeGoal:
 		if e.NextRecurrence.After(now) && e.NextRecurrence.Before(before) {
 			return []time.Time{e.NextRecurrence}

--- a/server/models/spending_test.go
+++ b/server/models/spending_test.go
@@ -725,4 +725,76 @@ func TestSpending_CalculateNextContribution(t *testing.T) {
 		assert.NoError(t, err)
 		assert.EqualValues(t, 16055, spending.NextContributionAmount, "should contribute half of the remaining amount")
 	})
+
+	t.Run("timezone ahead of UTC counts events in the right funding period", func(t *testing.T) {
+		// The stored DTSTART on a ruleset is the instant of midnight in the user's
+		// timezone but is represented in UTC. For timezones ahead of UTC that UTC
+		// representation falls on the previous day, and evaluating the rule without
+		// adjusting it back into the user's timezone shifts every occurrence a full
+		// day late. Here the expense is due on the 14th, the day before it is
+		// funded on the 15th, with nothing allocated to it; it must be considered
+		// behind. With the shifted occurrences the due date would collide with the
+		// funding date instead and the expense would not appear behind at all.
+		timezone, err := time.LoadLocation("Australia/Sydney")
+		require.NoError(t, err, "must be able to load timezone")
+		now := time.Date(2022, 2, 1, 12, 0, 0, 0, timezone)
+
+		// Due on the 14th of every month, midnight in Sydney (+11).
+		spendingString := "DTSTART:20220113T130000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=14"
+		spendingRule, err := NewRuleSet(spendingString)
+		require.NoError(t, err, "must be able to parse the rule")
+
+		// Funded on the 15th of every month, midnight in Sydney (+11).
+		contributionString := "DTSTART:20220114T130000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15"
+		contributionRule, err := NewRuleSet(contributionString)
+		require.NoError(t, err, "must be able to parse the rule")
+
+		spending := Spending{
+			SpendingType:   SpendingTypeExpense,
+			TargetAmount:   5000,
+			CurrentAmount:  0,
+			NextRecurrence: time.Date(2022, 2, 14, 0, 0, 0, 0, timezone).UTC(),
+			RuleSet:        spendingRule,
+		}
+
+		spending.CalculateNextContribution(
+			t.Context(),
+			timezone,
+			GiveMeAFundingSchedule(time.Date(2022, 2, 15, 0, 0, 0, 0, timezone).UTC(), contributionRule),
+			now,
+			testutils.GetLog(t),
+		)
+		assert.True(t, spending.IsBehind, "should be behind, the expense is due the day before it is funded and has nothing allocated")
+		assert.EqualValues(t, 5000, spending.NextContributionAmount, "should contribute the entire amount for the next spending event")
+	})
+}
+
+func TestSpending_GetRecurrencesBefore(t *testing.T) {
+	t.Run("occurrences are relative to midnight in the users timezone", func(t *testing.T) {
+		timezone, err := time.LoadLocation("Australia/Sydney")
+		require.NoError(t, err, "must be able to load timezone")
+
+		// Due on the 15th of every month, midnight in Sydney (+11). The DTSTART is
+		// the same instant represented in UTC, which falls on the 14th; the
+		// occurrences must still land on midnight of the 15th in Sydney.
+		ruleset, err := NewRuleSet("DTSTART:20220114T130000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15")
+		require.NoError(t, err, "must be able to parse the rule")
+
+		spending := Spending{
+			SpendingType: SpendingTypeExpense,
+			RuleSet:      ruleset,
+		}
+
+		recurrences := spending.GetRecurrencesBefore(
+			time.Date(2022, 2, 1, 0, 0, 0, 0, timezone),
+			time.Date(2022, 3, 1, 0, 0, 0, 0, timezone),
+			timezone,
+		)
+		assert.Len(t, recurrences, 1, "should recur exactly once in the window")
+		assert.True(
+			t,
+			recurrences[0].Equal(time.Date(2022, 2, 15, 0, 0, 0, 0, timezone)),
+			"recurrence should be midnight on the 15th in the user's timezone",
+		)
+	})
 }


### PR DESCRIPTION
When automatically creating a transaction from a spending object, this
could sometimes result in duplicates.
